### PR TITLE
Cats Blender Plugin 3.6.5.2 (Only for Blender 3.6) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Cats Blender Plugin Blender 3.6 Main.
+# Cats Blender Plugin Blender 3.6 Dev.
 
-### This is the main version for blender 3.6 only! you can use this branch but we recomend using an released version from releases tab.
+### This is the Development version for blender 3.6 only! this version could be unstable or have issues, please use an released version if you encounter issues.
 
 The non official version of Cats Blender Plugin which is maintained by Yusarina, Cats is an tool designed to shorten steps needed to import and optimize models into VRChat. Compatible models are: MMD, XNALara, Mixamo, Source Engine, Unreal Engine, DAZ/Poser, Blender Rigify, Sims 2, Motion Builder, 3DS Max and potentially more
 

--- a/__init__.py
+++ b/__init__.py
@@ -12,8 +12,7 @@ bl_info = {
     'tracker_url': 'https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/issues',
     'warning': '',
 }
-dev_branch = False
-
+dev_branch = True
 import os
 import sys
 

--- a/tools/common.py
+++ b/tools/common.py
@@ -1943,6 +1943,16 @@ def bake_mmd_colors(node_base_tex: ShaderNodeTexImage, node_mmd_shader: ShaderNo
         # Set the colorspace to match the original image
         baked_image.colorspace_settings.name = base_tex_image.colorspace_settings.name
         # Replace the existing image in the node with the new, baked image
+
+        expected_len = baked_image.size[0] * baked_image.size[1] * 4
+
+        pixels = np.empty(np.prod(base_tex_image.size) * 4, dtype=np.single)
+        base_tex_image.pixels.foreach_get(pixels)
+
+        # Resize pixels to expected length
+        pixels.resize(expected_len) 
+
+        print(f"Pixels length: {len(pixels)}, Expected: {expected_len}")
         node_base_tex.image = baked_image
 
         # Write the image pixels to the image

--- a/tools/common.py
+++ b/tools/common.py
@@ -686,14 +686,19 @@ def get_meshes_objects(armature_name=None, mode=0, check=True, visible_only=Fals
             armature_name = armature.name
 
     meshes = []
+    
     for ob in get_objects():
-        if ob.type == 'MESH':
-            if mode == 0 or mode == 5:
+            if ob is None:
+                continue
+            if ob.type != 'MESH':
+                continue
+                
+            if mode == 0 or mode == 5: 
                 if ob.parent:
                     if ob.parent.type == 'ARMATURE' and ob.parent.name == armature_name:
                         meshes.append(ob)
                     elif ob.parent.parent and ob.parent.parent.type == 'ARMATURE' and ob.parent.parent.name == armature_name:
-                        meshes.append(ob)
+                        meshes.append(ob) 
 
             elif mode == 1:
                 if not ob.parent:

--- a/tools/material.py
+++ b/tools/material.py
@@ -285,7 +285,9 @@ class FixMaterialsButton(bpy.types.Operator):
                 mat_slot.material.blend_method = "HASHED"
         
         materials = set() 
-        return materials
+
+        self.report({'INFO'}, "Fixed materials")
+        return {'FINISHED'} 
 
 @register_wrap
 class ConvertAllToPngButton(bpy.types.Operator):


### PR DESCRIPTION
This version will mainly contain fixes and some changes, i be working on this today and should be released in the next few hours.

### Fixes:
- Fixes several instances where pmx models would fail to merge, this includes in custom model and mmd fix model. 
- Fixed issue with fix materials when some models where the size of the pixel data being set to the baked image didn't match the expected size. We now calculate the expected length, get the base size and resize the pixels to match the expected length.

### Changes:
- Fix Materials will now let the user know that it's done something by saying it's fixed materials.