### PR TITLE
Cats Blender Plugin 3.6.6.2 (Only for Blender 3.6) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Cats Blender Plugin Blender 3.6 Main.
+# Cats Blender Plugin Blender 3.6 Dev.
 
-### This is the main version for blender 3.6 only! you can use this branch but we recomend using an released version from releases tab.
+### This is the Development version for blender 3.6 only! this version could be unstable or have issues, please use an released version if you encounter issues.
 
 The non official version of Cats Blender Plugin which is maintained by Yusarina, Cats is an tool designed to shorten steps needed to import and optimize models into VRChat. Compatible models are: MMD, XNALara, Mixamo, Source Engine, Unreal Engine, DAZ/Poser, Blender Rigify, Sims 2, Motion Builder, 3DS Max and potentially more.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ### This is the Development version for blender 3.6 only! this version could be unstable or have issues, please use an released version if you encounter issues.
 
-The non official version of Cats Blender Plugin which is maintained by Yusarina, Cats is an tool designed to shorten steps needed to import and optimize models into VRChat. Compatible models are: MMD, XNALara, Mixamo, Source Engine, Unreal Engine, DAZ/Poser, Blender Rigify, Sims 2, Motion Builder, 3DS Max and potentially more
+The non official version of Cats Blender Plugin which is maintained by Yusarina, Cats is an tool designed to shorten steps needed to import and optimize models into VRChat. Compatible models are: MMD, XNALara, Mixamo, Source Engine, Unreal Engine, DAZ/Poser, Blender Rigify, Sims 2, Motion Builder, 3DS Max and potentially more.
+
+### Please view the readme [here](https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/tree/Welcome)
 
 #### Warning, Cats has changed UI wise, please [click here](https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/wiki/Features) to see the new UI features.
 #### If your plugin is trying to update to a blender 4.0 version or is stuck in a update loop please ensure you using the latest version of the plugin for you blender version from the releases tab [here](https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/releases).
@@ -12,6 +14,3 @@ You can find both 3.6 and 4.0 blender releases [here](https://github.com/Yusarin
 - You can find the development version for Blender 3.6 [here](https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/tree/blender-36-dev).
 - You can find the development version for Blender 4.0 [here](https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/tree/blender-40-dev).
 - You can find the development version for Blender 4.1 [here](https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/tree/blender-41-dev).
-
-Please view the readme [here](https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/tree/Welcome)
-

--- a/README.md
+++ b/README.md
@@ -9,81 +9,9 @@ The non official version of Cats Blender Plugin which is maintained by Yusarina,
 
 You can find both 3.6 and 4.0 blender releases [here](https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/releases), ensure you are using the one for your blender version!  
 
-You can find the development version for Blender 3.6 [here](https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/tree/blender-36-dev).
-You can find the development version for Blender 4.0 [here](https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/tree/blender-40-dev).
+- You can find the development version for Blender 3.6 [here](https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/tree/blender-36-dev).
+- You can find the development version for Blender 4.0 [here](https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/tree/blender-40-dev).
+- You can find the development version for Blender 4.1 [here](https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/tree/blender-41-dev).
 
-### Warning for Blender 4.0 users:
-Though we have updated cats to blender 4.0, please note there are still some issues with MMD Tools which may break some plugin functionality, this is not a cats issue so please redirect those issues to MMD Tools. Blender 4.0 is not our priority and will be behind the blender 3.6 version. We HIGHLY recommend using blender 3.6 for the time being unless you REALLY need the new features in 4.0, which if your just making VRChat models or doing MMD stuff you most likely don't.
-
-Blender 4.0 is also buggy and does have issues as well, we won't be recommending use of blender 4.x unto the first LTS comes out later this year.
-
-With Cats it takes only a few minutes to upload your model into VRChat.
-All the hours long processes of fixing your models are compressed into a few functions!
-
-- See my gumroad: https://yusarina.gumroad.com
-- See my github: https://github.com/Yusarina
-- See all my social media sites here: https://yusarina.xyz
-
-[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/R6R1SDNNP)
-
-## Blender version support policies.
-Please [Click Here](https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/wiki/Blender-Version-Support-Policies) to view which versions of blender we support.
-
-## Features
-
-Please [Click Here](https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/wiki/Features) to view the features of cats.
-
-
-## Requirements
-
-- Blender 3.6 or above (run as administrator is recommended) (Please note some features may not work in version below 3.6).
-   - Blender 3.6 is Recommended as this is the latest LTS.
-   - Though I have updated CATS to Blender 4.0, I do not currently recommend using 4.0 as there multiple issues with MDD Tools and Blender 4.0 which cats uses.
-- Anything older then 3.6 is not supported and no longer works.
-- If you have custom Python installed which Blender might use, you need to have Numpy installed
-- NOTE TO WINDOWS STORE USERS, STOP USING THE WINDOWS STORE VERSION YOU WILL HAVE ISSUES, PLEASE EITHER USE THE STEAM VERSION OR THE ONE FROM THE OFFICIAL BLENDER WEBSITE.
-
-#### Additional Plugins Requirements.
-Some features of Cat's need additional plugins to work, you can find them here:
-
-- Material Combiner: https://github.com/Grim-es/material-combiner-addon/
-- Immersive Scaler: https://github.com/triazo/immersive_scaler
-
-## Installation
-
-Please [Click Here](https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/wiki/How-to-Install%3F) to see how to install.
-
-## Help
-
-If you need help with Cat's you can check the wiki [here](https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/wiki).
-You can also see the the following video tutorials as well (Please note these videos may become outdated over time).
-
-[![VRCHAT Avatar Setup - Blender CATS Plugin](https://i.ytimg.com/vi/2fJMaxbBewg/0.jpg)](https://www.youtube.com/watch?v=2fJMaxbBewg)
-
-[![Full Blender Tutorial on how to create VRChat models](https://i.ytimg.com/vi/2NdPHW4_SOg/0.jpg)](https://www.youtube.com/watch?v=2NdPHW4_SOg)
-
-## Acknowledgements
-
-Maintained by Yusarina.
-
-### Code contributors:
-- Hotox
-- Shotariya
-- Neitri
-- Kiraver
-- Jordo
-- Ruubick
-- 989onan
-
-Cats Blender Plugin was original developed by absolute quantum then maintained by the community, [click here](https://github.com/absolute-quantum/cats-blender-plugin) to see the original project.
-
-### Cat's Uses the Following Plugins to Enhance it's features:
-
- - [MMD Tools](https://github.com/UuuNyaa/blender_mmd_tools)
- - [Immersive Scaler](https://github.com/triazo/immersive_scaler)
- - [Material Combiner](https://github.com/Grim-es/material-combiner-addon)
-
-## Feedback
-
-Please open an issue if you need to leave feedback.
+Please view the readme [here](https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/tree/Welcome)
 

--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ bl_info = {
     'author': 'GiveMeAllYourCats & Hotox, Unofficial version maintained by Yusarina',
     'location': 'View 3D > Tool Shelf > CATS',
     'description': 'A tool designed to shorten steps needed to import and optimize models into VRChat',
-    'version': (3, 6, 6, 0),  # Has to be (x, x, x) not [x, x, x]!! Only change this version and the dev branch var right before publishing the new update!
+    'version': (3, 6, 6, 1),  # Has to be (x, x, x) not [x, x, x]!! Only change this version and the dev branch var right before publishing the new update!
     'blender': (3, 6, 0),
     'wiki_url': 'https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/wiki',
     'tracker_url': 'https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/issues',

--- a/__init__.py
+++ b/__init__.py
@@ -6,13 +6,13 @@ bl_info = {
     'author': 'GiveMeAllYourCats & Hotox, Unofficial version maintained by Yusarina',
     'location': 'View 3D > Tool Shelf > CATS',
     'description': 'A tool designed to shorten steps needed to import and optimize models into VRChat',
-    'version': (3, 6, 6, 1),  # Has to be (x, x, x) not [x, x, x]!! Only change this version and the dev branch var right before publishing the new update!
+    'version': (3, 6, 6, 2),  # Has to be (x, x, x) not [x, x, x]!! Only change this version and the dev branch var right before publishing the new update!
     'blender': (3, 6, 0),
     'wiki_url': 'https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/wiki',
     'tracker_url': 'https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/issues',
     'warning': '',
 }
-dev_branch = False
+dev_branch = True
 import os
 import sys
 

--- a/tools/armature_manual.py
+++ b/tools/armature_manual.py
@@ -1163,7 +1163,7 @@ class RemoveDoubles(bpy.types.Operator):
         Common.set_default_stage()
 
         for mesh in meshes:
-            removed_tris += Common.remove_doubles(mesh, 0.0001, save_shapes=True)
+            removed_tris += Common.remove_doubles(mesh, 0.00002, save_shapes=True)
 
         Common.set_default_stage()
 

--- a/tools/common.py
+++ b/tools/common.py
@@ -1563,10 +1563,19 @@ def ui_refresh():
 def fix_zero_length_bones(armature: bpy.types.Object):
     if armature.mode != 'EDIT':
         return
-
-    for bone in armature.data.edit_bones:
-        if all(round(h, 4) == round(t, 4) for h, t in zip(bone.head, bone.tail)):
-            bone.tail.z += 0.1
+        
+    edit_bones = armature.data.edit_bones[:]
+    
+    for bone in edit_bones:
+        length = (bone.head - bone.tail).length
+        if length > 0.0001:
+            continue
+            
+        head_rounded = [round(x, 4) for x in bone.head] 
+        tail_rounded = [round(x, 4) for x in bone.tail]
+        
+        if head_rounded == tail_rounded:
+            bone.tail.translate(Vector((0, 0, 0.1)))
 
 
 def fix_bone_orientations(armature):

--- a/tools/common.py
+++ b/tools/common.py
@@ -220,15 +220,6 @@ def switch(new_mode, check_mode=True):
         bpy.ops.object.mode_set(mode=new_mode, toggle=False)
 
 
-def set_default_stage_old():
-    switch('OBJECT')
-    unhide_all()
-    unselect_all()
-    armature = get_armature()
-    set_active(armature)
-    return armature
-
-
 def set_default_stage():
     """
     Selects the armature, unhides everything and sets the modes of every object to object mode
@@ -294,15 +285,6 @@ def remove_empty():
         unselect_all()
 
 
-def get_bone_angle(p1, p2):
-    try:
-        ret = degrees((p1.head - p1.tail).angle(p2.head - p2.tail))
-    except ValueError:
-        ret = 0
-
-    return ret
-
-
 def remove_unused_vertex_groups(ignore_main_bones=False):
     remove_count = 0
     unselect_all()
@@ -322,25 +304,6 @@ def remove_unused_vertex_groups(ignore_main_bones=False):
                     continue
                 mesh.vertex_groups.remove(mesh.vertex_groups[i])
                 remove_count += 1
-    return remove_count
-
-
-def remove_unused_vertex_groups_of_mesh(mesh):
-    remove_count = 0
-    unselect_all()
-    mesh.update_from_editmode()
-
-    vgroup_used = {i: False for i, k in enumerate(mesh.vertex_groups)}
-
-    for v in mesh.data.vertices:
-        for g in v.groups:
-            if g.weight > 0.0:
-                vgroup_used[g.group] = True
-
-    for i, used in sorted(vgroup_used.items(), reverse=True):
-        if not used:
-            mesh.vertex_groups.remove(mesh.vertex_groups[i])
-            remove_count += 1
     return remove_count
 
 
@@ -410,16 +373,6 @@ def get_top_meshes(self, context):
         choices.append((mesh.name, mesh.name, mesh.name))
 
     return choices
-
-
-# currently unused
-def get_all_meshes(self, context):
-    choices = []
-
-    for mesh in get_meshes_objects(mode=2, check=False):
-        choices.append((mesh.name, mesh.name, mesh.name))
-
-    return _sort_enum_choices_by_identifier_lower(choices)
 
 
 def get_armature_list(self, context):
@@ -1235,12 +1188,6 @@ def delete(obj):
     objs.remove(objs[obj.name], do_unlink=True)
 
 
-def days_between(d1, d2, time_format):
-    d1 = datetime.strptime(d1, time_format)
-    d2 = datetime.strptime(d2, time_format)
-    return abs((d2 - d1).days)
-
-
 def delete_bone_constraints(armature_name=None):
     if not armature_name:
         armature_name = bpy.context.scene.armature
@@ -1327,33 +1274,6 @@ def is_default_object(obj):
     elif obj.type == 'MESH' and obj.data.name == 'Cube':
         return True
     return False
-
-
-def remove_no_user_objects():
-    # print('\nREMOVE OBJECTS')
-    for block in get_objects():
-        # print(block.name, block.users)
-        if block.users == 0:
-            print('Removing obj ', block.name)
-            delete(block)
-    # print('\nREMOVE MESHES')
-    for block in bpy.data.meshes:
-        # print(block.name, block.users)
-        if block.users == 0:
-            print('Removing mesh ', block.name)
-            bpy.data.meshes.remove(block)
-    # print('\nREMOVE MATERIALS')
-    for block in bpy.data.materials:
-        # print(block.name, block.users)
-        if block.users == 0:
-            print('Removing material ', block.name)
-            bpy.data.materials.remove(block)
-
-    # print('\nREMOVE MATS')
-    # for block in bpy.data.materials:
-    #     print(block.name, block.users)
-    #     if block.users == 0:
-    #         bpy.data.materials.remove(block)
 
 
 def is_end_bone(name, armature_name):
@@ -1904,25 +1824,6 @@ def add_principled_shader(mesh: Object, bake_mmd=True):
                     cats_principled_bsdf.inputs["Base Color"].default_value = principled_base_color
                 # Link principled BSDF node's output to the material output
                 node_tree.links.new(cats_principled_bsdf.outputs["BSDF"], cats_material_output.inputs["Surface"])
-
-
-def remove_toon_shader(mesh):
-    for mat_slot in mesh.material_slots:
-        if mat_slot.material and mat_slot.material.node_tree:
-            nodes = mat_slot.material.node_tree.nodes
-            for node in nodes:
-                if node.name == 'mmd_toon_tex':
-                    print('Toon tex removed from material', mat_slot.material.name)
-                    nodes.remove(node)
-                    # if not node.image or not node.image.filepath:
-                    #     print('Toon tex removed: Empty, from material', mat_slot.material.name)
-                    #     nodes.remove(node)
-                    #     continue
-                    #
-                    # image_filepath = bpy.path.abspath(node.image.filepath)
-                    # if not os.path.isfile(image_filepath):
-                    #     print('Toon tex removed:', node.image.name, 'from material', mat_slot.material.name)
-                    #     nodes.remove(node)
 
 
 def fix_mmd_shader(mesh_obj: bpy.types.Object):

--- a/tools/register.py
+++ b/tools/register.py
@@ -5,7 +5,6 @@ import typing
 
 __bl_classes = []
 __bl_ordered_classes = []
-__make_annotations = (not bpy.app.version < (2, 79, 9))
 
 
 def _dummy_operator_poll_message_set(message, *args):
@@ -26,15 +25,14 @@ def register_wrap(cls):
 
 
 def make_annotations(cls):
-    if __make_annotations:
-            bl_props = {k:v for k, v in cls.__dict__.items() if isinstance(v, bpy.props._PropertyDeferred)}
-            if bl_props:
-                if '__annotations__' not in cls.__dict__:
-                    setattr(cls, '__annotations__', {})
-                annotations = cls.__dict__['__annotations__']
-                for k, v in bl_props.items():
-                    annotations[k] = v
-                    delattr(cls, k)
+    bl_props = {k: v for k, v in cls.__dict__.items() if isinstance(v, bpy.props._PropertyDeferred)}
+    if bl_props:
+        if '__annotations__' not in cls.__dict__:
+            setattr(cls, '__annotations__', {})
+        annotations = cls.__dict__['__annotations__']
+        for k, v in bl_props.items():
+            annotations[k] = v
+            delattr(cls, k)
     return cls
 
 


### PR DESCRIPTION
This version continues us removing unused code and also has a couple of improvements. 

Fixed:
- Fix remove doubles, being a little too sensitive.

Changed:
- Speed up fix zero length bones: Zero Length bones now Iterates through each edit bone to check if it has zero length and Calculates the vector length between the head and tail. Skips this bone if it already has some length.

Remved (This is mainly a code cleanup of old code no longer in use):
- Removed 2.79 for make_annotations. 
- Removed set_default_stage_old():
- Removed get_bone_angle(p1, p2):
- Removed remove_unused_vertex_groups_of_mesh(mesh):
- Removed get_all_meshes(self, context):
- Removed days_between(d1, d2, time_format):
- Removed remove_no_user_objects():
- Removed remove_toon_shader(mesh):
