### PR TITLE
Cats Blender Plugin 4.0.4.3 (For blender 4.0) 

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ bl_info = {
     'author': 'GiveMeAllYourCats & Hotox, Unofficial version maintained by Yusarina',
     'location': 'View 3D > Tool Shelf > CATS',
     'description': 'A tool designed to shorten steps needed to import and optimize models into VRChat',
-    'version': (4, 0, 4, 1),  # Has to be (x, x, x) not [x, x, x]!! Only change this version and the dev branch var right before publishing the new update!
+    'version': (4, 0, 4, 2),  # Has to be (x, x, x) not [x, x, x]!! Only change this version and the dev branch var right before publishing the new update!
     'blender': (4, 0, 0),
     'wiki_url': 'https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/wiki',
     'tracker_url': 'https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/issues',

--- a/extentions.py
+++ b/extentions.py
@@ -1,4 +1,6 @@
 # MIT License
+import os
+import pathlib
 
 from .tools import common as Common
 from .tools.common import wrap_dynamic_enum_items
@@ -11,10 +13,19 @@ from .tools import translations as Translations
 from .tools.translations import t
 
 from bpy.types import Scene
-from bpy.props import BoolProperty, EnumProperty, FloatProperty, IntProperty
+from bpy.props import BoolProperty, EnumProperty, FloatProperty, IntProperty, StringProperty
 
+documents_folder = pathlib.Path.home() / "Documents"
+default_exports_dir = os.path.join(documents_folder, "Cats")
 
 def register():
+    Scene.custom_shapekeys_export_dir = StringProperty(
+        name=t('Scene.customfoldershapekeycsv.label'),
+        description=t('Scene.customfoldershapekeycsv.desc'),
+        subtype = 'DIR_PATH',
+        default = default_exports_dir
+    )
+
     Scene.export_shapekeys_csv = BoolProperty(
         name=t('Scene.shapekeycsv.label'),
         description=t('Scene.shapekeycsv.desc'),

--- a/resources/translations.csv
+++ b/resources/translations.csv
@@ -1109,6 +1109,8 @@ Scene.debug_translations.label,Debug Google Translations,Google翻訳をデバ�
 Scene.debug_translations.desc,Tests the Google Translations and prints the Google response in case of error,,
 Scene.shapekeycsv.label,Export Shape Keys Translations CSV,シェイプキー翻訳CSVをエクスポート,쉐이프키 번역 CSV 내보내기
 Scene.shapekeycsv.desc,"When checked CATS will export shape keys translations to a CSV file located in Documents - cats - shapekeys.csv","チェックすると、CATS はシェイプ キーの翻訳をドキュメント - cats - Shapekeys.csv にある CSV ファイルにエクスポートします。","선택하면 CATS가 모양 키 번역을 문서 - cats - Shapekeys.csv에 있는 CSV 파일로 내보냅니다"
+Scene.customfoldershapekeycsv.label,Custom CSV Export Location,カスタムCSVエクスポートの場所,커스텀 CSV 내보내기 위치
+Scene.customfoldershapekeycsv.desc,Choose your own location to export for the shape keys CSV to be.,シェイプ キーの CSV をエクスポートする独自の場所を選択します。,선택한 위치에 쉐이프 키 CSV를 내보냅니다.
 CheckForUpdateButton.label,Check now for Update,今すぐアップデートを確認,업데이트 체크
 CheckForUpdateButton.desc,Checks if a new update is available for CATS,,
 UpdateToLatestButton.label,Update Now,今すぐアップデート,지금 업데이트

--- a/tools/translate.py
+++ b/tools/translate.py
@@ -1,4 +1,4 @@
-# GPL License
+# MIT License
 
 import re
 import os
@@ -32,10 +32,14 @@ resources_dir = os.path.join(str(main_dir), "resources")
 dictionary_file = os.path.join(resources_dir, "dictionary.json")
 dictionary_google_file = os.path.join(resources_dir, "dictionary_google.json")
 
-documents_dir = Path.home() / "Documents"
-cats_dir = documents_dir / "cats"
-cats_dir.mkdir(exist_ok=True)
-
+def get_cats_dir(context):
+    prefs = context.preferences.addons["cats-blender-plugin"].preferences
+    
+    if prefs.custom_shapekeys_export_dir: 
+        return prefs.custom_shapekeys_export_dir
+    
+    # Fallback to default cats directory
+    return os.path.join(bpy.utils.user_resource('DATAFILES'), "cats") 
 
 @register_wrap
 class TranslateShapekeyButton(bpy.types.Operator):
@@ -47,6 +51,23 @@ class TranslateShapekeyButton(bpy.types.Operator):
     def execute(self, context):
         saved_data = Common.SavedData()
 
+        cats_dir = context.scene.custom_shapekeys_export_dir
+        if not cats_dir:
+            # Fallback to default dir
+            cats_dir = get_cats_dir(context)  
+            
+        # Check if dir exists or can be created
+        if not os.path.exists(cats_dir):
+            try:
+                os.makedirs(cats_dir) 
+            except OSError:
+                self.report({'ERROR'}, "Unable to create export folder. Please manually set the export directory")
+                return {'CANCELLED'}
+                
+        if not os.path.exists(cats_dir) or not os.access(cats_dir, os.W_OK):  
+            self.report({'ERROR'}, "Unable to write to export folder. Please manually set the export directory")
+            return {'CANCELLED'}
+            
         if context.scene.export_shapekeys_csv:
             
             blend_path = bpy.context.blend_data.filepath
@@ -81,7 +102,7 @@ class TranslateShapekeyButton(bpy.types.Operator):
                                     'translated': key.name
                                 })
 
-            blend_name = os.path.splitext(os.path.basename(blend_path))[0]
+            blend_name = os.path.splitext(os.path.basename(blend_path))[0] 
             export_path = os.path.join(str(cats_dir), blend_name + "_shapekeys.csv")
             
             with open(export_path, 'w', newline='') as f:
@@ -117,6 +138,7 @@ class TranslateShapekeyButton(bpy.types.Operator):
 
         self.report({'INFO'}, t('TranslateShapekeyButton.success', number=str(i)))
         return {'FINISHED'}
+
 
 
 @register_wrap

--- a/ui/settings_updates.py
+++ b/ui/settings_updates.py
@@ -32,6 +32,13 @@ class UpdaterPanel(ToolPanel, bpy.types.Panel):
         row.prop(context.scene, 'embed_textures')
         row = col.row(align=True)
         row.prop(context.scene, "export_shapekeys_csv")
+        row = col.row(align=True)
+        path = context.scene.custom_shapekeys_export_dir
+        if path:
+            custom_shapekeys_export_dir = path
+        else:
+            custom_shapekeys_export_dir = default_cats_dir
+        row.prop(context.scene, "custom_shapekeys_export_dir")
 
         col.separator()
 


### PR DESCRIPTION
- The ability to choose your own folder of where you can export the CSV too, you can choose this in settings.
- Fix to issue https://github.com/Yusarina/Cats-Blender-Plugin-Unofficial-/issues/59 the addon shouldn't crash now and just give an error and tell you too manually set the export folder instead.