### PR TITLE
Cats Blender Plugin 4.0.5.0 (For blender 4.0)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -13,7 +13,7 @@ bl_info = {
     'warning': '',
 }
 
-dev_branch = False
+dev_branch = True
 
 import os
 import sys

--- a/extentions.py
+++ b/extentions.py
@@ -18,7 +18,12 @@ from bpy.props import BoolProperty, EnumProperty, FloatProperty, IntProperty, St
 documents_folder = pathlib.Path.home() / "Documents"
 default_exports_dir = os.path.join(documents_folder, "Cats")
 
-def register():  
+def register():
+    Scene.remove_rigidbodies_joints_global = BoolProperty(
+        name=t('Scene.removerigidbodiesjointsglobal.label'),
+        description=t('Scene.removerigidbodiesjointsglobal.desc'),
+        default=True  
+    )  
     Scene.custom_translate_csv_export_dir = StringProperty(
         name=t('Scene.customfoldershapekeycsv.label'),
         description=t('Scene.customfoldershapekeycsv.desc'),

--- a/extentions.py
+++ b/extentions.py
@@ -18,15 +18,15 @@ from bpy.props import BoolProperty, EnumProperty, FloatProperty, IntProperty, St
 documents_folder = pathlib.Path.home() / "Documents"
 default_exports_dir = os.path.join(documents_folder, "Cats")
 
-def register():
-    Scene.custom_shapekeys_export_dir = StringProperty(
+def register():  
+    Scene.custom_translate_csv_export_dir = StringProperty(
         name=t('Scene.customfoldershapekeycsv.label'),
         description=t('Scene.customfoldershapekeycsv.desc'),
         subtype = 'DIR_PATH',
         default = default_exports_dir
     )
 
-    Scene.export_shapekeys_csv = BoolProperty(
+    Scene.export_translate_csv = BoolProperty(
         name=t('Scene.shapekeycsv.label'),
         description=t('Scene.shapekeycsv.desc'),
         default = False

--- a/resources/translations.csv
+++ b/resources/translations.csv
@@ -76,6 +76,8 @@ QuickAccess.ImportAnyModel.label,Import Model,モデルのインポート,모델
 QuickAccess.JoinMeshes.label,Join all meshes,すべてのメッシュを結合する,모든 메쉬에 합류
 QuickAccess.CombineMats.label,Combine Materials,材料を組み合わせる,재료 결합
 mmdoptions.FixMaterialsButton.label,Fix Materials,固定材料,재료 수정
+MMDOptions.RemoveRigidBodiesManaulInfo1,This will remove Rigid Bodies and Joint,この操作はリジッドボディとジョイントを削除します,이 작업은 리ジッドボディ와 관계를 제거합니다.
+MMDOptions.RemoveRigidBodiesManaulInfo2,Which are not needed for VRChat,VRChatで不要なものです,VRChat에서 필요하지 않은 것입니다.
 FixMaterialsButton.label,Fix Materials,固定材料,재료 수정
 FixMaterialsButton.desc,"This will apply some vrchat related fixes to materials
 
@@ -190,6 +192,14 @@ Scene.eye_left.label,Left Eye,左目,왼쪽 눈
 Scene.eye_left.desc,The models left eye bone,,
 Scene.eye_right.label,Right Eye,右目,오른쪽 눈
 Scene.eye_right.desc,The models right eye bone,,
+Scene.removerigidbodiesjointsglobal.label,Remove Rigidbodies and Joints Global,グローバルにリジッドボディとジョイントを削除,리ジッドボディ와 조인트를 전역적으로 제거
+Scene.removerigidbodiesjointsglobal.desc,"Removes all Rigidbodies and Joints from the scene whenever a button is used
+This is on by default as if rigidbodies collections are not removed it can cause issues.
+Only turn off if you need rigid bodies persevered for MMD reasons.","ボタンが使用されるたびに、シーンからすべてのリジッドボディとジョイントを削除します
+Rigidbody コレクションが削除されないと問題が発生する可能性があるため、これはデフォルトでオンになっています.
+MMD の理由でリジッド ボディを維持する必要がある場合にのみオフにします。","버튼을 사용할 때마다 장면에서 모든 강체 및 관절을 제거합니다.
+이는 Rigidbodies 컬렉션이 제거되지 않은 것처럼 기본적으로 켜져 있으며 문제가 발생할 수 있습니다.
+MMD 이유로 인해 강체를 유지해야 하는 경우에만 끄십시오."
 FixLegacy.info1,Fix Model Button has been removed.,「モデルを修正」ボタンが削除されました。,모델 수정 버튼이 제거되었습니다.
 FixLegacy.info2,please see mmd options for alternatives.,代替案については mmd オプションを参照してください。,대안은 mmd 옵션을 참조하세요.
 LegacyStuff.label,Legacy Features,レガシーなもの,레거시 물건
@@ -1186,3 +1196,8 @@ select_this_to_keep_the_bones_after_merging_them_to_their_parents_or_to_the_acti
 select_this_to_only_merge_the_weights_of_the_visible_meshes,"Select this to only merge the weights of the visible meshes"
 keep_merged_bones,"Keep Merged Bones"
 merge_visible_meshes_only,"Merge Visible Meshes Only"
+RemoveRigidbodiesJointsOperator.label,"Remove Rigidbodies and Joints","剛体とジョイントを削除","리지드바디와 조인트 제거"
+RemoveRigidbodiesJointsOperator.description,"Rigidbodies and joints are used by MMD software to simulate physics. 
+They are completely useless for VRChat, so removing them is recommended for VRChat users!","剛体とジョイントはMMDソフトウェアによって物理シミュレーションを行います。
+VRChatでは彼らが役に立ちません。VRChatユーザーのためにこれらを削除することをお勧めします！","Rigidbodies와 joints는 MMD software에서 물리연산을 위해 사용되는 것들입니다.
+VRChat에 사용되지않으므로 VRChat 유저들에게는 이것들을 지우는 게 좋습니다!"

--- a/resources/translations.csv
+++ b/resources/translations.csv
@@ -1105,12 +1105,10 @@ Scene.ui_lang.label,Cats Language,,
 Scene.ui_lang.desc,Lets you select which language the Cats interface should have,,
 Scene.use_custom_mmd_tools.label,Use Custom mmd_tools,カスタムmmd_toolsを使用する,커스텀 mmd_tools 사용
 Scene.use_custom_mmd_tools.desc,Enable this to use your own version of mmd_tools. This will disable the internal cats mmd_tools,,
-Scene.debug_translations.label,Debug Google Translations,Google翻訳をデバッグ,Google 번역 디버그
-Scene.debug_translations.desc,Tests the Google Translations and prints the Google response in case of error,,
-Scene.shapekeycsv.label,Export Shape Keys Translations CSV,シェイプキー翻訳CSVをエクスポート,쉐이프키 번역 CSV 내보내기
-Scene.shapekeycsv.desc,"When checked CATS will export shape keys translations to a CSV file located in Documents - cats - shapekeys.csv","チェックすると、CATS はシェイプ キーの翻訳をドキュメント - cats - Shapekeys.csv にある CSV ファイルにエクスポートします。","선택하면 CATS가 모양 키 번역을 문서 - cats - Shapekeys.csv에 있는 CSV 파일로 내보냅니다"
-Scene.customfoldershapekeycsv.label,Custom CSV Export Location,カスタムCSVエクスポートの場所,커스텀 CSV 내보내기 위치
+Scene.shapekeycsv.label,Export Translations To CSV,シェイプキー翻訳CSVをエクスポート,쉐이프키 번역 CSV 내보내기
+Scene.customfoldershapekeycsv.label,Custom CSV Export Location,シェイプキー翻訳CSVのエクスポート先をカスタマイズ,쉐이프키 번역
 Scene.customfoldershapekeycsv.desc,Choose your own location to export for the shape keys CSV to be.,シェイプ キーの CSV をエクスポートする独自の場所を選択します。,선택한 위치에 쉐이프 키 CSV를 내보냅니다.
+Scene.shapekeycsv.desc,"When checked CATS will export translations to a CSV file located in documents - CATS. Note you can set your own path","チェックすると、CATS はドキュメント内の CSV ファイル (CATS) に翻訳をエクスポートします。独自のパスを設定できることに注意してください","선택하면 CATS가 문서에 있는 CSV 파일(CATS)로 번역을 내보냅니다. 자신만의 경로를 설정할 수 있습니다."
 CheckForUpdateButton.label,Check now for Update,今すぐアップデートを確認,업데이트 체크
 CheckForUpdateButton.desc,Checks if a new update is available for CATS,,
 UpdateToLatestButton.label,Update Now,今すぐアップデート,지금 업데이트

--- a/tools/armature_custom.py
+++ b/tools/armature_custom.py
@@ -33,6 +33,34 @@ class MergeArmature(bpy.types.Operator):
         merge_armature_name = bpy.context.scene.merge_armature
         base_armature = Common.get_objects()[base_armature_name]
         merge_armature = Common.get_objects()[merge_armature_name]
+        armature = Common.set_default_stage()
+
+        #Remove Rigid Bodies and Joints as there won't merge.    
+        to_delete = []
+        for child in Common.get_top_parent(base_armature).children:
+            if 'rigidbodies' in child.name or 'joints' in child.name:
+                to_delete.append(child.name)
+            for child2 in child.children:
+                if 'rigidbodies' in child2.name or 'joints' in child2.name:
+                    to_delete.append(child2.name)
+        for obj_name in to_delete:
+            Common.switch('EDIT')
+            Common.switch('OBJECT')
+            Common.delete_hierarchy(bpy.data.objects[obj_name])
+
+        if len(armature.children) > 1:
+            for child in armature.children:
+                for child2 in child.children:
+                    if child2.type != 'MESH':
+                        Common.delete(child2)
+
+                if child.type != 'MESH':
+                    Common.delete(child)
+
+        Common.set_default_stage()
+        Common.unselect_all()
+        Common.remove_empty()
+        Common.remove_unused_objects()
 
         if not merge_armature:
             saved_data.load()
@@ -66,20 +94,6 @@ class MergeArmature(bpy.types.Operator):
                 saved_data.load()
                 Common.show_error(6.2, t('MergeArmature.error.pleaseFix'))
                 return {'CANCELLED'}
-            
-        #Remove Rigid Bodies and Joints as there won't merge.    
-        to_delete = []
-        for child in Common.get_top_parent(base_armature).children:
-            if 'rigidbodies' in child.name or 'joints' in child.name:
-                to_delete.append(child.name)
-            for child2 in child.children:
-                if 'rigidbodies' in child2.name or 'joints' in child2.name:
-                    to_delete.append(child2.name)
-        for obj_name in to_delete:
-            Common.switch('EDIT')
-            Common.switch('OBJECT')
-            Common.delete_hierarchy(bpy.data.objects[obj_name])
-
 
         merge_armatures(base_armature_name, merge_armature_name, False, merge_same_bones=context.scene.merge_same_bones)
 

--- a/tools/armature_custom.py
+++ b/tools/armature_custom.py
@@ -26,7 +26,6 @@ class MergeArmature(bpy.types.Operator):
 
         # Set default stage
         Common.set_default_stage()
-        Common.remove_rigidbodies_global()
         Common.unselect_all()
 
         # Get both armatures
@@ -67,17 +66,21 @@ class MergeArmature(bpy.types.Operator):
                 saved_data.load()
                 Common.show_error(6.2, t('MergeArmature.error.pleaseFix'))
                 return {'CANCELLED'}
+            
+        #Remove Rigid Bodies and Joints as there won't merge.    
+        to_delete = []
+        for child in Common.get_top_parent(base_armature).children:
+            if 'rigidbodies' in child.name or 'joints' in child.name:
+                to_delete.append(child.name)
+            for child2 in child.children:
+                if 'rigidbodies' in child2.name or 'joints' in child2.name:
+                    to_delete.append(child2.name)
+        for obj_name in to_delete:
+            Common.switch('EDIT')
+            Common.switch('OBJECT')
+            Common.delete_hierarchy(bpy.data.objects[obj_name])
 
-        # if len(Common.get_meshes_objects(armature_name=merge_armature_name)) == 0:
-        #     saved_data.load()
-        #     Common.show_error(5.2, ['The armature "' + merge_armature_name + '" does not have any meshes.'])
-        #     return {'CANCELLED'}
-        # if len(Common.get_meshes_objects(armature_name=base_armature_name)) == 0:
-        #     saved_data.load()
-        #     Common.show_error(5.2, ['The armature "' + base_armature_name + '" does not have any meshes.'])
-        #     return {'CANCELLED'}
 
-        # Merge armatures
         merge_armatures(base_armature_name, merge_armature_name, False, merge_same_bones=context.scene.merge_same_bones)
 
         saved_data.load()

--- a/tools/armature_custom.py
+++ b/tools/armature_custom.py
@@ -26,6 +26,7 @@ class MergeArmature(bpy.types.Operator):
 
         # Set default stage
         Common.set_default_stage()
+        Common.remove_rigidbodies_global()
         Common.unselect_all()
 
         # Get both armatures
@@ -101,6 +102,7 @@ class AttachMesh(bpy.types.Operator):
 
         # Set default stage
         Common.set_default_stage()
+        Common.remove_rigidbodies_global()
         Common.unselect_all()
 
         # Get armature and mesh
@@ -290,6 +292,7 @@ def merge_armatures(base_armature_name, merge_armature_name, mesh_only, mesh_nam
 
     # Go back into object mode
     Common.set_default_stage()
+    Common.remove_rigidbodies_global()
     Common.unselect_all()
 
     # Select armature in correct way
@@ -357,6 +360,7 @@ def merge_armatures(base_armature_name, merge_armature_name, mesh_only, mesh_nam
 
     # Remove all unused bones, constraints and vertex groups
     Common.set_default_stage()
+    Common.remove_rigidbodies_global()
     if not mesh_only:
         Common.delete_bone_constraints(armature_name=base_armature_name)
         if bpy.context.scene.merge_armatures_remove_zero_weight_bones:
@@ -364,6 +368,7 @@ def merge_armatures(base_armature_name, merge_armature_name, mesh_only, mesh_nam
             if Common.get_meshes_objects(armature_name=base_armature_name):
                 Common.delete_zero_weight(armature_name=base_armature_name, ignore=root_name)
         Common.set_default_stage()
+        Common.remove_rigidbodies_global()
 
     # Merge bones into existing bones
     if not mesh_only:
@@ -432,12 +437,14 @@ def merge_armatures(base_armature_name, merge_armature_name, mesh_only, mesh_nam
 
     # Remove all unused bones, constraints and vertex groups
     Common.set_default_stage()
+    Common.remove_rigidbodies_global()
     if not mesh_only:
         if bpy.context.scene.merge_armatures_remove_zero_weight_bones:
             Common.remove_unused_vertex_groups()
             if Common.get_meshes_objects(armature_name=base_armature_name):
                 Common.delete_zero_weight(armature_name=base_armature_name, ignore=root_name)
             Common.set_default_stage()
+            Common.remove_rigidbodies_global()
 
     # Fix armature name
     Common.fix_armature_names(armature_name=base_armature_name)

--- a/tools/bonemerge.py
+++ b/tools/bonemerge.py
@@ -105,6 +105,7 @@ class BoneMergeButton(bpy.types.Operator):
 
                 # Mix the weights
                 Common.set_default_stage()
+                Common.remove_rigidbodies_global()
                 Common.set_active(mesh)
 
                 vg = mesh.vertex_groups.get(bone_name)
@@ -113,6 +114,7 @@ class BoneMergeButton(bpy.types.Operator):
                     Common.mix_weights(mesh, bone_name, parent_name)
 
                 Common.set_default_stage()
+                Common.remove_rigidbodies_global()
 
                 # We are done, remove the bone
                 Common.remove_bone(bone_name)

--- a/tools/common.py
+++ b/tools/common.py
@@ -219,15 +219,9 @@ def switch(new_mode, check_mode=True):
     if bpy.ops.object.mode_set.poll():
         bpy.ops.object.mode_set(mode=new_mode, toggle=False)
 
+def remove_rigidbodies_global():
 
-def set_default_stage():
-    """
-    Selects the armature, unhides everything and sets the modes of every object to object mode
-    :return: the armature
-    """
-
-    # Remove rigidbody collections, as they cause issues if they are not in the view_layer
-    if bpy.context.scene.remove_rigidbodies_joints:
+    if bpy.context.scene.remove_rigidbodies_joints_global:
         print('Collections:')
         for collection in bpy.data.collections:
             print(' ' + collection.name, collection.name.lower())
@@ -236,6 +230,18 @@ def set_default_stage():
                 for obj in collection.objects:
                     delete(obj)
                 bpy.data.collections.remove(collection)
+
+    armature = get_armature()
+    if armature:
+        set_active(armature)
+
+    return armature
+
+def set_default_stage():
+    """
+    Selects the armature, unhides everything and sets the modes of every object to object mode
+    :return: the armature
+    """
 
     unhide_all()
     unselect_all()

--- a/tools/decimation.py
+++ b/tools/decimation.py
@@ -165,6 +165,7 @@ class AutoDecimateButtonCats(bpy.types.Operator):
     def decimate(self, context):
         print('START DECIMATION')
         Common.set_default_stage()
+        Common.remove_rigidbodies_global()
 
         custom_decimation = context.scene.decimation_mode == 'CUSTOM'
         full_decimation = context.scene.decimation_mode == 'FULL'

--- a/tools/eyetracking.py
+++ b/tools/eyetracking.py
@@ -333,6 +333,7 @@ class CreateEyesButton(bpy.types.Operator):
 
         # Remove empty objects
         Common.set_default_stage()  # Fixes an error apparently
+        Common.remove_rigidbodies_global()
         Common.remove_empty()
 
         # Fix armature name
@@ -481,6 +482,7 @@ def fix_eye_position(context, old_eye, new_eye, head, right_side):
 def repair_shapekeys(mesh_name, vertex_group):
     # This is done to fix a very weird bug where the mouth stays open sometimes
     Common.set_default_stage()
+    Common.remove_rigidbodies_global()
     mesh = Common.get_objects()[mesh_name]
     Common.unselect_all()
     Common.set_active(mesh)
@@ -551,6 +553,7 @@ def randBoolNumber():
 def repair_shapekeys_mouth(mesh_name):  # TODO Add vertex repairing!
     # This is done to fix a very weird bug where the mouth stays open sometimes
     Common.set_default_stage()
+    Common.remove_rigidbodies_global()
     mesh = Common.get_objects()[mesh_name]
     Common.unselect_all()
     Common.set_active(mesh)
@@ -666,6 +669,7 @@ class StopTestingButton(bpy.types.Operator):
 
         if not context.object or context.object.mode != 'POSE':
             Common.set_default_stage()
+            Common.remove_rigidbodies_global()
             Common.switch('POSE')
 
         for pb in Common.get_armature().data.bones:

--- a/tools/material.py
+++ b/tools/material.py
@@ -100,6 +100,7 @@ class CombineMaterialsButton(bpy.types.Operator):
         saved_data = Common.SavedData()
 
         Common.set_default_stage()
+        Common.remove_rigidbodies_global()
         self.generate_combined_tex()
         Common.switch('OBJECT')
         i = 0

--- a/tools/rootbone.py
+++ b/tools/rootbone.py
@@ -23,6 +23,7 @@ class RootButton(bpy.types.Operator):
     def execute(self, context):
         saved_data = Common.SavedData()
         Common.set_default_stage()
+        Common.remove_rigidbodies_global()
 
         Common.switch('EDIT')
 

--- a/tools/translate.py
+++ b/tools/translate.py
@@ -51,7 +51,7 @@ class TranslateShapekeyButton(bpy.types.Operator):
     def execute(self, context):
         saved_data = Common.SavedData()
 
-        cats_dir = context.scene.custom_shapekeys_export_dir
+        cats_dir = context.scene.custom_translate_csv_export_dir
         if not cats_dir:
             # Fallback to default dir
             cats_dir = get_cats_dir(context)  
@@ -68,7 +68,7 @@ class TranslateShapekeyButton(bpy.types.Operator):
             self.report({'ERROR'}, "Unable to write to export folder. Please manually set the export directory")
             return {'CANCELLED'}
             
-        if context.scene.export_shapekeys_csv:
+        if context.scene.export_translate_csv:
             
             blend_path = bpy.context.blend_data.filepath
             if not blend_path:
@@ -140,7 +140,6 @@ class TranslateShapekeyButton(bpy.types.Operator):
         return {'FINISHED'}
 
 
-
 @register_wrap
 class TranslateBonesButton(bpy.types.Operator):
     bl_idname = 'cats_translate.bones'
@@ -148,28 +147,85 @@ class TranslateBonesButton(bpy.types.Operator):
     bl_description = t('TranslateBonesButton.desc')
     bl_options = {'REGISTER', 'UNDO', 'INTERNAL'}
 
-    @classmethod
-    def poll(cls, context):
-        if not Common.get_armature():
-            return False
-        return True
-
     def execute(self, context):
-        to_translate = []
-        for armature in Common.get_armature_objects():
-            for bone in armature.data.bones:
-                to_translate.append(bone.name)
+        saved_data = Common.SavedData()
 
-        update_dictionary(to_translate, self=self)
+        cats_dir = context.scene.custom_translate_csv_export_dir
+        if not cats_dir:
+            # Fallback to default dir
+            cats_dir = get_cats_dir(context)  
+            
+        # Check if dir exists or can be created
+        if not os.path.exists(cats_dir):
+            try:
+                os.makedirs(cats_dir) 
+            except OSError:
+                self.report({'ERROR'}, "Unable to create export folder. Please manually set the export directory")
+                return {'CANCELLED'}
+                
+        if not os.path.exists(cats_dir) or not os.access(cats_dir, os.W_OK):  
+            self.report({'ERROR'}, "Unable to write to export folder. Please manually set the export directory")
+            return {'CANCELLED'}
+            
+        if context.scene.export_translate_csv:
+            
+            blend_path = bpy.context.blend_data.filepath
+            if not blend_path:
+                self.report({'ERROR'}, "Please save blend first!")
+                return {'CANCELLED'}
+            
+            to_translate = []
+            for armature in Common.get_armature_objects():
+                for bone in armature.data.bones:
+                    to_translate.append(bone.name)
 
-        count = 0
-        for armature in Common.get_armature_objects():
-            for bone in armature.data.bones:
-                bone.name, translated = translate(bone.name)
-                if translated:
-                    count += 1
+            update_dictionary(to_translate, self=self)
+            
+            bones = []
+            i = 0
+            for armature in Common.get_armature_objects():
+                for bone in armature.data.bones:
+                    original_name = bone.name
+                    bone.name, translated = translate(bone.name)
+                    if translated:
+                        i += 1
+                        bones.append({
+                            'armature': armature.name,
+                            'original': original_name,
+                            'translated': bone.name
+                        })
 
-        self.report({'INFO'}, t('TranslateBonesButton.success', number=str(count)))
+            blend_name = os.path.splitext(os.path.basename(blend_path))[0] 
+            export_path = os.path.join(str(cats_dir), blend_name + "_bones.csv")
+            
+            with open(export_path, 'w', newline='') as f:
+                writer = csv.writer(f)
+                writer.writerow(['armature', 'original', 'translated'])
+                for bone in bones:
+                    writer.writerow([bone['armature'], bone['original'], bone['translated']])
+
+        else:
+            to_translate = []
+            for armature in Common.get_armature_objects():
+                for bone in armature.data.bones:
+                    if bone.name not in to_translate:
+                        to_translate.append(bone.name)
+
+            update_dictionary(to_translate, self=self)
+
+            i = 0
+            for armature in Common.get_armature_objects():
+                for bone in armature.data.bones:
+                    original_name = bone.name
+                    bone.name, translated = translate(bone.name)
+                    if translated:
+                        i += 1
+
+        Common.ui_refresh()
+
+        saved_data.load()
+
+        self.report({'INFO'}, t('TranslateBonesButton.success', number=str(i)))
         return {'FINISHED'}
 
 
@@ -181,37 +237,77 @@ class TranslateObjectsButton(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO', 'INTERNAL'}
 
     def execute(self, context):
-        if bpy.app.version < (2, 79, 0):
-            self.report({'ERROR'}, t('TranslateX.error.wrongVersion'))
-            return {'FINISHED'}
-        to_translate = []
-        for obj in Common.get_objects():
-            if obj.name not in to_translate:
+        saved_data = Common.SavedData()
+
+        cats_dir = context.scene.custom_translate_csv_export_dir
+        if not cats_dir:
+            # Fallback to default dir
+            cats_dir = get_cats_dir(context)
+
+        # Check if dir exists or can be created
+        if not os.path.exists(cats_dir):
+            try:
+                os.makedirs(cats_dir)
+            except OSError:
+                self.report({'ERROR'}, "Unable to create export folder. Please manually set the export directory")
+                return {'CANCELLED'}
+
+        if not os.path.exists(cats_dir) or not os.access(cats_dir, os.W_OK):
+            self.report({'ERROR'}, "Unable to write to export folder. Please manually set the export directory")
+            return {'CANCELLED'}
+
+        if context.scene.export_translate_csv:
+            blend_path = bpy.context.blend_data.filepath
+            if not blend_path:
+                self.report({'ERROR'}, "Please save blend first!")
+                return {'CANCELLED'}
+
+            to_translate = []
+            for obj in Common.get_objects():
                 to_translate.append(obj.name)
-            if obj.type == 'ARMATURE':
-                if obj.data and obj.data.name not in to_translate:
-                    to_translate.append(obj.data.name)
-                if obj.animation_data and obj.animation_data.action:
-                    to_translate.append(obj.animation_data.action.name)
 
-        update_dictionary(to_translate, self=self)
+            update_dictionary(to_translate, self=self)
 
-        i = 0
-        for obj in Common.get_objects():
-            obj.name, translated = translate(obj.name)
-            if translated:
-                i += 1
+            objects_translations = []
+            i = 0
+            for obj in Common.get_objects():
+                original_name = obj.name
+                obj.name, translated = translate(obj.name)
+                if translated:
+                    i += 1
+                    objects_translations.append({
+                        'object': obj.name,
+                        'original': original_name,
+                        'translated': obj.name
+                    })
 
-            if obj.type == 'ARMATURE':
-                if obj.data:
-                    obj.data.name, translated = translate(obj.data.name)
-                    if translated:
-                        i += 1
+            blend_name = os.path.splitext(os.path.basename(blend_path))[0]
+            export_path = os.path.join(str(cats_dir), blend_name + "_objects.csv")
 
-                if obj.animation_data and obj.animation_data.action:
-                    obj.animation_data.action.name, translated = translate(obj.animation_data.action.name)
-                    if translated:
-                        i += 1
+            with open(export_path, 'w', newline='', encoding='utf-8') as f:
+                writer = csv.writer(f)
+                writer.writerow(['object', 'original', 'translated'])
+                for translation in objects_translations:
+                    writer.writerow([translation['object'], translation['original'], translation['translated']])
+
+        else:
+            to_translate = []
+            for obj in Common.get_objects():
+                if obj.name not in to_translate:
+                    to_translate.append(obj.name)
+
+            update_dictionary(to_translate, self=self)
+
+            i = 0
+            for obj in Common.get_objects():
+                original_name = obj.name
+                obj.name, translated = translate(obj.name)
+                if translated:
+                    i += 1
+
+        Common.ui_refresh()
+
+        saved_data.load()
 
         self.report({'INFO'}, t('TranslateObjectsButton.success', number=str(i)))
         return {'FINISHED'}
@@ -225,31 +321,82 @@ class TranslateMaterialsButton(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO', 'INTERNAL'}
 
     def execute(self, context):
-        if bpy.app.version < (2, 79, 0):
-            self.report({'ERROR'}, t('TranslateX.error.wrongVersion'))
-            return {'FINISHED'}
-
         saved_data = Common.SavedData()
 
-        to_translate = []
-        for mesh in Common.get_meshes_objects(mode=2):
-            for matslot in mesh.material_slots:
-                if matslot.name not in to_translate:
+        cats_dir = context.scene.custom_translate_csv_export_dir
+        if not cats_dir:
+            # Fallback to default dir
+            cats_dir = get_cats_dir(context)
+
+        # Check if dir exists or can be created
+        if not os.path.exists(cats_dir):
+            try:
+                os.makedirs(cats_dir)
+            except OSError:
+                self.report({'ERROR'}, "Unable to create export folder. Please manually set the export directory")
+                return {'CANCELLED'}
+
+        if not os.path.exists(cats_dir) or not os.access(cats_dir, os.W_OK):
+            self.report({'ERROR'}, "Unable to write to export folder. Please manually set the export directory")
+            return {'CANCELLED'}
+
+        if context.scene.export_translate_csv:
+            blend_path = bpy.context.blend_data.filepath
+            if not blend_path:
+                self.report({'ERROR'}, "Please save blend first!")
+                return {'CANCELLED'}
+
+            to_translate = []
+            for mesh in Common.get_meshes_objects(mode=2):
+                for matslot in mesh.material_slots:
                     to_translate.append(matslot.name)
 
-        update_dictionary(to_translate, self=self)
+            update_dictionary(to_translate, self=self)
 
-        i = 0
-        for mesh in Common.get_meshes_objects(mode=2):
-            Common.set_active(mesh)
-            for index, matslot in enumerate(mesh.material_slots):
-                mesh.active_material_index = index
-                if bpy.context.object.active_material:
-                    bpy.context.object.active_material.name, translated = translate(bpy.context.object.active_material.name)
+            materials_translations = []
+            i = 0
+            for mesh in Common.get_meshes_objects(mode=2):
+                for matslot in mesh.material_slots:
+                    original_name = matslot.name
+                    matslot.material.name, translated = translate(matslot.material.name)
+                    if translated:
+                        i += 1
+                        materials_translations.append({
+                            'mesh': mesh.name,
+                            'original': original_name,
+                            'translated': matslot.material.name
+                        })
+
+            blend_name = os.path.splitext(os.path.basename(blend_path))[0]
+            export_path = os.path.join(str(cats_dir), blend_name + "_materials.csv")
+
+            with open(export_path, 'w', newline='', encoding='utf-8') as f:
+                writer = csv.writer(f)
+                writer.writerow(['mesh', 'original', 'translated'])
+                for translation in materials_translations:
+                    writer.writerow([translation['mesh'], translation['original'], translation['translated']])
+
+        else:
+            to_translate = []
+            for mesh in Common.get_meshes_objects(mode=2):
+                for matslot in mesh.material_slots:
+                    if matslot.name not in to_translate:
+                        to_translate.append(matslot.name)
+
+            update_dictionary(to_translate, self=self)
+
+            i = 0
+            for mesh in Common.get_meshes_objects(mode=2):
+                for matslot in mesh.material_slots:
+                    original_name = matslot.name
+                    matslot.material.name, translated = translate(matslot.material.name)
                     if translated:
                         i += 1
 
+        Common.ui_refresh()
+
         saved_data.load()
+
         self.report({'INFO'}, t('TranslateMaterialsButton.success', number=str(i)))
         return {'FINISHED'}
 
@@ -310,9 +457,13 @@ class TranslateAllButton(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO', 'INTERNAL'}
 
     def execute(self, context):
-        if bpy.app.version < (2, 79, 0):
-            self.report({'ERROR'}, t('TranslateX.error.wrongVersion'))
-            return {'FINISHED'}
+        
+        # Check if the export_translate_csv is checked and if the blend file is saved
+        if context.scene.export_translate_csv:
+            if not bpy.data.filepath:
+                # Prompt the user to save the blend file
+                self.report({'ERROR'}, "Please save the blend file before exporting translations.")
+                return {'CANCELLED'}
 
         error_shown = False
 
@@ -629,30 +780,3 @@ def reset_google_dict():
 def save_google_dict():
     with open(dictionary_google_file, 'w', encoding="utf8") as outfile:
         json.dump(dictionary_google, outfile, ensure_ascii=False, indent=4)
-
-# def cvs_to_json():
-#     temp_dict = OrderedDict()
-#
-#     # Load internal dictionary
-#     try:
-#         with open(dictionary_file, encoding="utf8") as file:
-#             data = csv.reader(file, delimiter=',')
-#             for row in data:
-#                 name = fix_jp_chars(str(row[0]))
-#                 translation = row[1]
-#
-#                 if translation.startswith(' "'):
-#                     translation = translation[2:-1]
-#                 if translation.startswith('"'):
-#                     translation = translation[1:-1]
-#
-#                 temp_dict[name] = translation
-#             print('DICTIONARY LOADED!')
-#     except FileNotFoundError:
-#         print('DICTIONARY NOT FOUND!')
-#         pass
-#
-#     # # Create json from cvs
-#     dictionary_file_new = os.path.join(resources_dir, "dictionary2.json")
-#     with open(dictionary_file_new, 'w', encoding="utf8") as outfile:
-#         json.dump(temp_dict, outfile, ensure_ascii=False, indent=4)

--- a/tools/viseme.py
+++ b/tools/viseme.py
@@ -37,6 +37,7 @@ class AutoVisemeButton(bpy.types.Operator):
         saved_data = Common.SavedData()
 
         Common.set_default_stage()
+        Common.remove_rigidbodies_global()
 
         wm = bpy.context.window_manager
 

--- a/ui/mmdoptions.py
+++ b/ui/mmdoptions.py
@@ -64,7 +64,17 @@ class MMDOptions(ToolPanel, bpy.types.Panel):
         row = split.row(align=True)
         row.scale_y = 1.5
         row.operator(Material.FixMaterialsButton.bl_idname, text=t('mmdoptions.FixMaterialsButton.label'), icon='NODE_MATERIAL')
-
+        col.separator()
+        split = col.row(align=True)
+        row = split.row(align=True)
+        row.scale_y = 1.5
+        sub.label(text=t("MMDOptions.RemoveRigidBodiesManaulInfo1"), icon='INFO')
+        sub.label(text=t("MMDOptions.RemoveRigidBodiesManaulInfo2"), icon='NONE')
+        col.separator()
+        split = col.row(align=True)
+        row = split.row(align=True)
+        row.scale_y = 1.5
+        row.operator(Armature_manual.RemoveRigidbodiesJointsOperator.bl_idname, icon='RIGID_BODY')
         col.separator()
         col.separator()
               

--- a/ui/mmdoptions.py
+++ b/ui/mmdoptions.py
@@ -65,9 +65,9 @@ class MMDOptions(ToolPanel, bpy.types.Panel):
         row.scale_y = 1.5
         row.operator(Material.FixMaterialsButton.bl_idname, text=t('mmdoptions.FixMaterialsButton.label'), icon='NODE_MATERIAL')
         col.separator()
-        split = col.row(align=True)
-        row = split.row(align=True)
-        row.scale_y = 1.5
+        col.separator()
+        sub = col.column(align=True)
+        sub.scale_y = 0.75
         sub.label(text=t("MMDOptions.RemoveRigidBodiesManaulInfo1"), icon='INFO')
         sub.label(text=t("MMDOptions.RemoveRigidBodiesManaulInfo2"), icon='NONE')
         col.separator()

--- a/ui/settings_updates.py
+++ b/ui/settings_updates.py
@@ -30,6 +30,8 @@ class UpdaterPanel(ToolPanel, bpy.types.Panel):
         row = col.row(align=True)
         row.prop(context.scene, 'embed_textures')
         row = col.row(align=True)
+        row.prop(context.scene, 'remove_rigidbodies_joints_global')
+        row = col.row(align=True)
         row.prop(context.scene, "export_translate_csv")
         row = col.row(align=True)
         path = context.scene.custom_translate_csv_export_dir

--- a/ui/settings_updates.py
+++ b/ui/settings_updates.py
@@ -9,7 +9,6 @@ from ..tools import settings as Settings
 from ..tools.register import register_wrap
 from ..tools.translations import t, DownloadTranslations
 
-
 @register_wrap
 class UpdaterPanel(ToolPanel, bpy.types.Panel):
     bl_idname = 'VIEW3D_PT_updater_v3'
@@ -31,14 +30,14 @@ class UpdaterPanel(ToolPanel, bpy.types.Panel):
         row = col.row(align=True)
         row.prop(context.scene, 'embed_textures')
         row = col.row(align=True)
-        row.prop(context.scene, "export_shapekeys_csv")
+        row.prop(context.scene, "export_translate_csv")
         row = col.row(align=True)
-        path = context.scene.custom_shapekeys_export_dir
+        path = context.scene.custom_translate_csv_export_dir
         if path:
-            custom_shapekeys_export_dir = path
+            custom_translate_csv_export_dir = path
         else:
-            custom_shapekeys_export_dir = default_cats_dir
-        row.prop(context.scene, "custom_shapekeys_export_dir")
+            custom_translate_csv_export_dir = default_cats_dir
+        row.prop(context.scene, "custom_translate_csv_export_dir")
 
         col.separator()
 


### PR DESCRIPTION
This version makes some large changes for Cats and resolves issue #69 and expands the ability to export translations. Once tests are complete on the Blender 4.0 version I will bring these changes to blender 3.6 and 4.1 soon.

We can't just removed the function of removing rigidbodies as it still seem to cause issues in the view layer if we do, however this also causes issues for the people who needs rigidbodies for MMD stuff, therefor we added a global option to turn this on/ off so the user can we needed.

#### Added: 
- Added option in settings which allow the user to turn off the removal of rigid bodies when using cats. This is not recommended to turn off as it can cause issues.
- Added the ability to export translations to csv to all translations options, this means you can now export translations for Mesh/ objects, Materials, Bones and Shapekeys.
- Added a check on translate all button to make sure blender file is saved if the export to csv option is checked.
- Added a manual remove rigid bodies and joints button to help users remove them when needed.

#### Changes: 
- Separated the Fix MMD model remove rigid bodies options for the global setting this will prevent accidental removal when just using normal cats features. (This could break some functions in cats, tests pending before merge).
- Translations cleanup.

#### Removed 
- Removed old 2.79 checks for translation classes.

#### To-Do:
- [ ] Test all functions of cats with and without the global setting on.
- [ ] Fix any issues.
- [ ] Update wiki (As these changes will be on all versions of cats anyway).