### PR TITLE
Blender 42 dev

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -294,10 +294,6 @@ def unregister():
     # Unregister updater
     updater.unregister()
 
-    # Register unloaded mmd_tools tabs if they are hidden to avoid issues when unloading mmd_tools
-    if not bpy.context.scene.show_mmd_tabs:
-        tools.common.toggle_mmd_tabs(shutdown_plugin=True)
-
     # Unload mmd_tools
     try:
         mmd_tools_local.unregister()

--- a/updater.py
+++ b/updater.py
@@ -380,7 +380,7 @@ def check_for_update():
     print('Checking for Cats update...')
 
     # Get all releases from Github
-    if not get_github_releases('Darkblader24') and not get_github_releases('teamneoneko'):
+    if not get_github_releases('teamneoneko'):
         finish_update_checking(error=t('check_for_update.cantCheck'))
         return
 


### PR DESCRIPTION
- Fixed issue where mmd_tools_tabs would give an error when trying to disable the add-on.
- Fixed issue where settings threads would hang blender and not disable.
-  Remove check for Darkblader24 releases, I must of forgot to do this a while ago.