### PR TITLE
Bones no longer load automatically in bone merging tab. 

### DIFF
--- a/extentions.py
+++ b/extentions.py
@@ -432,12 +432,11 @@ def register():
         # get_meshes is used elsewhere than for EnumProperty items so must contain the sorting itself
         items=wrap_dynamic_enum_items(Common.get_meshes, 'merge_mesh', sort=False),
     )
-
+    
     Scene.merge_bone = EnumProperty(
         name=t('Scene.merge_bone.label'),
         description=t('Scene.merge_bone.desc'),
-        # Root bone choices get cached, so we don't want to fix them in-place, otherwise the cache would get modified
-        items=wrap_dynamic_enum_items(Rootbone.get_parent_root_bones, 'merge_bone', sort=False, in_place=False),
+        items=[],  # Start with an empty list to prevent auto-population
     )
 
     # Settings

--- a/ui/optimization.py
+++ b/ui/optimization.py
@@ -220,13 +220,24 @@ class OptimizePanel(ToolPanel, bpy.types.Panel):
             if len(Common.get_meshes_objects(check=False)) > 1:
                 row = box.row(align=True)
                 row.prop(context.scene, 'merge_mesh')
+            
+            # Load Bones button
             row = box.row(align=True)
+            row.scale_y = 1.1
+            row.operator('cats_bonemerge.load_bones', text="Load Bones", icon='BONE_DATA')
+            
+            # Bone selection and ratio controls - disabled until bones are loaded
+            row = box.row(align=True)
+            row.enabled = bool(globs.root_bones.get(context.scene.merge_bone))
             row.prop(context.scene, 'merge_bone')
+            
             row = box.row(align=True)
+            row.enabled = bool(globs.root_bones.get(context.scene.merge_bone))
             row.prop(context.scene, 'merge_ratio')
+            
+            # Refresh and Merge buttons - disabled until bones are loaded
             row = box.row(align=True)
-            col.separator()
-            row.operator(Rootbone.RefreshRootButton.bl_idname, icon='FILE_REFRESH')
+            row.enabled = bool(globs.root_bones.get(context.scene.merge_bone))
             row.operator(Bonemerge.BoneMergeButton.bl_idname, icon='AUTOMERGE_ON')
             
             col.separator()


### PR DESCRIPTION
This is to fix the issue of bones loading automatically, altough in normal circumstances it should be fine, in certain cases where the users model may have alot of bones blender can freaze, we added a load bones button so the user can load the bones. This should solve #186