### PR TITLE
Bones no longer load automatically in bone merging tab.

### DIFF
--- a/extentions.py
+++ b/extentions.py
@@ -416,8 +416,7 @@ def register():
     Scene.merge_bone = EnumProperty(
         name=t('Scene.merge_bone.label'),
         description=t('Scene.merge_bone.desc'),
-        # Root bone choices get cached, so we don't want to fix them in-place, otherwise the cache would get modified
-        items=wrap_dynamic_enum_items(Rootbone.get_parent_root_bones, 'merge_bone', sort=False, in_place=False),
+        items=[],  # Start with an empty list to prevent auto-population
     )
 
     # Settings

--- a/tools/bonemerge.py
+++ b/tools/bonemerge.py
@@ -7,10 +7,40 @@ from .register import register_wrap
 from .. import globs
 from .translations import t
 
-# wm = bpy.context.window_manager
-# wm.progress_begin(0, len(bone_merge))
-# wm.progress_update(index)
-# wm.progress_end()
+from .rootbone import get_parent_root_bones
+
+from .rootbone import get_parent_root_bones
+
+@register_wrap
+class LoadBonesButton(bpy.types.Operator):
+    bl_idname = 'cats_bonemerge.load_bones'
+    bl_label = t('LoadBonesButton.label')
+    bl_description = t('LoadBonesButton.desc')
+    bl_options = {'REGISTER', 'UNDO', 'INTERNAL'}
+
+    @classmethod
+    def poll(cls, context):
+        return Common.get_armature() is not None
+
+    def execute(self, context):
+        armature = Common.get_armature()
+        
+        globs.root_bones_choices = {}
+        choices = get_parent_root_bones(self, context)
+        
+        # Use the wrap_dynamic_enum_items helper
+        wrapped_items = Common.wrap_dynamic_enum_items(
+            lambda s, c: choices,
+            'merge_bone'
+        )
+        
+        bpy.types.Scene.merge_bone = bpy.props.EnumProperty(
+            name=t('Scene.merge_bone.label'),
+            description=t('Scene.merge_bone.desc'),
+            items=wrapped_items
+        )
+
+        return {'FINISHED'}
 
 
 @register_wrap
@@ -22,7 +52,8 @@ class BoneMergeButton(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return Common.is_enum_non_empty(context.scene.merge_mesh) and Common.is_enum_non_empty(context.scene.merge_bone)
+        return (context.scene.merge_bone in globs.root_bones and 
+                Common.is_enum_non_empty(context.scene.merge_mesh))
 
     def execute(self, context):
         saved_data = Common.SavedData()
@@ -93,15 +124,7 @@ class BoneMergeButton(bpy.types.Operator):
             if bone.parent is not None:
                 parent_name = bone.parent.name
 
-                print('Merging ' + bone_name + ' into ' + parent_name+ ' with ratio ' + str(i) )
-
-                # # Set new parent bone position
-                # armature = Common.set_default_stage()
-                # Common.switch('EDIT')
-                #
-                # child = armature.data.edit_bones.get(bone_name)
-                # parent = armature.data.edit_bones.get(parent_name)
-                # parent.tail = child.tail
+                print('Merging ' + bone_name + ' into ' + parent_name+ ' with ratio ' + str(i))
 
                 # Mix the weights
                 Common.set_default_stage()

--- a/ui/optimization.py
+++ b/ui/optimization.py
@@ -220,13 +220,24 @@ class OptimizePanel(ToolPanel, bpy.types.Panel):
             if len(Common.get_meshes_objects(check=False)) > 1:
                 row = box.row(align=True)
                 row.prop(context.scene, 'merge_mesh')
+            
+            # Load Bones button
             row = box.row(align=True)
+            row.scale_y = 1.1
+            row.operator('cats_bonemerge.load_bones', text="Load Bones", icon='BONE_DATA')
+            
+            # Bone selection and ratio controls - disabled until bones are loaded
+            row = box.row(align=True)
+            row.enabled = bool(globs.root_bones.get(context.scene.merge_bone))
             row.prop(context.scene, 'merge_bone')
+            
             row = box.row(align=True)
+            row.enabled = bool(globs.root_bones.get(context.scene.merge_bone))
             row.prop(context.scene, 'merge_ratio')
+            
+            # Refresh and Merge buttons - disabled until bones are loaded
             row = box.row(align=True)
-            col.separator()
-            row.operator(Rootbone.RefreshRootButton.bl_idname, icon='FILE_REFRESH')
+            row.enabled = bool(globs.root_bones.get(context.scene.merge_bone))
             row.operator(Bonemerge.BoneMergeButton.bl_idname, icon='AUTOMERGE_ON')
             
             col.separator()


### PR DESCRIPTION
This is to fix the issue of bones loading automatically, altough in normal circumstances it should be fine, in certain cases where the users model may have alot of bones blender can freaze, we added a load bones button so the user can load the bones. This should solve #186