### PR TITLE
No longer allow metarigs and rigify armatures

### DIFF
--- a/tools/armature.py
+++ b/tools/armature.py
@@ -38,6 +38,29 @@ class FixArmature(bpy.types.Operator):
 
     def execute(self, context):
         saved_data = Common.SavedData()
+        armature = Common.get_armature()
+        
+        # Check for Rigify/Metarig
+        is_rigify = False
+        rigify_bones = {'brow.B.L', 'lip.B.R', 'lip.T.R', 'lip.B.L', 'lip.T.L'}
+        
+        if armature.name.lower() == 'metarig':
+            is_rigify = True
+        
+        if not is_rigify:
+            for bone in armature.data.bones:
+                if bone.name.startswith(('DEF-', 'MCH-', 'ORG-')) or bone.name in rigify_bones:
+                    is_rigify = True
+                    break
+                
+        if is_rigify:
+            Common.show_error(3, ["Rigify and Metarig armatures are not", 
+                                "supported. Please use Rigify to Unity", 
+                                "plugin instead.",
+                                "If you think this is a error, then make sure your",
+                                "bones and amrature do not have metarig", 
+                                "names or Rigify names."])
+            return {'CANCELLED'}
 
         # Check if all meshes are single user
         meshes_to_check = Common.get_meshes_objects()


### PR DESCRIPTION
- Cats Fix Model/ Fix MMD Model has never supported metarigs/ rigify, it will break the armature, now due to rigify changes it now causes crashes, therefor we don't allow the operation. Semi fix for teamneoneko#199