### PR TITLE
4.1.2.4 (Blender 4.1)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ bl_info = {
     'author': 'GiveMeAllYourCats & Hotox, Unofficial version maintained by the Unoffical Cats Team.',
     'location': 'View 3D > Tool Shelf > CATS',
     'description': 'A tool designed to shorten steps needed to import and optimize models into VRChat',
-    'version': (4, 1, 2, 2),  # Has to be (x, x, x) not [x, x, x]!! Only change this version and the dev branch var right before publishing the new update!
+    'version': (4, 1, 2, 3),  # Has to be (x, x, x) not [x, x, x]!! Only change this version and the dev branch var right before publishing the new update!
     'blender': (4, 1, 0),
     'wiki_url': 'https://github.com/teamneoneko/Cats-Blender-Plugin-Unofficial-/wiki',
     'tracker_url': 'https://github.com/teamneoneko/Cats-Blender-Plugin-Unofficial-/issues',

--- a/tools/armature.py
+++ b/tools/armature.py
@@ -38,6 +38,29 @@ class FixArmature(bpy.types.Operator):
 
     def execute(self, context):
         saved_data = Common.SavedData()
+        armature = Common.get_armature()
+        
+        # Check for Rigify/Metarig
+        is_rigify = False
+        rigify_bones = {'brow.B.L', 'lip.B.R', 'lip.T.R', 'lip.B.L', 'lip.T.L'}
+        
+        if armature.name.lower() == 'metarig':
+            is_rigify = True
+        
+        if not is_rigify:
+            for bone in armature.data.bones:
+                if bone.name.startswith(('DEF-', 'MCH-', 'ORG-')) or bone.name in rigify_bones:
+                    is_rigify = True
+                    break
+                
+        if is_rigify:
+            Common.show_error(3, ["Rigify and Metarig armatures are not", 
+                                "supported. Please use Rigify to Unity", 
+                                "plugin instead.",
+                                "If you think this is a error, then make sure your",
+                                "bones and amrature do not have metarig", 
+                                "names or Rigify names."])
+            return {'CANCELLED'}
 
         # Check if all meshes are single user
         meshes_to_check = Common.get_meshes_objects()

--- a/tools/armature_custom.py
+++ b/tools/armature_custom.py
@@ -116,12 +116,16 @@ class AttachMesh(bpy.types.Operator):
         return len(Common.get_armature_objects()) > 0 and len(Common.get_meshes_objects(mode=1, check=False)) > 0
 
     def execute(self, context):
+        wm = context.window_manager
+        wm.progress_begin(0, 100)
+
         saved_data = Common.SavedData()
 
         # Set default stage
         Common.set_default_stage()
         Common.remove_rigidbodies_global()
         Common.unselect_all()
+        wm.progress_update(10)
 
         # Get armature and mesh
         mesh_name = bpy.context.scene.attach_mesh
@@ -129,18 +133,22 @@ class AttachMesh(bpy.types.Operator):
         attach_bone_name = bpy.context.scene.attach_to_bone
         mesh = Common.get_objects()[mesh_name]
         armature = Common.get_objects()[base_armature_name]
+        wm.progress_update(20)
 
         # Reparent mesh to target armature
         mesh.parent = armature
         mesh.parent_type = 'OBJECT'
+        wm.progress_update(30)
 
         # Applies transforms of the armature and new mesh
         Common.apply_transforms(armature_name=base_armature_name)
+        wm.progress_update(40)
 
         # Switch mesh to edit mode
         Common.unselect_all()
         Common.set_active(mesh)
         Common.switch('EDIT')
+        wm.progress_update(50)
 
         # Delete all previous vertex groups
         if mesh.vertex_groups:
@@ -148,25 +156,55 @@ class AttachMesh(bpy.types.Operator):
 
         # Select and assign all vertices to new vertex group
         bpy.ops.mesh.select_all(action='SELECT')
-        mesh.vertex_groups.new(name=mesh_name)
+        vg = mesh.vertex_groups.new(name=mesh_name)
         bpy.ops.object.vertex_group_assign()
+        wm.progress_update(60)
 
         Common.switch('OBJECT')
+
+        # Verify that the vertex group has vertices assigned
+        verts_in_group = []
+        for v in mesh.data.vertices:
+            for group in v.groups:
+                if group.group == vg.index:
+                    verts_in_group.append(v)
+                    break
+
+        if not verts_in_group:
+            self.report({'ERROR'}, f"Vertex group '{mesh_name}' is empty or does not exist.")
+            saved_data.load()
+            wm.progress_end()
+            return {'CANCELLED'}
 
         # Switch armature to edit mode
         Common.unselect_all()
         Common.set_active(armature)
         Common.switch('EDIT')
+        wm.progress_update(70)
 
         # Create bone in target armature and reparent it to the target bone
         attach_to_bone = armature.data.edit_bones.get(attach_bone_name)
+        if not attach_to_bone:
+            self.report({'ERROR'}, f"Attach bone '{attach_bone_name}' not found in armature.")
+            saved_data.load()
+            wm.progress_end()
+            return {'CANCELLED'}
         mesh_bone = armature.data.edit_bones.new(mesh_name)
         mesh_bone.parent = attach_to_bone
 
-        # Put new bone in center of mesh
-        mesh_bone.head = Common.find_center_vector_of_vertex_group(mesh, mesh_name)
-        mesh_bone.tail = mesh_bone.head
+        # Compute the center vector
+        center_vector = Common.find_center_vector_of_vertex_group(mesh, mesh_name)
+        if center_vector is None:
+            self.report({'ERROR'}, f"Unable to find center of vertex group '{mesh_name}'.")
+            saved_data.load()
+            wm.progress_end()
+            return {'CANCELLED'}
+
+        # Set bone head and tail positions
+        mesh_bone.head = center_vector
+        mesh_bone.tail = center_vector.copy()
         mesh_bone.tail[2] += 0.1
+        wm.progress_update(80)
 
         # Switch armature back to object mode
         Common.switch('OBJECT')
@@ -179,14 +217,18 @@ class AttachMesh(bpy.types.Operator):
         # Create new armature modifier
         mod = mesh.modifiers.new('Armature', 'ARMATURE')
         mod.object = armature
+        wm.progress_update(90)
 
-        # Put the attach bone field back to it's original state
+        # Restore the attach bone field
         bpy.context.scene.attach_to_bone = attach_bone_name
 
         saved_data.load()
+        wm.progress_update(100)
+        wm.progress_end()
 
         self.report({'INFO'}, t('AttachMesh.success'))
         return {'FINISHED'}
+
 
 @register_wrap
 class CustomModelTutorialButton(bpy.types.Operator):

--- a/tools/common.py
+++ b/tools/common.py
@@ -311,35 +311,35 @@ def remove_unused_vertex_groups(ignore_main_bones=False):
                 remove_count += 1
     return remove_count
 
-
 def find_center_vector_of_vertex_group(mesh, vertex_group):
     data = mesh.data
     verts = data.vertices
     verts_in_group = []
 
+    # Ensure the vertex group exists
+    vg = mesh.vertex_groups.get(vertex_group)
+    if vg is None:
+        return None  # Vertex group doesn't exist
+
     for vert in verts:
         i = vert.index
         try:
-            if mesh.vertex_groups[vertex_group].weight(i) > 0:
+            if vg.weight(i) > 0:
                 verts_in_group.append(vert)
         except RuntimeError:
-            # vertex is not in the group
+            # Vertex is not in the group
             pass
 
-    # Find the average vector point of the vertex cluster
-    divide_by = len(verts_in_group)
+    if not verts_in_group:
+        return None  # No vertices in the group
+
+    # Calculate the average position
     total = Vector()
-
-    if divide_by == 0:
-        return False
-
     for vert in verts_in_group:
         total += vert.co
 
-    average = total / divide_by
-
+    average = total / len(verts_in_group)
     return average
-
 
 def vertex_group_exists(mesh_name, bone_name):
     mesh = get_objects()[mesh_name]


### PR DESCRIPTION
- Cats Fix Model/ Fix MMD Model has never supported metarigs/ rigify, it will break the armature, now due to rigify changes it now causes crashes, therefor we don't allow the operation now. Semi fix for https://github.com/teamneoneko/Cats-Blender-Plugin-Unofficial-/issues/199
- Improvements to attach mesh, should be better and faster, less errors.