### PR TITLE
Prevent locked shape keys from translating

### DIFF
--- a/extentions.py
+++ b/extentions.py
@@ -106,6 +106,12 @@ def register():
         default=False
     )
 
+    Scene.skip_locked_shape_keys = BoolProperty(
+        name=t('Scene.skip_locked_shape_keys.label'),
+        description=t('Scene.skip_locked_shape_keys.desc'),
+        default=False
+    )
+
     Scene.keep_merged_bones = BoolProperty(
         name=t('keep_merged_bones'),
         description=t('select_this_to_keep_the_bones_after_merging_them_to_their_parents_or_to_the_active_bone'),

--- a/resources/translations.csv
+++ b/resources/translations.csv
@@ -874,6 +874,8 @@ They are completely useless for VRChat, so removing them is recommended for VRCh
 VRChat에 사용되지않으므로 VRChat 유저들에게는 이것들을 지우는 게 좋습니다!"
 Scene.use_google_only.label,Use Old Translations (not recommended),古い翻訳を使用する(推奨しません),구버전 번역을 사용 (권장되지 않음)
 Scene.use_google_only.desc,"Ignores the internal dictionary and only uses the Google Translator for shape key translations.
+Scene.skip_locked_shape_keys.label,Skip Locked Shape Keys
+Scene.skip_locked_shape_keys.desc,When checked, skips translating locked shape keys. To lock or unlock a shape key, click the lock icon next to it, or click and drag over multiple lock icons to lock or unlock multiple ones.
 
 This will result in slower translation speed and worse translations, but the translations will be like in CATS version 0.9.0 and older.
 Only use this if you have animations which rely on the old translations and you don't want to convert them to the new ones",,"내장된 사전 대신에 구글 번역기를 쉐이프키 번역에 사용합니다.

--- a/resources/translations/en_US.json
+++ b/resources/translations/en_US.json
@@ -597,6 +597,8 @@
         "Scene.remove_rigidbodies_joints.desc": "Rigidbodies and joints are used by MMD software to simulate physics.\nThey are completely useless for VRChat, so removing them is recommended for VRChat users!",
         "Scene.use_google_only.label": "Use Old Translations (not recommended)",
         "Scene.use_google_only.desc": "Ignores the internal dictionary and only uses the Google Translator for shape key translations.\n\nThis will result in slower translation speed and worse translations, but the translations will be like in CATS version 0.9.0 and older.\nOnly use this if you have animations which rely on the old translations and you don't want to convert them to the new ones",
+        "Scene.skip_locked_shape_keys.label": "Skip Locked Shape Keys",
+        "Scene.skip_locked_shape_keys.desc": "When checked, skips translating locked shape keys. To lock or unlock a shape key, click the lock icon next to it, or click and drag over multiple lock icons to lock or unlock multiple ones.",
         "Scene.show_more_options.label": "Show More Options",
         "Scene.show_more_options.desc": "Shows more model options",
         "Scene.merge_mode.label": "Merge Mode",

--- a/tools/translate.py
+++ b/tools/translate.py
@@ -127,7 +127,7 @@ class TranslateShapekeyButton(bpy.types.Operator):
             for mesh in Common.get_meshes_objects(mode=2):
                 if Common.has_shapekeys(mesh):
                     for shapekey in mesh.data.shape_keys.key_blocks:
-                        if 'vrc.' not in shapekey.name:
+                        if not shapekey.lock_shape and 'vrc.' not in shapekey.name:
                             shapekey.name, translated = translate(shapekey.name, add_space=True, translating_shapes=True)
                             if translated:
                                 i += 1

--- a/ui/otheroptions.py
+++ b/ui/otheroptions.py
@@ -41,6 +41,10 @@ class OtherOptionsPanel(ToolPanel, bpy.types.Panel):
         row.scale_y = button_height
         row.prop(context.scene, 'use_google_only')
 
+        row = col.row(align=True)
+        row.scale_y = button_height
+        row.prop(context.scene, 'skip_locked_shape_keys')
+
         split = layout_split(col, factor=0.27, align=True)
 
         row = split.row(align=True)


### PR DESCRIPTION
Locking shape keys should prevent them from being translated. This is useful for mmd shape keys and the likes.