### PR TITLE
Fix too FIx MMD Model crashing blender

### DIFF
--- a/tools/armature.py
+++ b/tools/armature.py
@@ -40,6 +40,34 @@ class FixArmature(bpy.types.Operator):
         saved_data = Common.SavedData()
         armature = Common.get_armature()
         
+        # Store and remove bone collections to prevent crashes
+        bone_collections_backup = []
+        # Check if this is an MMD model
+        mmd_root = None
+        try:
+            mmd_root = armature.parent.mmd_root
+        except AttributeError:
+            pass
+                
+        if mmd_root:
+            # This is an MMD model, back up and remove bone collections
+            for collection in list(armature.data.collections):
+                # Store collection data
+                collection_data = {
+                    'name': collection.name,
+                    'is_visible': collection.is_visible,
+                    'bones': []
+                }
+                
+                # Store bones in edit mode
+                Common.switch('EDIT')
+                for bone in collection.bones:
+                    collection_data['bones'].append(bone.name)
+                
+                bone_collections_backup.append(collection_data)
+                # Remove the collection
+                armature.data.collections.remove(collection)
+        
         # Check for Rigify/Metarig
         is_rigify = False
         rigify_bones = {'brow.B.L', 'lip.B.R', 'lip.T.R', 'lip.B.L', 'lip.T.L'}
@@ -67,9 +95,9 @@ class FixArmature(bpy.types.Operator):
         for mesh in meshes_to_check:
             if mesh.data.users > 1:
                 Common.show_error(4, [t('JoinMeshes.error.not_single_user'),
-                                      t('JoinMeshes.error.make_single_user'),
-                                      t('JoinMeshes.error.make_single_user1'),
-                                      t('JoinMeshes.error.make_single_user2')])
+                                    t('JoinMeshes.error.make_single_user'),
+                                    t('JoinMeshes.error.make_single_user1'),
+                                    t('JoinMeshes.error.make_single_user2')])
                 return {'CANCELLED'}
 
         is_vrm = False
@@ -98,12 +126,12 @@ class FixArmature(bpy.types.Operator):
         for key, value in temp_rename_bones.items():
             if key == 'Spine':
                 continue
-            list = temp_reweight_bones.get(key)
-            if not list:
+            bone_list = temp_reweight_bones.get(key) 
+            if not bone_list:
                 temp_reweight_bones[key] = value
             else:
                 for name in value:
-                    if name not in list:
+                    if name not in bone_list:
                         temp_reweight_bones.get(key).append(name)
 
         # Count objects for loading bar
@@ -123,19 +151,19 @@ class FixArmature(bpy.types.Operator):
         # Get Double Entries
         print('DOUBLE ENTRIES:')
         print('RENAME:')
-        list = []
+        name_list = []  
         for key, value in temp_rename_bones.items():
             for name in value:
-                if name.lower() not in list:
-                    list.append(name.lower())
+                if name.lower() not in name_list:
+                    name_list.append(name.lower())
                 else:
                     print(key + " | " + name)
         print('REWEIGHT:')
-        list = []
+        name_list = [] 
         for key, value in temp_reweight_bones.items():
             for name in value:
-                if name.lower() not in list:
-                    list.append(name.lower())
+                if name.lower() not in name_list:
+                    name_list.append(name.lower())
                 else:
                     print(key + " | " + name)
         print('DOUBLES END')
@@ -372,7 +400,7 @@ class FixArmature(bpy.types.Operator):
 
                 Common.sort_shape_keys(mesh.name, shapekey_order)        
 
-			# Remove empty shape keys and then save the shape key order
+            # Remove empty shape keys and then save the shape key order
             Common.clean_shapekeys(mesh)
             Common.save_shapekey_order(mesh.name)
 
@@ -441,17 +469,16 @@ class FixArmature(bpy.types.Operator):
 
         # Count steps for loading bar again and reset the layers
         steps += len(armature.data.edit_bones)
-        if Common.version_3_6_or_older:
-            def set_bone_visible(edit_bone):
-                edit_bone.layers[0] = True
+        
+        # Handle bone visibility based on Blender version
+        if Common.version_3_6_or_older():
+            # For Blender 3.6 or older, use bone layers
+            for bone in armature.data.edit_bones:
+                bone.layers[0] = True
         else:
-            # Armature/Bone layers were replaced with Bone Collections in Blender 4.0.
+            # For Blender 4.0+, use bone collections
             bone_collections = armature.data.collections
-            if not bone_collections:
-                # All bones are visible when there are no bone collections, so nothing to do.
-                def set_bone_visible(_edit_bone):
-                    pass
-            else:
+            if bone_collections:
                 # The default collection on new Armatures is called "Bones" and usually has all bones assigned to it.
                 default_collection_name = "Bones"
                 bone_collection = bone_collections.get(default_collection_name)
@@ -460,18 +487,17 @@ class FixArmature(bpy.types.Operator):
                     bone_collection = bone_collections.new(default_collection_name)
                 # Ensure the collection is visible.
                 bone_collection.is_visible = True
-
-                def set_bone_visible(edit_bone):
-                    bone_collection.assign(edit_bone)
+                
+                # Assign all bones to the default collection
+                for bone in armature.data.edit_bones:
+                    bone_collection.assign(bone)
+        
         for bone in armature.data.edit_bones:
             if bone.name in Bones.bone_list or bone.name.startswith(tuple(Bones.bone_list_with)):
                 if bone.parent is not None:
                     steps += 1
                 else:
                     steps -= 1
-        if version_3_6_or_older():
-            bone.layers[0] = True
-            
 
         # Start loading bar
         current_step = 0
@@ -650,7 +676,7 @@ class FixArmature(bpy.types.Operator):
         for bone_new, bones_old in temp_rename_bones.items():
             if "\\L" in bone_new:
                 bones = [[bone_new.replace("\\Left", "Left").replace("\\L", "L"), ""],
-                         [bone_new.replace("\\Left", "Right").replace("\\L", "R"), ""]]
+                        [bone_new.replace("\\Left", "Right").replace("\\L", "R"), ""]]
             else:
                 bones = [[bone_new, ""]]
             for bone_old in bones_old:
@@ -1204,7 +1230,6 @@ class FixArmature(bpy.types.Operator):
         Common.fix_armature_names()
         
         fixed_uv_coords = False
-
         armature.show_in_front = False
         wm.progress_end()
 

--- a/tools/common.py
+++ b/tools/common.py
@@ -127,8 +127,6 @@ def get_armature(armature_name=None):
         for obj in objects:
             if obj and obj.type == 'ARMATURE':
                 return obj
-                
-    return None
 
 def get_armature_objects():
     armatures = []
@@ -857,34 +855,44 @@ def separate_by_loose_parts(context, mesh):
     # This essentially does nothing but merges the extremely small parts together.
     remove_doubles(mesh, 0, save_shapes=True)
 
-    # Switch to edit mode and select all vertices
-    set_active(mesh)
-    switch('EDIT')
-    bpy.ops.mesh.select_all(action='SELECT')
-
-    # Separate by loose parts using Blender's built-in operator
-    bpy.ops.mesh.separate(type='LOOSE')
+    utils.separateByMaterials(mesh)
 
     meshes = []
-    for obj in context.selected_objects:
-        if obj.type == 'MESH':
-            hide(obj, False)
-            meshes.append(obj)
+    for ob in context.selected_objects:
+        if ob.type == 'MESH':
+            hide(ob, False)
+            meshes.append(ob)
 
     wm = bpy.context.window_manager
     current_step = 0
     wm.progress_begin(current_step, len(meshes))
 
     for mesh in meshes:
-        clean_shapekeys(mesh)
+        unselect_all()
+        set_active(mesh)
+        bpy.ops.mesh.separate(type='LOOSE')
+
+        meshes2 = []
+        for ob in context.selected_objects:
+            if ob.type == 'MESH':
+                meshes2.append(ob)
+
+        ## This crashes blender, but would be better
+        # unselect_all()
+        # for mesh2 in meshes2:
+        #     if len(mesh2.data.vertices) <= 3:
+        #         select(mesh2)
+        #     elif bpy.ops.object.join.poll():
+        #         bpy.ops.object.join()
+        #         unselect_all()
+
+        for mesh2 in meshes2:
+            clean_shapekeys(mesh2)
 
         current_step += 1
         wm.progress_update(current_step)
 
     wm.progress_end()
-
-    # Switch back to object mode
-    switch('OBJECT')
 
     utils.clearUnusedMeshes()
 
@@ -1244,6 +1252,7 @@ def delete_zero_weight(armature_name=None, ignore=''):
         if keep_twists and ("_twist" in bone_name.lower() or "Twist" in bone_name):
             continue
 
+
         if keep_empty_parents:
             found_non_empty_child = False
             if bone:
@@ -1253,7 +1262,7 @@ def delete_zero_weight(armature_name=None, ignore=''):
                         break
             if found_non_empty_child:
                 continue
-
+        
         if not bpy.context.scene.keep_end_bones or not is_end_bone(bone_name, armature_name):
             if bone_name not in Bones.dont_delete_these_bones and 'Root_' not in bone_name and bone_name != ignore:
                 armature.data.edit_bones.remove(bone)  # delete bone

--- a/tools/common.py
+++ b/tools/common.py
@@ -127,6 +127,8 @@ def get_armature(armature_name=None):
         for obj in objects:
             if obj and obj.type == 'ARMATURE':
                 return obj
+                
+    return None
 
 def get_armature_objects():
     armatures = []
@@ -855,44 +857,34 @@ def separate_by_loose_parts(context, mesh):
     # This essentially does nothing but merges the extremely small parts together.
     remove_doubles(mesh, 0, save_shapes=True)
 
-    utils.separateByMaterials(mesh)
+    # Switch to edit mode and select all vertices
+    set_active(mesh)
+    switch('EDIT')
+    bpy.ops.mesh.select_all(action='SELECT')
+
+    # Separate by loose parts using Blender's built-in operator
+    bpy.ops.mesh.separate(type='LOOSE')
 
     meshes = []
-    for ob in context.selected_objects:
-        if ob.type == 'MESH':
-            hide(ob, False)
-            meshes.append(ob)
+    for obj in context.selected_objects:
+        if obj.type == 'MESH':
+            hide(obj, False)
+            meshes.append(obj)
 
     wm = bpy.context.window_manager
     current_step = 0
     wm.progress_begin(current_step, len(meshes))
 
     for mesh in meshes:
-        unselect_all()
-        set_active(mesh)
-        bpy.ops.mesh.separate(type='LOOSE')
-
-        meshes2 = []
-        for ob in context.selected_objects:
-            if ob.type == 'MESH':
-                meshes2.append(ob)
-
-        ## This crashes blender, but would be better
-        # unselect_all()
-        # for mesh2 in meshes2:
-        #     if len(mesh2.data.vertices) <= 3:
-        #         select(mesh2)
-        #     elif bpy.ops.object.join.poll():
-        #         bpy.ops.object.join()
-        #         unselect_all()
-
-        for mesh2 in meshes2:
-            clean_shapekeys(mesh2)
+        clean_shapekeys(mesh)
 
         current_step += 1
         wm.progress_update(current_step)
 
     wm.progress_end()
+
+    # Switch back to object mode
+    switch('OBJECT')
 
     utils.clearUnusedMeshes()
 
@@ -1252,7 +1244,6 @@ def delete_zero_weight(armature_name=None, ignore=''):
         if keep_twists and ("_twist" in bone_name.lower() or "Twist" in bone_name):
             continue
 
-
         if keep_empty_parents:
             found_non_empty_child = False
             if bone:
@@ -1262,7 +1253,7 @@ def delete_zero_weight(armature_name=None, ignore=''):
                         break
             if found_non_empty_child:
                 continue
-        
+
         if not bpy.context.scene.keep_end_bones or not is_end_bone(bone_name, armature_name):
             if bone_name not in Bones.dont_delete_these_bones and 'Root_' not in bone_name and bone_name != ignore:
                 armature.data.edit_bones.remove(bone)  # delete bone

--- a/tools/importer.py
+++ b/tools/importer.py
@@ -433,7 +433,7 @@ class ImportMMD(bpy.types.Operator):
         try:
             bpy.ops.mmd_tools_local.import_model('INVOKE_DEFAULT',
                                            scale=0.08,
-                                           types={'MESH', 'ARMATURE', 'MORPHS'},
+                                           types={'MESH', 'ARMATURE', 'MORPHS', 'DISPLAY'},
                                            log_level='WARNING')
         except AttributeError:
             bpy.ops.cats_importer.enable_mmd('INVOKE_DEFAULT')

--- a/tools/translations.py
+++ b/tools/translations.py
@@ -24,7 +24,7 @@ translations_dir = os.path.join(resources_dir, "translations")
 dictionary: dict[str, str] = dict()
 languages = []
 verbose = True
-dictionary_download_link = "https://github.com/teamneoneko/Cats-Blender-Plugin-Unofficial-translations/blob/4.2-translations/dictionary.json"
+dictionary_download_link = "https://github.com/teamneoneko/Cats-Blender-Plugin-Unofficial-translations/blob/4.3-translations/dictionary.json"
 
 def load_translations():
     global dictionary, languages
@@ -139,7 +139,7 @@ class DownloadTranslations(bpy.types.Operator):
         # GitHub repository and folder information
         repo_owner = "teamneoneko"
         repo_name = "Cats-Blender-Plugin-Unofficial-translations"
-        branch = "4.2-translations"
+        branch = "4.3-translations"
         folder_path = "UI%20Tanslations"
 
         # Construct the API URL to get the list of files in the folder

--- a/tools/translations.py
+++ b/tools/translations.py
@@ -24,7 +24,7 @@ translations_dir = os.path.join(resources_dir, "translations")
 dictionary: dict[str, str] = dict()
 languages = []
 verbose = True
-dictionary_download_link = "https://github.com/teamneoneko/Cats-Blender-Plugin-Unofficial-translations/blob/4.3-translations/dictionary.json"
+dictionary_download_link = "https://github.com/teamneoneko/Cats-Blender-Plugin-Unofficial-translations/blob/4.2-translations/dictionary.json"
 
 def load_translations():
     global dictionary, languages
@@ -139,7 +139,7 @@ class DownloadTranslations(bpy.types.Operator):
         # GitHub repository and folder information
         repo_owner = "teamneoneko"
         repo_name = "Cats-Blender-Plugin-Unofficial-translations"
-        branch = "4.3-translations"
+        branch = "4.2-translations"
         folder_path = "UI%20Tanslations"
 
         # Construct the API URL to get the list of files in the folder


### PR DESCRIPTION
- This fixes Fix MMD Model crashing blender.
- Store collections in a temp state then removes them after.
- Also added DISPLAY argument to MMD Importer so it imports the collections.

Note my auto system brought over other changes that do not belong in the 4.3 branch, i reverted them afterwards.

Fixes: https://github.com/teamneoneko/Cats-Blender-Plugin-Unofficial-/issues/317