### PR TITLE
Fix: Armature merge respects Apply Transforms checkbox

### DIFF
--- a/resources/translations/en_US.json
+++ b/resources/translations/en_US.json
@@ -837,6 +837,6 @@
         "EyeTrackingPanel.troubleshooting.shapeKeys": "• Check shape keys are named correctly", 
         "EyeTrackingPanel.troubleshooting.boneWeights": "• Ensure eye bones are properly weighted",
         "EyeTrackingPanel.troubleshooting.restPosition": "• Confirm armature is in rest position",
-        "merge_armatures.error.mustapplytransforms": "Your armature has different scale values for X, Y, and Z axes, rather\nthan having uniform scaling (where all axes have the same scale value)\n\nThis is important to fix before merging armatures to ensure proper bone\ntransformations and avoid potential deformation issues.\n\nIf you want to continue with this merge even with this warning please\nmake sure apply transforms is checked before you start merging."
+        "merge_armatures.error.mustapplytransforms": "Transform Issue Detected!\n\nYour armatures have non-uniform scaling or rotations that need to be fixed before merging.\nThis is important to prevent size changes and deformation issues.\n\nTo fix this:\n1. Enable the 'Apply Transforms' checkbox in the merge settings\n2. Try the merge again\n\nThe 'Apply Transforms' option will normalize all scale, rotation, and position values\nso your armatures merge correctly without changing size.\n\nIf you've already checked 'Apply Transforms' and still see this error,\nplease report this as a bug."
     }
 }

--- a/tools/armature_custom.py
+++ b/tools/armature_custom.py
@@ -463,8 +463,10 @@ def merge_armatures(
                 return
             Common.apply_transforms(armature_name=merge_armature_name)
         else:
-            adjust_merge_armature_transforms(merge_armature, mesh_merge)
-            Common.apply_transforms(armature_name=merge_armature_name)
+            # Only adjust and apply transforms if the checkbox is enabled
+            if bpy.context.scene.apply_transforms:
+                adjust_merge_armature_transforms(merge_armature, mesh_merge)
+                Common.apply_transforms(armature_name=merge_armature_name)
     elif bpy.context.scene.apply_transforms:
         Common.apply_transforms(armature_name=merge_armature_name)
 

--- a/tools/common.py
+++ b/tools/common.py
@@ -842,6 +842,14 @@ def apply_transforms(armature_name=None):
         bpy.ops.object.transform_apply(location=True, rotation=True, scale=True)
 
 
+def apply_transforms_to_mesh(mesh):
+    """Apply transforms to a single mesh object."""
+    unselect_all()
+    set_active(mesh)
+    switch('OBJECT')
+    bpy.ops.object.transform_apply(location=True, rotation=True, scale=True)
+
+
 def apply_all_transforms():
 
     def apply_transforms_with_children(parent):


### PR DESCRIPTION
- Added missing apply_transforms_to_mesh() function
- Fixed transforms being applied even when checkbox was disabled
- Improved error message clarity for transform issues

Fixes issue where merging armatures would unexpectedly change model size even with Apply Transforms unchecked.