### PR TITLE
Cats 4.5.2.1 (Blender 4.5 LTS) Finale Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ readme.md
 readme
 readme.txt
 README.text
+crashlog.txt

--- a/extern_tools/mmd_tools_local/__init__.py
+++ b/extern_tools/mmd_tools_local/__init__.py
@@ -19,8 +19,8 @@
 bl_info = {
     "name": "mmd_tools_local",
     "author": "sugiany",
-    "version": (4, 3, 6),
-    "blender": (4, 2, 5),
+    "version": (4, 5, 2),
+    "blender": (4, 5, 2),
     "location": "View3D > Sidebar > MMD Panel",
     "description": "Utility tools for MMD model editing. (UuuNyaa's forked version)",
     "warning": "",

--- a/extern_tools/mmd_tools_local/auto_scene_setup.py
+++ b/extern_tools/mmd_tools_local/auto_scene_setup.py
@@ -5,22 +5,32 @@ import bpy
 
 
 def setupFrameRanges():
-    s, e = 1, 1
-    for i in bpy.data.actions:
-        ts, te = i.frame_range
-        s = min(s, ts)
-        e = max(e, te)
-    bpy.context.scene.frame_start = int(s)
-    bpy.context.scene.frame_end = int(e)
+    base = min(bpy.context.scene.frame_current, bpy.context.scene.frame_start)
+    s = base
+    e = base
+
+    for action in bpy.data.actions:
+        # Skip orphaned actions
+        if action.users == 0:
+            continue
+
+        # When create_new_action=False, multiple VMDs share the same action
+        # Need to toggle use_frame_range to access frame ranges from both VMDs:
+        # use_frame_range = True: gets range from the first imported VMD
+        # use_frame_range = False: gets range from the newly imported VMD
+        # By toggling twice, we ensure both ranges are captured regardless of initial state
+        ts, te = action.frame_range
+        s, e = min(s, ts), max(e, te)
+        action.use_frame_range = not action.use_frame_range  # Toggle to access the other VMD's range
+        ts, te = action.frame_range
+        s, e = min(s, ts), max(e, te)
+        action.use_frame_range = not action.use_frame_range  # Restore to original state
+
+    bpy.context.scene.frame_start = round(s)
+    bpy.context.scene.frame_end = round(e)
     if bpy.context.scene.rigidbody_world is not None:
-        bpy.context.scene.rigidbody_world.point_cache.frame_start = int(s)
-        bpy.context.scene.rigidbody_world.point_cache.frame_end = int(e)
-
-
-def setupLighting():
-    bpy.context.scene.world.light_settings.use_ambient_occlusion = True
-    bpy.context.scene.world.light_settings.use_environment_light = True
-    bpy.context.scene.world.light_settings.use_indirect_light = True
+        bpy.context.scene.rigidbody_world.point_cache.frame_start = round(s)
+        bpy.context.scene.rigidbody_world.point_cache.frame_end = round(e)
 
 
 def setupFps():

--- a/extern_tools/mmd_tools_local/bpyutils.py
+++ b/extern_tools/mmd_tools_local/bpyutils.py
@@ -2,9 +2,12 @@
 # This file is part of MMD Tools.
 
 import contextlib
+import math
 from typing import Generator, List, Optional, TypeVar
 
+import bmesh
 import bpy
+from mathutils import Matrix
 
 
 class Props:  # For API changes of only name changed properties
@@ -29,7 +32,7 @@ class __EditMode:
     def __enter__(self):
         return self.__obj.data
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, exc_type, exc_value, traceback):
         if self.__prevMode == "EDIT":
             bpy.ops.object.mode_set(mode="OBJECT")  # update edited data
         bpy.ops.object.mode_set(mode=self.__prevMode)
@@ -51,7 +54,7 @@ class __SelectObjects:
             i.select_set(False)
 
         self.__active_object = active_object
-        self.__selected_objects = tuple(set(selected_objects) | set([active_object])) if selected_objects else (active_object,)
+        self.__selected_objects = tuple(set(selected_objects) | {active_object}) if selected_objects else (active_object,)
 
         self.__hides: List[bool] = []
         for i in self.__selected_objects:
@@ -62,8 +65,8 @@ class __SelectObjects:
     def __enter__(self) -> bpy.types.Object:
         return self.__active_object
 
-    def __exit__(self, type, value, traceback):
-        for i, j in zip(self.__selected_objects, self.__hides):
+    def __exit__(self, exc_type, exc_value, traceback):
+        for i, j in zip(self.__selected_objects, self.__hides, strict=False):
             try:
                 i.hide_set(j)
             except ReferenceError:
@@ -104,7 +107,10 @@ def select_object(obj: bpy.types.Object, objects: Optional[List[bpy.types.Object
        with select_object(obj):
            some functions...
     """
-    # TODO: Reimplement with bpy.context.temp_override (If it ain't broke, don't fix it.)
+    # TODO: Consider reimplementing with bpy.context.temp_override,
+    #       but note that Blender's new API has stability issues.
+    #       temp_override is prone to crashes, making the current approach safer.
+    #       If it ain't broke, don't fix it.
     return __SelectObjects(obj, objects)
 
 
@@ -118,10 +124,9 @@ def createObject(name="Object", object_data=None, target_scene=None):
 
 
 def makeSphere(segment=8, ring_count=5, radius=1.0, target_object=None):
-    import bmesh
-
     if target_object is None:
-        target_object = createObject(name="Sphere")
+        mesh_data = bpy.data.meshes.new("Sphere")
+        target_object = createObject(name="Sphere", object_data=mesh_data)
 
     mesh = target_object.data
     bm = bmesh.new()
@@ -139,11 +144,9 @@ def makeSphere(segment=8, ring_count=5, radius=1.0, target_object=None):
 
 
 def makeBox(size=(1, 1, 1), target_object=None):
-    import bmesh
-    from mathutils import Matrix
-
     if target_object is None:
-        target_object = createObject(name="Box")
+        mesh_data = bpy.data.meshes.new("Box")
+        target_object = createObject(name="Box", object_data=mesh_data)
 
     mesh = target_object.data
     bm = bmesh.new()
@@ -160,12 +163,9 @@ def makeBox(size=(1, 1, 1), target_object=None):
 
 
 def makeCapsule(segment=8, ring_count=2, radius=1.0, height=1.0, target_object=None):
-    import math
-
-    import bmesh
-
     if target_object is None:
-        target_object = createObject(name="Capsule")
+        mesh_data = bpy.data.meshes.new("Capsule")
+        target_object = createObject(name="Capsule", object_data=mesh_data)
     height = max(height, 1e-3)
 
     mesh = target_object.data
@@ -174,8 +174,11 @@ def makeCapsule(segment=8, ring_count=2, radius=1.0, height=1.0, target_object=N
     top = (0, 0, height / 2 + radius)
     verts.new(top)
 
-    # f = lambda i: radius*i/ring_count
-    f = lambda i: radius * math.sin(0.5 * math.pi * i / ring_count)
+    # def f(i):
+    #     return radius * i / ring_count
+    def f(i):
+        return radius * math.sin(0.5 * math.pi * i / ring_count)
+
     for i in range(ring_count, 0, -1):
         z = f(i - 1)
         t = math.sqrt(radius**2 - z**2)
@@ -317,7 +320,7 @@ class FnContext:
     def get_active_object(context: bpy.types.Context) -> Optional[bpy.types.Object]:
         # Added defensive programming for get methods
         # Related to: https://github.com/MMD-Blender/blender_mmd_tools_local/issues/176
-        if context is None or not hasattr(context, 'active_object'):
+        if context is None or not hasattr(context, "active_object"):
             return None
         return context.active_object
 
@@ -334,7 +337,7 @@ class FnContext:
     def get_scene_objects(context: bpy.types.Context) -> bpy.types.SceneObjects:
         # Added defensive programming for get methods
         # Added for consistency with get_active_object
-        if context is None or not hasattr(context, 'scene') or not hasattr(context.scene, 'objects'):
+        if context is None or not hasattr(context, "scene") or not hasattr(context.scene, "objects"):
             return []
         return context.scene.objects
 
@@ -434,7 +437,7 @@ class FnContext:
     @staticmethod
     def find_user_layer_collection_by_object(context: bpy.types.Context, target_object: bpy.types.Object) -> Optional[bpy.types.LayerCollection]:
         """
-        Finds the layer collection that contains the given target_object in the user's collections.
+        Find the layer collection that contains the given target_object in the user's collections.
 
         Args:
             context (bpy.types.Context): The Blender context.

--- a/extern_tools/mmd_tools_local/compat/__init__.py
+++ b/extern_tools/mmd_tools_local/compat/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.

--- a/extern_tools/mmd_tools_local/compat/action_compat.py
+++ b/extern_tools/mmd_tools_local/compat/action_compat.py
@@ -1,0 +1,385 @@
+# Copyright 2025 MMD Tools authors
+# This file is part of MMD Tools.
+
+"""
+Simplest compatibility layer for Action.
+
+Only the first channelbag of ActionChannelbag is used,
+preserving the behavior of the previous version.
+Although ActionChannelbag was introduced in Blender 4.4,
+since MMD Tools works well in 4.2–4.5, use it only in Blender 5.0+.
+"""
+
+import bpy
+
+IS_BLENDER_50_UP = bpy.app.version >= (5, 0)
+
+if IS_BLENDER_50_UP:
+    FCurvesCollection = bpy.types.ActionChannelbagFCurves
+else:
+    FCurvesCollection = bpy.types.ActionFCurves
+
+
+class ActionGroupsCompatibility:
+    """Compatibility layer: Makes Action.groups work in Blender 5.0+"""
+
+    def __init__(self, action: bpy.types.Action):
+        self._action = action
+
+    def _get_channelbag(self):
+        """Get the first channelbag"""
+        if not hasattr(self._action, "layers"):
+            return None
+
+        if len(self._action.layers) == 0:
+            return None
+
+        layer = self._action.layers[0]
+        if not hasattr(layer, "strips") or len(layer.strips) == 0:
+            return None
+
+        strip = layer.strips[0]
+        if not hasattr(strip, "channelbags"):
+            return None
+
+        channelbags = strip.channelbags
+        if len(channelbags) == 0:
+            return None
+
+        return channelbags[0]
+
+    def new(self, name: str):
+        """Create a new action group"""
+        channelbag = self._get_channelbag()
+        if channelbag is None:
+            # Need to create channelbag structure first
+            # Use ActionFCurvesCompatibility logic here
+            fcurves_compat = ActionFCurvesCompatibility(self._action)
+            channelbag = fcurves_compat._get_channelbag(ensure=True)
+            if channelbag is None:
+                raise RuntimeError("Cannot create action group: failed to get or create channelbag")
+
+        return channelbag.groups.new(name)
+
+    def remove(self, action_group):
+        """Remove action group"""
+        channelbag = self._get_channelbag()
+        if channelbag is not None:
+            channelbag.groups.remove(action_group)
+
+    def __iter__(self):
+        """Iterate all groups"""
+        channelbag = self._get_channelbag()
+        if channelbag is not None:
+            return iter(channelbag.groups)
+        return iter([])
+
+    def __len__(self):
+        """Get the number of groups"""
+        channelbag = self._get_channelbag()
+        if channelbag is not None:
+            return len(channelbag.groups)
+        return 0
+
+    def __getitem__(self, key):
+        """Access group by index or name"""
+        channelbag = self._get_channelbag()
+        if channelbag is not None:
+            return channelbag.groups[key]
+        raise IndexError("No channelbag available")
+
+    def __bool__(self):
+        """Check if there are groups"""
+        return len(self) > 0
+
+
+class ActionFCurvesCompatibility:
+    """Compatibility layer: Makes Action.fcurves work in Blender 5.0+"""
+
+    def __init__(self, action: bpy.types.Action):
+        self._action = action
+
+    def _ensure_layer_and_strip(self):
+        """Ensure Action has at least one layer and strip"""
+        action = self._action
+
+        # Ensure there is a layer
+        if not hasattr(action, "layers") or len(action.layers) == 0:
+            if hasattr(action, "layers") and hasattr(action.layers, "new"):
+                layer = action.layers.new(name="Layer")
+            else:
+                return None, None
+        else:
+            layer = action.layers[0]
+
+        # Ensure there is a strip
+        if not hasattr(layer, "strips") or len(layer.strips) == 0:
+            if hasattr(layer, "strips") and hasattr(layer.strips, "new"):
+                strip = layer.strips.new(type="KEYFRAME")
+            else:
+                return layer, None
+        else:
+            strip = layer.strips[0]
+
+        return layer, strip
+
+    def _ensure_slot(self, id_type: str = "OBJECT"):
+        """Ensure Action has at least one slot"""
+        action = self._action
+
+        if not hasattr(action, "slots") or len(action.slots) == 0:
+            if hasattr(action, "slots") and hasattr(action.slots, "new"):
+                # Create a default slot
+                slot_name = action.name if action.name else "Slot"
+                return action.slots.new(name=slot_name, id_type=id_type)
+            return None
+        return action.slots[0]
+
+    def _get_channelbag(self, ensure=False, id_type: str = "OBJECT"):
+        """Get the first channelbag"""
+        if not hasattr(self._action, "layers"):
+            return None
+
+        if ensure:
+            layer, strip = self._ensure_layer_and_strip()
+        else:
+            if len(self._action.layers) == 0:
+                return None
+            layer = self._action.layers[0]
+            if not hasattr(layer, "strips") or len(layer.strips) == 0:
+                return None
+            strip = layer.strips[0]
+
+        if layer is None or strip is None:
+            return None
+
+        # Get or create channelbag
+        if not hasattr(strip, "channelbags"):
+            return None
+
+        channelbags = strip.channelbags
+        if len(channelbags) == 0:
+            if ensure:
+                # Ensure there is a slot
+                slot = self._ensure_slot(id_type=id_type)
+                if slot is None:
+                    return None
+                return channelbags.new(slot)
+            return None
+
+        return channelbags[0]
+
+    def new(self, data_path: str, index: int = 0, group_name: str = "", action_group: str = "", id_type: str = "OBJECT"):
+        """Create a new F-Curve (returns existing one if already exists)
+
+        Note: For compatibility with legacy code, when an F-Curve already exists,
+        this method returns the existing F-Curve instead of throwing an error.
+        This differs from the native behavior in Blender 5.0+, but matches the
+        expectations of the old version.
+
+        Args:
+            data_path: Data path for the F-Curve
+            index: Array index
+            group_name: Group name (used in Blender 5.0+)
+            action_group: Action group (legacy compatibility parameter, converts to group_name)
+            id_type: The ID type for the action slot, e.g. "OBJECT" or "KEY".
+        """
+        channelbag = self._get_channelbag(ensure=True, id_type=id_type)
+        if channelbag is None:
+            raise RuntimeError("Cannot create F-Curve: failed to get or create channelbag")
+
+        # Legacy compatibility: If action_group is provided, use it as group_name
+        if action_group and not group_name:
+            group_name = action_group
+
+        # Check if it already exists first (legacy version behavior)
+        existing = channelbag.fcurves.find(data_path, index=index)
+        if existing is not None:
+            # If group_name is specified, try to update the group
+            if group_name and hasattr(existing, "group"):
+                # Could try to set the group here, but may need additional logic
+                pass
+            return existing
+
+        # Create new if it doesn't exist
+        try:
+            return channelbag.fcurves.new(data_path, index=index, group_name=group_name)
+        except RuntimeError as e:
+            # If it still reports that it already exists, try to find and return it again
+            if "already exists" in str(e):
+                existing = channelbag.fcurves.find(data_path, index=index)
+                if existing is not None:
+                    return existing
+            raise
+
+    def ensure(self, data_path: str, index: int = 0, group_name: str = "", action_group: str = "", id_type: str = "OBJECT"):
+        """Ensure F-Curve exists
+
+        Args:
+            data_path: Data path for the F-Curve
+            index: Array index
+            group_name: Group name (used in Blender 5.0+)
+            action_group: Action group (legacy compatibility parameter, converts to group_name)
+            id_type: The ID type for the action slot, e.g. "OBJECT" or "KEY".
+        """
+        channelbag = self._get_channelbag(ensure=True, id_type=id_type)
+        if channelbag is None:
+            raise RuntimeError("Cannot ensure F-Curve: failed to get or create channelbag")
+
+        # Legacy compatibility: If action_group is provided, use it as group_name
+        if action_group and not group_name:
+            group_name = action_group
+
+        return channelbag.fcurves.ensure(data_path, index=index, group_name=group_name)
+
+    def find(self, data_path: str, index: int = 0):
+        """Find F-Curve"""
+        channelbag = self._get_channelbag(ensure=False)
+        if channelbag is None:
+            return None
+        return channelbag.fcurves.find(data_path, index=index)
+
+    def remove(self, fcurve):
+        """Remove F-Curve"""
+        channelbag = self._get_channelbag(ensure=False)
+        if channelbag is not None:
+            channelbag.fcurves.remove(fcurve)
+
+    def clear(self):
+        """Clear all F-Curves"""
+        channelbag = self._get_channelbag(ensure=False)
+        if channelbag is not None:
+            channelbag.fcurves.clear()
+
+    def __iter__(self):
+        """Iterate all F-Curves"""
+        channelbag = self._get_channelbag(ensure=False)
+        if channelbag is not None:
+            return iter(channelbag.fcurves)
+        return iter([])
+
+    def __len__(self):
+        """Get the number of F-Curves"""
+        channelbag = self._get_channelbag(ensure=False)
+        if channelbag is not None:
+            return len(channelbag.fcurves)
+        return 0
+
+    def __getitem__(self, key):
+        """Access F-Curve by index or name"""
+        channelbag = self._get_channelbag(ensure=False)
+        if channelbag is not None:
+            return channelbag.fcurves[key]
+        raise IndexError("No channelbag available")
+
+    def __bool__(self):
+        """Check if there are F-Curves"""
+        return len(self) > 0
+
+
+def get_action_fcurves(action: bpy.types.Action):
+    """Get Action's fcurves (compatible with Blender 5.0+)
+
+    Returns native action.fcurves in Blender 4.x
+    Returns compatibility layer object in Blender 5.0+
+    """
+    if IS_BLENDER_50_UP:
+        return ActionFCurvesCompatibility(action)
+    return action.fcurves
+
+
+def get_action_groups(action: bpy.types.Action):
+    """Get Action's groups (compatible with Blender 5.0+)
+
+    Returns native action.groups in Blender 4.x
+    Returns compatibility layer object in Blender 5.0+
+    """
+    if IS_BLENDER_50_UP:
+        return ActionGroupsCompatibility(action)
+    return action.groups
+
+
+def new_fcurve(action_obj: bpy.types.Action, data_path: str, index: int = 0, group_name: str = "", id_type: str = "OBJECT"):
+    """
+    Create an F-Curve in a version-independent way.
+    Handles the `id_type` argument, available only in Blender 5.0+.
+    """
+    fcurves = get_action_fcurves(action_obj)
+
+    if IS_BLENDER_50_UP:
+        return fcurves.new(data_path, index=index, group_name=group_name, id_type=id_type)
+    return fcurves.new(data_path, index=index, action_group=group_name)
+
+
+def assign_action_to_datablock(datablock, action):
+    """Assign Action to datablock and ensure slot is properly set in Blender 5.0+"""
+    if not datablock.animation_data:
+        datablock.animation_data_create()
+
+    datablock.animation_data.action = action
+
+    if IS_BLENDER_50_UP and action is not None:
+        # Auto-create slot if missing
+        if not hasattr(action, "slots") or len(action.slots) == 0:
+            id_type = "OBJECT"
+            if isinstance(datablock, bpy.types.Key):
+                id_type = "KEY"
+            elif hasattr(datablock, "node_tree"):
+                id_type = "NODETREE"
+
+            slot_name = action.name if action.name else "Slot"
+            action.slots.new(name=slot_name, id_type=id_type)
+
+        datablock.animation_data.action_slot = action.slots[0]
+
+
+# Monkey patch to Action objects
+def patch_action_fcurves():
+    """Patch fcurves and groups properties onto Action objects
+
+    This patch allows Action objects in Blender 5.0+ to be accessed
+    directly via action.fcurves and action.groups like the old version,
+    without going through the layers -> strips -> channelbags hierarchy.
+    """
+    if not IS_BLENDER_50_UP:
+        return
+
+    # Save the original __getattribute__
+    if not hasattr(bpy.types.Action, "_original_getattribute"):
+        bpy.types.Action._original_getattribute = bpy.types.Action.__getattribute__
+
+    original_getattr = bpy.types.Action._original_getattribute
+
+    def custom_getattr(self, name):
+        if name == "fcurves":
+            return ActionFCurvesCompatibility(self)
+        if name == "groups":
+            return ActionGroupsCompatibility(self)
+        return original_getattr(self, name)
+
+    bpy.types.Action.__getattribute__ = custom_getattr
+
+
+def unpatch_action_fcurves():
+    """Remove the fcurves and groups patch"""
+    if IS_BLENDER_50_UP and hasattr(bpy.types.Action, "_original_getattribute"):
+        bpy.types.Action.__getattribute__ = bpy.types.Action._original_getattribute
+        delattr(bpy.types.Action, "_original_getattribute")
+
+
+def register():
+    """Register compatibility layer
+
+    Register fcurves and groups property patch in Blender 5.0+
+    """
+    if IS_BLENDER_50_UP:
+        patch_action_fcurves()
+
+
+def unregister():
+    """Unregister compatibility layer
+
+    Remove fcurves and groups property patch
+    """
+    if IS_BLENDER_50_UP:
+        unpatch_action_fcurves()

--- a/extern_tools/mmd_tools_local/core/bone.py
+++ b/extern_tools/mmd_tools_local/core/bone.py
@@ -69,7 +69,7 @@ class FnBone:
     @staticmethod
     def __get_selected_pose_bones(armature_object: bpy.types.Object) -> Iterable[bpy.types.PoseBone]:
         if armature_object.mode == "EDIT":
-            bpy.ops.object.mode_set(mode="OBJECT") # update selected bones
+            bpy.ops.object.mode_set(mode="OBJECT")  # update selected bones
             bpy.ops.object.mode_set(mode="EDIT")  # back to edit mode
         context_selected_bones = bpy.context.selected_pose_bones or bpy.context.selected_bones or []
         bones = armature_object.pose.bones
@@ -109,7 +109,7 @@ class FnBone:
 
     @staticmethod
     def __is_special_bone_collection(bone_collection: bpy.types.BoneCollection) -> bool:
-        return BONE_COLLECTION_CUSTOM_PROPERTY_VALUE_SPECIAL == bone_collection.get(BONE_COLLECTION_CUSTOM_PROPERTY_NAME)
+        return bone_collection.get(BONE_COLLECTION_CUSTOM_PROPERTY_NAME) == BONE_COLLECTION_CUSTOM_PROPERTY_VALUE_SPECIAL
 
     @staticmethod
     def __set_bone_collection_to_special(bone_collection: bpy.types.BoneCollection, is_visible: bool):
@@ -118,7 +118,7 @@ class FnBone:
 
     @staticmethod
     def __is_normal_bone_collection(bone_collection: bpy.types.BoneCollection) -> bool:
-        return BONE_COLLECTION_CUSTOM_PROPERTY_VALUE_NORMAL == bone_collection.get(BONE_COLLECTION_CUSTOM_PROPERTY_NAME)
+        return bone_collection.get(BONE_COLLECTION_CUSTOM_PROPERTY_NAME) == BONE_COLLECTION_CUSTOM_PROPERTY_VALUE_NORMAL
 
     @staticmethod
     def __set_bone_collection_to_normal(bone_collection: bpy.types.BoneCollection):
@@ -217,7 +217,7 @@ class FnBone:
             used_frame_index.add(display_item_frames.find(bone_collection_name))
 
             ItemOp.resize(display_item_frame.data, len(bone_collection.bones))
-            for display_item, bone in zip(display_item_frame.data, bone_collection.bones):
+            for display_item, bone in zip(display_item_frame.data, bone_collection.bones, strict=False):
                 display_item.type = "BONE"
                 display_item.name = bone.name
 
@@ -326,10 +326,7 @@ class FnBone:
 
     @staticmethod
     def apply_auto_bone_roll(armature):
-        bone_names = []
-        for b in armature.pose.bones:
-            if not b.is_mmd_shadow_bone and not b.mmd_bone.enabled_local_axes and FnBone.has_auto_local_axis(b.mmd_bone.name_j):
-                bone_names.append(b.name)
+        bone_names = [b.name for b in armature.pose.bones if not b.is_mmd_shadow_bone and not b.mmd_bone.enabled_local_axes and FnBone.has_auto_local_axis(b.mmd_bone.name_j)]
         with bpyutils.edit_object(armature) as data:
             bone: bpy.types.EditBone
             for bone in data.edit_bones:
@@ -371,6 +368,9 @@ class FnBone:
 
     @staticmethod
     def clean_additional_transformation(armature_object: bpy.types.Object):
+        if armature_object.type != "ARMATURE" or armature_object.pose is None:
+            return
+
         # clean constraints
         p_bone: bpy.types.PoseBone
         for p_bone in armature_object.pose.bones:
@@ -453,6 +453,11 @@ class FnBone:
                 remove_constraint(constraints, name)
                 return
             c = TransformConstraintOp.create(constraints, name, map_type)
+            # FIXME: Some bones require specific rotation modes to match MMD behavior.
+            # Currently using hardcoded bone names as a temporary solution.
+            # See https://github.com/MMD-Blender/blender_mmd_tools_local/issues/242
+            if bone_name in {"左肩C", "右肩C", "肩C.L", "肩C.R", "肩C_L", "肩C_R"}:
+                c.from_rotation_mode = "ZYX"  # Best matches MMD behavior for shoulder bones
             c.target = p_bone.id_data
             shadow_bone.add_constraint(c)
             TransformConstraintOp.update_min_max(c, value, influence)

--- a/extern_tools/mmd_tools_local/core/camera.py
+++ b/extern_tools/mmd_tools_local/core/camera.py
@@ -5,6 +5,7 @@ import math
 from typing import Optional
 
 import bpy
+from mathutils import Matrix, Vector
 
 from ..bpyutils import FnContext, Props
 
@@ -58,13 +59,12 @@ class FnCamera:
                 v.targets[0].data_path = "mmd_camera.angle"
                 expression = expression.replace("$angle", v.name)
             if "$sensor_height" in expression:
-                v = d.variables.new()
-                v.name = "sensor_height"
-                v.type = "SINGLE_PROP"
-                v.targets[0].id_type = "CAMERA"
-                v.targets[0].id = camera_object.data
-                v.targets[0].data_path = "sensor_height"
-                expression = expression.replace("$sensor_height", v.name)
+                # Use fixed sensor_height instead of dynamic reference.
+                # When controlled by MMD angle, sensor_height shouldn't change.
+                # This avoids unnecessary dependency cycles.
+                # Reference: https://github.com/MMD-Blender/blender_mmd_tools_local/issues/227
+                current_sensor_height = camera_object.data.sensor_height
+                expression = expression.replace("$sensor_height", str(current_sensor_height))
 
             d.expression = expression
 
@@ -77,7 +77,7 @@ class FnCamera:
     def remove_drivers(camera_object: bpy.types.Object):
         camera_object.data.driver_remove("ortho_scale")
         camera_object.driver_remove("rotation_euler")
-        camera_object.data.driver_remove("ortho_scale")
+        camera_object.data.driver_remove("type")
         camera_object.data.driver_remove("lens")
 
 
@@ -101,7 +101,7 @@ class MMDCamera:
     def __init__(self, obj):
         root_object = FnCamera.find_root(obj)
         if root_object is None:
-            raise ValueError("%s is not MMDCamera" % str(obj))
+            raise ValueError(f"{str(obj)} is not MMDCamera")
 
         self.__emptyObj = getattr(root_object, "original", obj)
 
@@ -164,20 +164,18 @@ class MMDCamera:
             if scene.camera is None:
                 scene.camera = mmd_cam
                 return MMDCamera(mmd_cam_root)
-            _camera_override_func = lambda: scene.camera
+            def _camera_override_func():
+                return scene.camera
 
         _target_override_func = None
         if cameraTarget is None:
-            _target_override_func = lambda camObj: camObj.data.dof.focus_object or camObj
+            def _target_override_func(camObj):
+                return camObj.data.dof.focus_object or camObj
 
         action_name = mmd_cam_root.name
         parent_action = bpy.data.actions.new(name=action_name)
         distance_action = bpy.data.actions.new(name=action_name + "_dis")
         FnCamera.remove_drivers(mmd_cam)
-
-        from math import atan
-
-        from mathutils import Matrix, Vector
 
         render = scene.render
         factor = (render.resolution_y * render.pixel_aspect_y) / (render.resolution_x * render.pixel_aspect_x)
@@ -187,18 +185,15 @@ class MMDCamera:
         frame_count = frame_end - frame_start
         frames = range(frame_start, frame_end)
 
-        fcurves = []
-        for i in range(3):
-            fcurves.append(parent_action.fcurves.new(data_path="location", index=i))  # x, y, z
-        for i in range(3):
-            fcurves.append(parent_action.fcurves.new(data_path="rotation_euler", index=i))  # rx, ry, rz
+        fcurves = [parent_action.fcurves.new(data_path="location", index=i) for i in range(3)]  # x, y, z
+        fcurves.extend(parent_action.fcurves.new(data_path="rotation_euler", index=i) for i in range(3))  # rx, ry, rz
         fcurves.append(parent_action.fcurves.new(data_path="mmd_camera.angle"))  # fov
         fcurves.append(parent_action.fcurves.new(data_path="mmd_camera.is_perspective"))  # persp
         fcurves.append(distance_action.fcurves.new(data_path="location", index=1))  # dis
         for c in fcurves:
             c.keyframe_points.add(frame_count)
 
-        for f, x, y, z, rx, ry, rz, fov, persp, dis in zip(frames, *(c.keyframe_points for c in fcurves)):
+        for f, x, y, z, rx, ry, rz, fov, persp, dis in zip(frames, *(c.keyframe_points for c in fcurves), strict=False):
             scene.frame_set(f)
             if _camera_override_func:
                 cameraObj = _camera_override_func()
@@ -231,7 +226,7 @@ class MMDCamera:
             x.co, y.co, z.co = ((f, i) for i in cam_target_loc)
             rx.co, ry.co, rz.co = ((f, i) for i in cam_rotation)
             dis.co = (f, cam_dis)
-            fov.co = (f, 2 * atan(tan_val))
+            fov.co = (f, 2 * math.atan(tan_val))
             persp.co = (f, cameraObj.data.type != "ORTHO")
             persp.interpolation = "CONSTANT"
             for kp in (x, y, z, rx, ry, rz, fov, dis):

--- a/extern_tools/mmd_tools_local/core/exceptions.py
+++ b/extern_tools/mmd_tools_local/core/exceptions.py
@@ -8,5 +8,5 @@ class MaterialNotFoundError(KeyError):
     """Exception raised when a material is not found in the scene"""
 
     def __init__(self, *args: object) -> None:
-        """Constructor for MaterialNotFoundError"""
+        """Initialize MaterialNotFoundError"""
         super().__init__(*args)

--- a/extern_tools/mmd_tools_local/core/lamp.py
+++ b/extern_tools/mmd_tools_local/core/lamp.py
@@ -13,7 +13,7 @@ class MMDLamp:
         if obj and obj.type == "EMPTY" and obj.mmd_type == "LIGHT":
             self.__emptyObj = obj
         else:
-            raise ValueError("%s is not MMDLamp" % str(obj))
+            raise ValueError(f"{str(obj)} is not MMDLamp")
 
     @staticmethod
     def isLamp(obj):

--- a/extern_tools/mmd_tools_local/core/material.py
+++ b/extern_tools/mmd_tools_local/core/material.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Iterable, Optional, Tuple, cast
 
 import bpy
@@ -48,7 +49,7 @@ class FnMaterial:
         FnMaterial.__NODES_ARE_READONLY = nodes_are_readonly
 
     @classmethod
-    def from_material_id(cls, material_id: str):
+    def from_material_id(cls, material_id: int):
         for material in bpy.data.materials:
             if material.mmd_material.material_id == material_id:
                 return cls(material)
@@ -66,7 +67,8 @@ class FnMaterial:
     @staticmethod
     def swap_materials(mesh_object: bpy.types.Object, mat1_ref: str | int, mat2_ref: str | int, reverse=False, swap_slots=False) -> Tuple[bpy.types.Material, bpy.types.Material]:
         """
-        This method will assign the polygons of mat1 to mat2.
+        Assign the polygons of mat1 to mat2.
+
         If reverse is True it will also swap the polygons assigned to mat2 to mat1.
         The reference to materials can be indexes or names
         Finally it will also swap the material slots if the option is given.
@@ -84,16 +86,16 @@ class FnMaterial:
         Raises:
             MaterialNotFoundError: If one of the materials is not found
         """
-        mesh = cast(bpy.types.Mesh, mesh_object.data)
+        mesh = cast("bpy.types.Mesh", mesh_object.data)
         try:
             # Try to find the materials
             mat1 = mesh.materials[mat1_ref]
             mat2 = mesh.materials[mat2_ref]
-            if None in (mat1, mat2):
-                raise MaterialNotFoundError()
+            if None in {mat1, mat2}:
+                raise MaterialNotFoundError
         except (KeyError, IndexError) as exc:
             # Wrap exceptions within our custom ones
-            raise MaterialNotFoundError() from exc
+            raise MaterialNotFoundError from exc
         mat1_idx = mesh.materials.find(mat1.name)
         mat2_idx = mesh.materials.find(mat2.name)
         # Swap polygons
@@ -110,10 +112,8 @@ class FnMaterial:
 
     @staticmethod
     def fixMaterialOrder(meshObj: bpy.types.Object, material_names: Iterable[str]):
-        """
-        This method will fix the material order. Which is lost after joining meshes.
-        """
-        materials = cast(bpy.types.Mesh, meshObj.data).materials
+        """Fix the material order which is lost after joining meshes."""
+        materials = cast("bpy.types.Mesh", meshObj.data).materials
         for new_idx, mat in enumerate(material_names):
             # Get the material that is currently on this index
             other_mat = materials[new_idx]
@@ -144,8 +144,8 @@ class FnMaterial:
             # pylint: disable=bare-except
             try:
                 return os.path.samefile(img_filepath, filepath)
-            except:
-                pass
+            except Exception as e:
+                logging.warning(f"Failed to compare files '{img_filepath}' and '{filepath}': {e}")
         return False
 
     def _load_image(self, filepath):
@@ -154,7 +154,7 @@ class FnMaterial:
             # pylint: disable=bare-except
             try:
                 img = bpy.data.images.load(filepath)
-            except:
+            except Exception:
                 logging.warning("Cannot create a texture for %s. No such file.", filepath)
                 img = bpy.data.images.new(os.path.basename(filepath), 1, 1)
                 img.source = "FILE"
@@ -173,7 +173,7 @@ class FnMaterial:
         if mmd_mat.is_shared_toon_texture:
             shared_toon_folder = FnContext.get_addon_preferences_attribute(FnContext.ensure_context(), "shared_toon_folder", "")
             toon_path = os.path.join(shared_toon_folder, "toon%02d.bmp" % (mmd_mat.shared_toon_texture + 1))
-            self.create_toon_texture(bpy.path.resolve_ncase(path=toon_path))
+            self.create_toon_texture(str(Path(toon_path).resolve()))
         elif mmd_mat.toon_texture != "":
             self.create_toon_texture(mmd_mat.toon_texture)
         else:
@@ -251,7 +251,7 @@ class FnMaterial:
         sphere_texture_type = int(self.material.mmd_material.sphere_texture_type)
         is_sph_add = sphere_texture_type == 2
 
-        if sphere_texture_type not in (1, 2, 3):
+        if sphere_texture_type not in {1, 2, 3}:
             self.__update_shader_input("Sphere Tex Fac", 0)
         else:
             self.__update_shader_input("Sphere Tex Fac", 1)
@@ -269,7 +269,7 @@ class FnMaterial:
                 nodes, links = mat.node_tree.nodes, mat.node_tree.links
                 if sphere_texture_type == 3:
                     if obj and obj.type == "MESH" and mat in tuple(obj.data.materials):
-                        uv_layers = (l for l in obj.data.uv_layers if not l.name.startswith("_"))
+                        uv_layers = (layer for layer in obj.data.uv_layers if not layer.name.startswith("_"))
                         next(uv_layers, None)  # skip base UV
                         subtex_uv = getattr(next(uv_layers, None), "name", "")
                         if subtex_uv != "UV1":
@@ -317,8 +317,6 @@ class FnMaterial:
     def __create_texture_node(self, node_name, filepath, pos):
         texture = self.__get_texture_node(node_name)
         if texture is None:
-            from mathutils import Vector
-
             self.__update_shader_nodes()
             nodes = self.material.node_tree.nodes
             texture = nodes.new("ShaderNodeTexImage")
@@ -380,7 +378,7 @@ class FnMaterial:
         mmd_mat = mat.mmd_material
         mat.roughness = 1 / pow(max(mmd_mat.shininess, 1), 0.37)
         if hasattr(mat, "metallic"):
-            mat.metallic = pow(1 - mat.roughness, 2.7)
+            mat.metallic = 0.0
         if hasattr(mat, "specular_hardness"):
             mat.specular_hardness = mmd_mat.shininess
         self.__update_shader_input("Reflect", mmd_mat.shininess)
@@ -458,9 +456,9 @@ class FnMaterial:
                 tex_node.name = "mmd_base_tex"
             else:
                 # Take the Base Color from BSDF if there's no texture
-                bsdf_node = next((n for n in m.node_tree.nodes if n.type.startswith('BSDF_')), None)
+                bsdf_node = next((n for n in m.node_tree.nodes if n.type.startswith("BSDF_")), None)
                 if bsdf_node:
-                    base_color_input = bsdf_node.inputs.get('Base Color') or bsdf_node.inputs.get('Color')
+                    base_color_input = bsdf_node.inputs.get("Base Color") or bsdf_node.inputs.get("Color")
                     if base_color_input:
                         mmd_material.diffuse_color = base_color_input.default_value[:3]
                         # ambient should be half the diffuse
@@ -492,7 +490,7 @@ class FnMaterial:
 
         # delete bsdf node if it's there
         if m.use_nodes:
-            nodes_to_remove = [n for n in m.node_tree.nodes if n.type == 'BSDF_PRINCIPLED' or n.type.startswith('BSDF_')]
+            nodes_to_remove = [n for n in m.node_tree.nodes if n.type == "BSDF_PRINCIPLED" or n.type.startswith("BSDF_")]
             for n in nodes_to_remove:
                 m.node_tree.nodes.remove(n)
 
@@ -523,7 +521,7 @@ class FnMaterial:
         if node_shader is None:
             node_shader: bpy.types.ShaderNodeGroup = nodes.new("ShaderNodeGroup")
             node_shader.name = "mmd_shader"
-            node_shader.location = (0, 1500)
+            node_shader.location = (0, 300)
             node_shader.width = 200
             node_shader.node_tree = self.__get_shader()
 
@@ -553,7 +551,7 @@ class FnMaterial:
             links.new(node_shader.outputs["Shader"], node_output.inputs["Surface"])
 
         for name_id in ("Base", "Toon", "Sphere"):
-            texture = self.__get_texture_node("mmd_%s_tex" % name_id.lower())
+            texture = self.__get_texture_node(f"mmd_{name_id.lower()}_tex")
             if texture:
                 name_tex_in, name_alpha_in, name_uv_out = (name_id + x for x in (" Tex", " Alpha", " UV"))
                 if not node_shader.inputs.get(name_tex_in, _Dummy).is_linked:

--- a/extern_tools/mmd_tools_local/core/model.py
+++ b/extern_tools/mmd_tools_local/core/model.py
@@ -9,16 +9,15 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Iterator, Optio
 import bpy
 import idprop
 import rna_prop_ui
-from mathutils import Vector
+from mathutils import Matrix, Vector
 
-from .. import mmd_tools_local_VERSION, bpyutils
-from ..bpyutils import FnContext, Props
+from .. import mmd_tools_local_VERSION
+from ..bpyutils import FnContext, Props, createObject, duplicateObject, edit_object, select_object
 from . import rigid_body
 from .morph import FnMorph
 from .rigid_body import MODE_DYNAMIC, MODE_DYNAMIC_BONE, MODE_STATIC
 
 if TYPE_CHECKING:
-    from ..properties.morph import MaterialMorphData
     from ..properties.rigid_body import MMDRigidBody
 
 
@@ -41,20 +40,24 @@ class FnModel:
         return obj
 
     @staticmethod
-    def find_armature_object(root_object: bpy.types.Object) -> Optional[bpy.types.Object]:
+    def find_armature_object(root_object: Optional[bpy.types.Object]) -> Optional[bpy.types.Object]:
         """Find the armature object of the model.
         Args:
-            root_object (bpy.types.Object): The root object of the model.
+            root_object (Optional[bpy.types.Object]): The root object of the model.
         Returns:
             Optional[bpy.types.Object]: The armature object of the model. If the model does not have an armature, None is returned.
         """
+        if root_object is None:
+            return None
         for o in root_object.children:
             if o.type == "ARMATURE":
                 return o
         return None
 
     @staticmethod
-    def find_rigid_group_object(root_object: bpy.types.Object) -> Optional[bpy.types.Object]:
+    def find_rigid_group_object(root_object: Optional[bpy.types.Object]) -> Optional[bpy.types.Object]:
+        if root_object is None:
+            return None
         for o in root_object.children:
             if o.type == "EMPTY" and o.mmd_type == "RIGID_GRP_OBJ":
                 return o
@@ -72,13 +75,17 @@ class FnModel:
 
     @staticmethod
     def ensure_rigid_group_object(context: bpy.types.Context, root_object: bpy.types.Object) -> bpy.types.Object:
+        if root_object is None:
+            raise ValueError("root_object cannot be None")
         rigid_group_object = FnModel.find_rigid_group_object(root_object)
         if rigid_group_object is not None:
             return rigid_group_object
         return FnModel.__new_group_object(context, name="rigidbodies", mmd_type="RIGID_GRP_OBJ", parent=root_object)
 
     @staticmethod
-    def find_joint_group_object(root_object: bpy.types.Object) -> Optional[bpy.types.Object]:
+    def find_joint_group_object(root_object: Optional[bpy.types.Object]) -> Optional[bpy.types.Object]:
+        if root_object is None:
+            return None
         for o in root_object.children:
             if o.type == "EMPTY" and o.mmd_type == "JOINT_GRP_OBJ":
                 return o
@@ -86,13 +93,17 @@ class FnModel:
 
     @staticmethod
     def ensure_joint_group_object(context: bpy.types.Context, root_object: bpy.types.Object) -> bpy.types.Object:
+        if root_object is None:
+            raise ValueError("root_object cannot be None")
         joint_group_object = FnModel.find_joint_group_object(root_object)
         if joint_group_object is not None:
             return joint_group_object
         return FnModel.__new_group_object(context, name="joints", mmd_type="JOINT_GRP_OBJ", parent=root_object)
 
     @staticmethod
-    def find_temporary_group_object(root_object: bpy.types.Object) -> Optional[bpy.types.Object]:
+    def find_temporary_group_object(root_object: Optional[bpy.types.Object]) -> Optional[bpy.types.Object]:
+        if root_object is None:
+            return None
         for o in root_object.children:
             if o.type == "EMPTY" and o.mmd_type == "TEMPORARY_GRP_OBJ":
                 return o
@@ -100,13 +111,17 @@ class FnModel:
 
     @staticmethod
     def ensure_temporary_group_object(context: bpy.types.Context, root_object: bpy.types.Object) -> bpy.types.Object:
+        if root_object is None:
+            raise ValueError("root_object cannot be None")
         temporary_group_object = FnModel.find_temporary_group_object(root_object)
         if temporary_group_object is not None:
             return temporary_group_object
         return FnModel.__new_group_object(context, name="temporary", mmd_type="TEMPORARY_GRP_OBJ", parent=root_object)
 
     @staticmethod
-    def find_bone_order_mesh_object(root_object: bpy.types.Object) -> Optional[bpy.types.Object]:
+    def find_bone_order_mesh_object(root_object: Optional[bpy.types.Object]) -> Optional[bpy.types.Object]:
+        if root_object is None:
+            return None
         armature_object = FnModel.find_armature_object(root_object)
         if armature_object is None:
             return None
@@ -117,17 +132,21 @@ class FnModel:
         return None
 
     @staticmethod
-    def find_mesh_object_by_name(root_object: bpy.types.Object, name: str) -> Optional[bpy.types.Object]:
+    def find_mesh_object_by_name(root_object: Optional[bpy.types.Object], name: str) -> Optional[bpy.types.Object]:
+        if root_object is None:
+            return None
         if not name:
             return None
 
         for o in FnModel.iterate_mesh_objects(root_object):
-            if o.name == name or (hasattr(o.data, 'name') and o.data.name == name):
+            if o.name == name or (hasattr(o.data, "name") and o.data.name == name):
                 return o
         return None
 
     @staticmethod
-    def iterate_child_objects(obj: bpy.types.Object) -> Iterator[bpy.types.Object]:
+    def iterate_child_objects(obj: Optional[bpy.types.Object]) -> Iterator[bpy.types.Object]:
+        if obj is None:
+            return iter(())
         for child in obj.children:
             yield child
             yield from FnModel.iterate_child_objects(child)
@@ -150,11 +169,15 @@ class FnModel:
         return FnModel.iterate_filtered_child_objects(FnModel.is_mesh_object, obj)
 
     @staticmethod
-    def iterate_mesh_objects(root_object: bpy.types.Object) -> Iterator[bpy.types.Object]:
+    def iterate_mesh_objects(root_object: Optional[bpy.types.Object]) -> Iterator[bpy.types.Object]:
+        if root_object is None:
+            return iter(())
         return FnModel.__iterate_child_mesh_objects(FnModel.find_armature_object(root_object))
 
     @staticmethod
-    def iterate_rigid_body_objects(root_object: bpy.types.Object) -> Iterator[bpy.types.Object]:
+    def iterate_rigid_body_objects(root_object: Optional[bpy.types.Object]) -> Iterator[bpy.types.Object]:
+        if root_object is None:
+            return iter(())
         if root_object.mmd_root.is_built:
             return itertools.chain(
                 FnModel.iterate_filtered_child_objects(FnModel.is_rigid_body_object, FnModel.find_armature_object(root_object)),
@@ -163,13 +186,17 @@ class FnModel:
         return FnModel.iterate_filtered_child_objects(FnModel.is_rigid_body_object, FnModel.find_rigid_group_object(root_object))
 
     @staticmethod
-    def iterate_joint_objects(root_object: bpy.types.Object) -> Iterator[bpy.types.Object]:
+    def iterate_joint_objects(root_object: Optional[bpy.types.Object]) -> Iterator[bpy.types.Object]:
+        if root_object is None:
+            return iter(())
         return FnModel.iterate_filtered_child_objects(FnModel.is_joint_object, FnModel.find_joint_group_object(root_object))
 
     @staticmethod
-    def iterate_temporary_objects(root_object: bpy.types.Object, rigid_track_only: bool = False) -> Iterator[bpy.types.Object]:
-        rigid_body_objects = FnModel.iterate_filtered_child_objects(FnModel.is_temporary_object, FnModel.find_rigid_group_object(root_object))
+    def iterate_temporary_objects(root_object: Optional[bpy.types.Object], rigid_track_only: bool = False) -> Iterator[bpy.types.Object]:
+        if root_object is None:
+            return iter(())
 
+        rigid_body_objects = FnModel.iterate_filtered_child_objects(FnModel.is_temporary_object, FnModel.find_rigid_group_object(root_object))
         if rigid_track_only:
             return rigid_body_objects
 
@@ -179,11 +206,15 @@ class FnModel:
         return itertools.chain(rigid_body_objects, FnModel.__iterate_filtered_child_objects_internal(FnModel.is_temporary_object, temporary_group_object))
 
     @staticmethod
-    def iterate_materials(root_object: bpy.types.Object) -> Iterator[bpy.types.Material]:
-        return (material for mesh_object in FnModel.iterate_mesh_objects(root_object) for material in cast(bpy.types.Mesh, mesh_object.data).materials if material is not None)
+    def iterate_materials(root_object: Optional[bpy.types.Object]) -> Iterator[bpy.types.Material]:
+        if root_object is None:
+            return iter(())
+        return (material for mesh_object in FnModel.iterate_mesh_objects(root_object) for material in cast("bpy.types.Mesh", mesh_object.data).materials if material is not None)
 
     @staticmethod
-    def iterate_unique_materials(root_object: bpy.types.Object) -> Iterator[bpy.types.Material]:
+    def iterate_unique_materials(root_object: Optional[bpy.types.Object]) -> Iterator[bpy.types.Material]:
+        if root_object is None:
+            return iter(())
         materials: Dict[bpy.types.Material, None] = {}  # use dict because set does not guarantee the order
         materials.update((material, None) for material in FnModel.iterate_materials(root_object))
         return iter(materials.keys())
@@ -213,14 +244,14 @@ class FnModel:
         """Find maximum bone ID from pose bones, return -1 if no valid IDs found"""
         max_bone_id = -1
         for bone in pose_bones:
-            if not hasattr(bone, 'is_mmd_shadow_bone') or not bone.is_mmd_shadow_bone:
+            if not hasattr(bone, "is_mmd_shadow_bone") or not bone.is_mmd_shadow_bone:
                 max_bone_id = max(max_bone_id, bone.mmd_bone.bone_id)
         return max_bone_id
 
     @staticmethod
     def unsafe_change_bone_id(bone: bpy.types.PoseBone, new_bone_id: int, bone_morphs, pose_bones):
         """
-        Changes bone ID and updates all references without validating if new_bone_id is already in use.
+        Change bone ID and updates all references without validating if new_bone_id is already in use.
         If new_bone_id is already in use, it may cause conflicts and corrupt existing bone references.
         """
         # Store the original bone_id and change it
@@ -235,14 +266,14 @@ class FnModel:
 
         # Update all additional_transform_bone_id references in pose bones
         for pose_bone in pose_bones:
-            if not hasattr(pose_bone, 'is_mmd_shadow_bone') or not pose_bone.is_mmd_shadow_bone:
+            if not hasattr(pose_bone, "is_mmd_shadow_bone") or not pose_bone.is_mmd_shadow_bone:
                 mmd_bone = pose_bone.mmd_bone
                 if mmd_bone.additional_transform_bone_id == bone_id:
                     mmd_bone.additional_transform_bone_id = new_bone_id
 
         # Update all display_connection_bone_id references in pose bones
         for pose_bone in pose_bones:
-            if not hasattr(pose_bone, 'is_mmd_shadow_bone') or not pose_bone.is_mmd_shadow_bone:
+            if not hasattr(pose_bone, "is_mmd_shadow_bone") or not pose_bone.is_mmd_shadow_bone:
                 mmd_bone = pose_bone.mmd_bone
                 if mmd_bone.display_connection_bone_id == bone_id:
                     mmd_bone.display_connection_bone_id = new_bone_id
@@ -250,7 +281,7 @@ class FnModel:
     @staticmethod
     def safe_change_bone_id(bone: bpy.types.PoseBone, new_bone_id: int, bone_morphs, pose_bones):
         """
-        Changes bone ID and updates all references safely by detecting and resolving conflicts automatically.
+        Change bone ID and updates all references safely by detecting and resolving conflicts automatically.
         If new_bone_id is already in use, shifts all conflicting bone IDs sequentially until a gap is found.
         """
         # Validate new_bone_id is non-negative
@@ -296,40 +327,313 @@ class FnModel:
         id_a = bone_a.mmd_bone.bone_id
         id_b = bone_b.mmd_bone.bone_id
 
+        # Check for invalid bone IDs
+        if id_a < 0:
+            logging.warning(f"Cannot swap bone '{bone_a.name}' with invalid bone_id ({id_a})")
+            return
+        if id_b < 0:
+            logging.warning(f"Cannot swap bone '{bone_b.name}' with invalid bone_id ({id_b})")
+            return
+
+        # If both bones have the same ID, no swap needed
+        if id_a == id_b:
+            return
+
         # Use temporary ID for three-step swap
         temp_id = FnModel.get_max_bone_id(pose_bones) + 1
         FnModel.unsafe_change_bone_id(bone_a, temp_id, bone_morphs, pose_bones)
         FnModel.unsafe_change_bone_id(bone_b, id_a, bone_morphs, pose_bones)
         FnModel.unsafe_change_bone_id(bone_a, id_b, bone_morphs, pose_bones)
 
-    def realign_bone_ids(bones, bone_id_offset: int, bone_morphs, pose_bones):
-        """Realigns all bone IDs sequentially without gaps.
-        New sequence starts from bone_id_offset."""
-        # Get valid bones (non-shadow bones with valid IDs)
-        valid_bones = [pb for pb in pose_bones
-                    if not (hasattr(pb, 'is_mmd_shadow_bone') and pb.is_mmd_shadow_bone)
-                    and pb.mmd_bone.bone_id != -1]
+    @staticmethod
+    def shift_bone_id(old_bone_id: int, new_bone_id: int, bone_morphs, pose_bones):
+        """
+        Shifts a bone to a specified ID position within a fixed bone ID order structure.
+        Maintains the gap structure of bone IDs unchanged, only changes which bone corresponds to which ID.
+        Other bones shift positions to accommodate the change while preserving relative order.
+        """
+        if old_bone_id < 0:
+            logging.warning(f"Cannot shift bone with invalid old_bone_id ({old_bone_id})")
+            return
+        if new_bone_id < 0:
+            logging.warning(f"Cannot shift bone to invalid new_bone_id ({new_bone_id})")
+            return
+        if old_bone_id == new_bone_id:
+            return
 
-        # Sort and reassign IDs sequentially
+        valid_bones = [pb for pb in pose_bones if not (hasattr(pb, "is_mmd_shadow_bone") and pb.is_mmd_shadow_bone) and pb.mmd_bone.bone_id >= 0]
         valid_bones.sort(key=lambda pb: pb.mmd_bone.bone_id)
+
+        # Extract current bone IDs (this order structure must remain unchanged)
+        fixed_bone_ids = [pb.mmd_bone.bone_id for pb in valid_bones]
+
+        # Find the bone to move and target position
+        old_pos = None
+        new_pos = None
+        moving_bone = None
+
+        for i, bone in enumerate(valid_bones):
+            if bone.mmd_bone.bone_id == old_bone_id:
+                old_pos = i
+                moving_bone = bone
+            if bone.mmd_bone.bone_id == new_bone_id:
+                new_pos = i
+
+        # If old_bone_id doesn't exist, return directly
+        if old_pos is None or moving_bone is None:
+            logging.warning(f"Could not find bone with ID {old_bone_id}")
+            return
+
+        # If new_bone_id doesn't exist, use safe_change_bone_id instead
+        if new_pos is None:
+            FnModel.safe_change_bone_id(moving_bone, new_bone_id, bone_morphs, pose_bones)
+            return
+
+        # 1. Determine the changes and build the translation map
+        id_translation_map = {}
+        bone_to_new_id_map = {}
+
+        if old_pos < new_pos:  # Move down (ID increases)
+            # Bone at old_pos moves to new_pos's ID.
+            # Bones from old_pos+1 to new_pos shift up to fill the gap.
+            id_translation_map[old_bone_id] = fixed_bone_ids[new_pos]
+            bone_to_new_id_map[moving_bone.name] = fixed_bone_ids[new_pos]
+            for i in range(old_pos, new_pos):
+                bone_to_shift = valid_bones[i + 1]
+                target_id = fixed_bone_ids[i]
+                id_translation_map[bone_to_shift.mmd_bone.bone_id] = target_id
+                bone_to_new_id_map[bone_to_shift.name] = target_id
+        else:  # Move up (ID decreases)
+            # Bone at old_pos moves to new_pos's ID.
+            # Bones from new_pos to old_pos-1 shift down.
+            id_translation_map[old_bone_id] = fixed_bone_ids[new_pos]
+            bone_to_new_id_map[moving_bone.name] = fixed_bone_ids[new_pos]
+            for i in range(new_pos + 1, old_pos + 1):
+                bone_to_shift = valid_bones[i - 1]
+                target_id = fixed_bone_ids[i]
+                id_translation_map[bone_to_shift.mmd_bone.bone_id] = target_id
+                bone_to_new_id_map[bone_to_shift.name] = target_id
+
+        # 2. Assign the new IDs to the affected bones
+        for bone_name, new_id in bone_to_new_id_map.items():
+            pose_bones[bone_name].mmd_bone.bone_id = new_id
+
+        # 3. Batch update all references (morphs and other bones)
+        if not id_translation_map:
+            return
+
+        for bone_morph in bone_morphs:
+            for data in bone_morph.data:
+                if data.bone_id in id_translation_map:
+                    data.bone_id = id_translation_map[data.bone_id]
+
+        for pose_bone in pose_bones:
+            if not (hasattr(pose_bone, "is_mmd_shadow_bone") and pose_bone.is_mmd_shadow_bone):
+                mmd_bone = pose_bone.mmd_bone
+                if mmd_bone.additional_transform_bone_id in id_translation_map:
+                    mmd_bone.additional_transform_bone_id = id_translation_map[mmd_bone.additional_transform_bone_id]
+                if mmd_bone.display_connection_bone_id in id_translation_map:
+                    mmd_bone.display_connection_bone_id = id_translation_map[mmd_bone.display_connection_bone_id]
+
+    @staticmethod
+    def realign_bone_ids(bone_id_offset: int, bone_morphs, pose_bones):
+        """Realigns all bone IDs sequentially without gaps and sorts bones in MMD-compatible hierarchy order."""
+        # Build bone_id to pose_bone index for fast lookup
+        bone_id_to_pose_bone = {}
+        valid_bones = []
+        for pose_bone in pose_bones:
+            if not (hasattr(pose_bone, "is_mmd_shadow_bone") and pose_bone.is_mmd_shadow_bone):
+                valid_bones.append(pose_bone)
+                bone_id = pose_bone.mmd_bone.bone_id
+                if bone_id >= 0:
+                    bone_id_to_pose_bone[bone_id] = pose_bone
+
+        def get_sort_key(bone):
+            """Generate sorting key that only moves bones violating parent-child rules and additional transform rules"""
+            transform_order = getattr(bone.mmd_bone, "transform_order", 0)
+            current_id = bone.mmd_bone.bone_id if bone.mmd_bone.bone_id >= 0 else float("inf")
+            additional_transform_bone_id = getattr(bone.mmd_bone, "additional_transform_bone_id", -1)
+
+            # Check if this bone violates parent-child order rules
+            violation_found = False
+            max_ancestor_id = -1
+            parent = bone.parent
+
+            while parent:
+                if hasattr(parent, "is_mmd_shadow_bone") and parent.is_mmd_shadow_bone:
+                    parent = parent.parent
+                    continue
+
+                parent_transform_order = getattr(parent.mmd_bone, "transform_order", 0)
+                parent_id = parent.mmd_bone.bone_id
+
+                # The rule that can be solved by sorting:
+                # if parent.transform_order == child.transform_order,
+                # then parent.bone_id must be < child.bone_id
+                if parent_transform_order == transform_order and parent_id >= 0 and current_id >= 0 and parent_id >= current_id:
+                    violation_found = True
+                    max_ancestor_id = max(max_ancestor_id, parent_id)
+
+                parent = parent.parent
+
+            # Check additional transform constraint
+            # additional_transform_bone_id must be smaller than current bone_id when transform_order is the same
+            if additional_transform_bone_id >= 0 and current_id >= 0 and additional_transform_bone_id >= current_id:
+                additional_transform_bone = bone_id_to_pose_bone.get(additional_transform_bone_id)
+                if additional_transform_bone:
+                    additional_transform_order = getattr(additional_transform_bone.mmd_bone, "transform_order", 0)
+                    # Only apply constraint when transform_order is the same
+                    if additional_transform_order == transform_order:
+                        violation_found = True
+                        max_ancestor_id = max(max_ancestor_id, additional_transform_bone_id)
+
+            if violation_found:
+                # Move this bone after its ancestors and additional transform dependencies
+                return (max_ancestor_id + 0.1, current_id, bone.name)
+            # Keep original position - use current bone_id for sorting
+            return (current_id, current_id, bone.name)
+
+        # Sort - only bones violating rules will be moved
+        valid_bones.sort(key=get_sort_key)
+
+        # Create a translation map from old bone_id to new bone_id
+        id_translation_map = {}
+        bone_to_new_id_map = {}
         for i, bone in enumerate(valid_bones):
             new_id = bone_id_offset + i
+            old_id = bone.mmd_bone.bone_id
+            if old_id != new_id:
+                if old_id >= 0:
+                    id_translation_map[old_id] = new_id
+            bone_to_new_id_map[bone.name] = new_id
+
+        # Assign the new IDs to the bones themselves
+        for bone in valid_bones:
+            new_id = bone_to_new_id_map[bone.name]
             if bone.mmd_bone.bone_id != new_id:
-                FnModel.safe_change_bone_id(bone, new_id, bone_morphs, pose_bones)
+                bone.mmd_bone.bone_id = new_id
+
+        # Batch update all references (morphs and other bones) using the translation map
+        if not id_translation_map:  # No changes needed
+            return
+
+        for bone_morph in bone_morphs:
+            for data in bone_morph.data:
+                if data.bone_id in id_translation_map:
+                    data.bone_id = id_translation_map[data.bone_id]
+
+        for pose_bone in pose_bones:
+            if not (hasattr(pose_bone, "is_mmd_shadow_bone") and pose_bone.is_mmd_shadow_bone):
+                mmd_bone = pose_bone.mmd_bone
+                if mmd_bone.additional_transform_bone_id in id_translation_map:
+                    mmd_bone.additional_transform_bone_id = id_translation_map[mmd_bone.additional_transform_bone_id]
+                if mmd_bone.display_connection_bone_id in id_translation_map:
+                    mmd_bone.display_connection_bone_id = id_translation_map[mmd_bone.display_connection_bone_id]
+
+    @staticmethod
+    def clean_invalid_bone_id_references(mmd_root_object) -> int:
+        """
+        Scan all bones and bone morphs to clean up invalid bone ID references.
+
+        This function performs two main tasks:
+        1.  For bone properties that reference another bone by ID (e.g.,
+            additional_transform_bone_id, display_connection_bone_id), it
+            resets the ID to -1 if the target bone no longer exists.
+        2.  For Bone Morphs, it removes individual morph data entries
+            that reference a bone that no longer exists.
+
+        Args:
+            mmd_root_object: The MMD root object (should have mmd_root property).
+
+        Returns:
+            int: The total number of invalid references that were cleaned or removed.
+        """
+        if not mmd_root_object or not hasattr(mmd_root_object, "mmd_root"):
+            logging.warning("Invalid mmd_root_object provided")
+            return 0
+
+        # Find armature
+        armature = FnModel.find_armature_object(mmd_root_object)
+        if not armature:
+            logging.warning(f"Armature not found for MMD model '{mmd_root_object.name}'")
+            return 0
+
+        pose_bones = armature.pose.bones
+        bone_morphs = mmd_root_object.mmd_root.bone_morphs
+
+        if not pose_bones:
+            return 0
+
+        cleaned_count = 0
+        valid_bone_ids = {b.mmd_bone.bone_id for b in pose_bones if hasattr(b, "mmd_bone") and b.mmd_bone.bone_id >= 0 and not getattr(b, "is_mmd_shadow_bone", False)}
+
+        # Step 2: Clean up ID references on the bones themselves.
+        for bone in pose_bones:
+            if not hasattr(bone, "mmd_bone"):
+                continue
+
+            mmd_bone = bone.mmd_bone
+
+            # --- Clean up Additional Transform ---
+            ref_bone_id = mmd_bone.additional_transform_bone_id
+            if ref_bone_id >= 0 and ref_bone_id not in valid_bone_ids:
+                mmd_bone.additional_transform_bone_id = -1
+                mmd_bone.is_additional_transform_dirty = True
+                cleaned_count += 1
+                logging.info(f"Cleaned invalid additional transform reference on bone '{bone.name}' (bone_id: {ref_bone_id} does not exist)")
+
+            # --- Clean up Display Connection ---
+            ref_bone_id = mmd_bone.display_connection_bone_id
+            if ref_bone_id >= 0 and ref_bone_id not in valid_bone_ids:
+                mmd_bone.display_connection_bone_id = -1
+                cleaned_count += 1
+                logging.info(f"Cleaned invalid display connection reference on bone '{bone.name}' (bone_id: {ref_bone_id} does not exist)")
+
+        # Step 3: Clean up invalid references within Bone Morphs.
+        if bone_morphs:
+            for morph in bone_morphs:
+                morph_data = morph.data
+                for i in range(len(morph_data) - 1, -1, -1):
+                    item = morph_data[i]
+                    ref_bone_id = item.bone_id
+                    if ref_bone_id >= 0 and ref_bone_id not in valid_bone_ids:
+                        item.bone_id = -1
+                        cleaned_count += 1
+                        logging.info(f"Cleaned invalid bone reference on morph '{morph.name}' (bone_id: {ref_bone_id} does not exist)")
+
+        return cleaned_count
 
     @staticmethod
     def join_models(parent_root_object: bpy.types.Object, child_root_objects: Iterable[bpy.types.Object]):
-        # Ensure we are in object mode
-        if bpy.context.mode != 'OBJECT':
-            bpy.ops.object.mode_set(mode='OBJECT')
+        if not parent_root_object or not child_root_objects:
+            return
 
+        context = FnContext.ensure_context()
+
+        bpy.ops.object.mode_set(mode="OBJECT")
+        bpy.ops.object.select_all(action="DESELECT")
         parent_armature_object = FnModel.find_armature_object(parent_root_object)
-
-        # Deselect all objects to ensure a clean selection state before operations
-        bpy.ops.object.select_all(action='DESELECT')
-
         # Get the maximum bone ID of parent model's armature to avoid ID conflicts during merging
         max_bone_id = FnModel.get_max_bone_id(parent_armature_object.pose.bones)
+
+        # Store original transform matrix for parent root object
+        original_matrix_world = parent_root_object.matrix_world.copy()
+        parent_root_object.matrix_world = Matrix.Identity(4)
+        # Apply child transform
+        for child_root_object in child_root_objects:
+            child_root_object.matrix_world = original_matrix_world.inverted() @ child_root_object.matrix_world
+            FnContext.set_active_and_select_single_object(context, child_root_object)
+            bpy.ops.object.transform_apply(location=True, rotation=True, scale=True)
+
+        # Reset object visibility
+        FnContext.set_active_and_select_single_object(context, parent_root_object)
+        bpy.ops.mmd_tools_local.reset_object_visibility()
+        for child_root_object in child_root_objects:
+            FnContext.set_active_and_select_single_object(context, child_root_object)
+            bpy.ops.mmd_tools_local.reset_object_visibility()
+
+        # Store material morph references for all child models
+        related_meshes = {}
 
         # Process each child model
         for child_root_object in child_root_objects:
@@ -340,216 +644,107 @@ class FnModel:
             if child_armature_object is None:
                 continue
 
-            # Ensure we're in the correct mode
-            if bpy.context.mode != 'OBJECT':
-                bpy.ops.object.mode_set(mode='OBJECT')
+            bpy.ops.object.mode_set(mode="OBJECT")
 
             # Update bone IDs
             child_pose_bones = child_armature_object.pose.bones
             child_bone_morphs = child_root_object.mmd_root.bone_morphs
 
             # Reassign bone IDs to avoid conflicts
-            FnModel.realign_bone_ids(child_pose_bones, max_bone_id + 1, child_bone_morphs, child_pose_bones)
+            FnModel.realign_bone_ids(max_bone_id + 1, child_bone_morphs, child_pose_bones)
             max_bone_id = FnModel.get_max_bone_id(child_pose_bones)
 
-            # Save material morph references
-            related_meshes = {}
+            # Save material morph references for this child model
             for material_morph in child_root_object.mmd_root.material_morphs:
                 for material_morph_data in material_morph.data:
                     if material_morph_data.related_mesh_data is not None:
                         related_meshes[material_morph_data] = material_morph_data.related_mesh_data
                         material_morph_data.related_mesh_data = None
 
-            # Store world coordinate positions of child mesh objects
-            child_mesh_transforms = {}
-            try:
-                for mesh in FnModel.__iterate_child_mesh_objects(child_armature_object):
-                    if mesh.name in bpy.context.view_layer.objects.keys():
-                        # Store the original world coordinate matrix
-                        child_mesh_transforms[mesh.name] = mesh.matrix_world.copy()
-            finally:
-                # Restore material references
-                for material_morph_data, mesh_data in related_meshes.items():
-                    material_morph_data.related_mesh_data = mesh_data
+            # Move mesh objects to parent armature using parent_set
+            mesh_objects = list(FnModel.__iterate_child_mesh_objects(child_armature_object))
+            if mesh_objects:
+                with select_object(parent_armature_object, objects=[parent_armature_object] + mesh_objects):
+                    bpy.ops.object.parent_set(type="OBJECT", keep_transform=True)
 
-            # Merge armatures - using a safer method
-            if parent_armature_object and child_armature_object:
-                if (parent_armature_object.name in bpy.context.view_layer.objects.keys() and
-                    child_armature_object.name in bpy.context.view_layer.objects.keys()):
-                    try:
-                        # Store the world coordinate matrix of the child armature
-                        child_armature_matrix = child_armature_object.matrix_world.copy()
+                for mesh in mesh_objects:
+                    FnContext.set_active_and_select_single_object(context, mesh)
+                    bpy.ops.object.transform_apply(location=True, rotation=True, scale=True)
 
-                        # Ensure we're in object mode
-                        if bpy.context.mode != 'OBJECT':
-                            bpy.ops.object.mode_set(mode='OBJECT')
-
-                        # Clear all selections
-                        bpy.ops.object.select_all(action='DESELECT')
-
-                        # Select and activate the parent armature
-                        parent_armature_object.select_set(True)
-                        bpy.context.view_layer.objects.active = parent_armature_object
-
-                        # Select the child armature
-                        child_armature_object.select_set(True)
-
-                        # Execute the join - after merging, objects will remain at the parent armature's position
-                        bpy.ops.object.join()
-
-                    except Exception as e:
-                        logging.error(f"Error joining armatures: {e}")
-                        # Ensure we exit special modes regardless of what happened
-                        if bpy.context.mode != 'OBJECT':
-                            bpy.ops.object.mode_set(mode='OBJECT')
-
-            # Update mesh armature modifiers and restore positions
-            mesh_objects = list(FnModel.__iterate_child_mesh_objects(parent_armature_object))
-            for mesh in mesh_objects:
-                if mesh.name not in bpy.context.view_layer.objects.keys():
-                    continue
-
-                # Handle armature modifiers
-                armature_modifier = None
-                for mod in mesh.modifiers:
-                    if mod.type == 'ARMATURE':
-                        if mod.name == 'mmd_armature' or mod.object is None:
-                            armature_modifier = mod
-                            break
-
-                if armature_modifier is None:
-                    armature_modifier = mesh.modifiers.new("mmd_armature", "ARMATURE")
-
-                armature_modifier.object = parent_armature_object
-
-                # If this mesh was originally part of the child model, restore its world coordinate position
-                if mesh.name in child_mesh_transforms:
-                    mesh.matrix_world = child_mesh_transforms[mesh.name]
+                for mesh in mesh_objects:
+                    armature_modifier = next((mod for mod in mesh.modifiers if mod.type == "ARMATURE"), None)
+                    if armature_modifier is None:
+                        armature_modifier = mesh.modifiers.new("mmd_armature", "ARMATURE")
+                    armature_modifier.object = parent_armature_object
 
             # Handle rigid bodies
             child_rigid_group_object = FnModel.find_rigid_group_object(child_root_object)
-            if child_rigid_group_object and child_rigid_group_object.name in bpy.context.view_layer.objects.keys():
-                parent_rigid_group_object = FnModel.find_rigid_group_object(parent_root_object)
-                if parent_rigid_group_object and parent_rigid_group_object.name in bpy.context.view_layer.objects.keys():
-                    # Safely handle each rigid body
-                    rigid_objects = []
-                    for obj in FnModel.iterate_rigid_body_objects(child_root_object):
-                        if obj.name in bpy.context.view_layer.objects.keys():
-                            rigid_objects.append(obj)
+            if child_rigid_group_object:
+                parent_rigid_group_object = FnModel.ensure_rigid_group_object(context, parent_root_object)
+                rigid_objects = list(FnModel.iterate_rigid_body_objects(child_root_object))
+                if rigid_objects:
+                    with select_object(parent_rigid_group_object, objects=[parent_rigid_group_object] + rigid_objects):
+                        bpy.ops.object.parent_set(type="OBJECT", keep_transform=True)
+                bpy.data.objects.remove(child_rigid_group_object)
 
-                    if rigid_objects:
-                        # Ensure we're in object mode
-                        if bpy.context.mode != 'OBJECT':
-                            bpy.ops.object.mode_set(mode='OBJECT')
-
-                        for rigid_obj in rigid_objects:
-                            # Save world coordinate position
-                            original_matrix_world = rigid_obj.matrix_world.copy()
-
-                            # Set parent object
-                            rigid_obj.parent = parent_rigid_group_object
-                            rigid_obj.parent_type = 'OBJECT'
-
-                            # Restore world coordinate position
-                            rigid_obj.matrix_world = original_matrix_world
-
-                    # Safely remove the original group
-                    try:
-                        if child_rigid_group_object.name in bpy.data.objects:
-                            bpy.data.objects.remove(child_rigid_group_object)
-                    except Exception as e:
-                        logging.error(f"Error removing rigid group: {e}")
-
-            # Handle joints - similar to the rigid body approach
+            # Handle joints
             child_joint_group_object = FnModel.find_joint_group_object(child_root_object)
-            if child_joint_group_object and child_joint_group_object.name in bpy.context.view_layer.objects.keys():
-                parent_joint_group_object = FnModel.find_joint_group_object(parent_root_object)
-                if parent_joint_group_object and parent_joint_group_object.name in bpy.context.view_layer.objects.keys():
-                    joint_objects = []
-                    for obj in FnModel.iterate_joint_objects(child_root_object):
-                        if obj.name in bpy.context.view_layer.objects.keys():
-                            joint_objects.append(obj)
+            if child_joint_group_object:
+                parent_joint_group_object = FnModel.ensure_joint_group_object(context, parent_root_object)
+                joint_objects = list(FnModel.iterate_joint_objects(child_root_object))
+                if joint_objects:
+                    with select_object(parent_joint_group_object, objects=[parent_joint_group_object] + joint_objects):
+                        bpy.ops.object.parent_set(type="OBJECT", keep_transform=True)
+                bpy.data.objects.remove(child_joint_group_object)
 
-                    if joint_objects:
-                        # Ensure we're in object mode
-                        if bpy.context.mode != 'OBJECT':
-                            bpy.ops.object.mode_set(mode='OBJECT')
-
-                        for joint_obj in joint_objects:
-                            # Save world coordinate position
-                            original_matrix_world = joint_obj.matrix_world.copy()
-
-                            # Set parent object
-                            joint_obj.parent = parent_joint_group_object
-                            joint_obj.parent_type = 'OBJECT'
-
-                            # Restore world coordinate position
-                            joint_obj.matrix_world = original_matrix_world
-
-                    # Safely remove the original group
-                    try:
-                        if child_joint_group_object.name in bpy.data.objects:
-                            bpy.data.objects.remove(child_joint_group_object)
-                    except Exception as e:
-                        logging.error(f"Error removing joint group: {e}")
-
-            # Handle temporary objects - similar approach
+            # Handle temporary objects
             child_temporary_group_object = FnModel.find_temporary_group_object(child_root_object)
-            if child_temporary_group_object and child_temporary_group_object.name in bpy.context.view_layer.objects.keys():
-                parent_temporary_group_object = FnModel.find_temporary_group_object(parent_root_object)
-                if parent_temporary_group_object and parent_temporary_group_object.name in bpy.context.view_layer.objects.keys():
-                    temp_objects = []
-                    for obj in FnModel.iterate_temporary_objects(child_root_object):
-                        if obj.name in bpy.context.view_layer.objects.keys():
-                            temp_objects.append(obj)
-
-                    if temp_objects:
-                        # Ensure we're in object mode
-                        if bpy.context.mode != 'OBJECT':
-                            bpy.ops.object.mode_set(mode='OBJECT')
-
-                        for temp_obj in temp_objects:
-                            # Save world coordinate position
-                            original_matrix_world = temp_obj.matrix_world.copy()
-
-                            # Set parent object
-                            temp_obj.parent = parent_temporary_group_object
-                            temp_obj.parent_type = 'OBJECT'
-
-                            # Restore world coordinate position
-                            temp_obj.matrix_world = original_matrix_world
-
-                    # Safely remove child objects and groups
-                    try:
-                        child_objects = []
-                        for obj in FnModel.iterate_child_objects(child_temporary_group_object):
-                            if obj.name in bpy.data.objects:
-                                child_objects.append(obj)
-                        for obj in child_objects:
-                            bpy.data.objects.remove(obj)
-
-                        if child_temporary_group_object.name in bpy.data.objects:
-                            bpy.data.objects.remove(child_temporary_group_object)
-                    except Exception as e:
-                        logging.error(f"Error removing temporary objects: {e}")
+            if child_temporary_group_object:
+                parent_temporary_group_object = FnModel.ensure_temporary_group_object(context, parent_root_object)
+                temp_objects = list(FnModel.iterate_temporary_objects(child_root_object))
+                if temp_objects:
+                    with select_object(parent_temporary_group_object, objects=[parent_temporary_group_object] + temp_objects):
+                        bpy.ops.object.parent_set(type="OBJECT", keep_transform=True)
+                bpy.data.objects.remove(child_temporary_group_object)
 
             # Copy MMD root properties
-            try:
-                FnModel.copy_mmd_root(parent_root_object, child_root_object, overwrite=False)
-            except Exception as e:
-                logging.error(f"Error copying MMD root: {e}")
+            FnModel.copy_mmd_root(parent_root_object, child_root_object, overwrite=False)
 
-            # Safely remove empty child root objects
-            try:
-                if child_root_object and len(child_root_object.children) == 0:
-                    if child_root_object.name in bpy.data.objects:
-                        bpy.data.objects.remove(child_root_object)
-            except Exception as e:
-                logging.error(f"Error removing child root object: {e}")
+        # Clean additional transform before join
+        bpy.ops.object.mode_set(mode="OBJECT")
+        FnContext.set_active_and_select_single_object(context, parent_root_object)
+        bpy.ops.mmd_tools_local.clean_additional_transform()
+        for child_root_object in child_root_objects:
+            FnContext.set_active_and_select_single_object(context, child_root_object)
+            bpy.ops.mmd_tools_local.clean_additional_transform()
 
-        # Clean and reapply additional transformations to properly set up all bones and constraints
+        # Join all child armatures to parent armature
+        bpy.ops.object.mode_set(mode="OBJECT")
+        child_armature_objects = [FnModel.find_armature_object(child_root) for child_root in child_root_objects if FnModel.find_armature_object(child_root) is not None]
+        armature_data_to_remove = [child_arm.data for child_arm in child_armature_objects if child_arm.data]
+        if child_armature_objects:
+            with select_object(parent_armature_object, objects=[parent_armature_object] + child_armature_objects):
+                bpy.ops.object.join()
+        for armature_data in armature_data_to_remove:
+            if armature_data and armature_data.users == 0:
+                bpy.data.armatures.remove(armature_data)
+
+        # Apply additional transform after join
+        FnContext.set_active_object(context, parent_root_object)
         bpy.ops.mmd_tools_local.clean_additional_transform()
         bpy.ops.mmd_tools_local.apply_additional_transform()
+
+        # Remove empty child root objects
+        for child_root_object in child_root_objects:
+            assert len(child_root_object.children) == 0
+            bpy.data.objects.remove(child_root_object)
+
+        # Restore material morph references for all child models
+        for material_morph_data, mesh_data in related_meshes.items():
+            material_morph_data.related_mesh_data = mesh_data
+
+        # Restore original transform matrix for parent root object
+        parent_root_object.matrix_world = original_matrix_world
 
     @staticmethod
     def _add_armature_modifier(mesh_object: bpy.types.Object, armature_object: bpy.types.Object) -> bpy.types.ArmatureModifier:
@@ -557,9 +752,9 @@ class FnModel:
             if m.type != "ARMATURE":
                 continue
             # already has armature modifier.
-            return cast(bpy.types.ArmatureModifier, m)
+            return cast("bpy.types.ArmatureModifier", m)
 
-        modifier = cast(bpy.types.ArmatureModifier, mesh_object.modifiers.new(name="Armature", type="ARMATURE"))
+        modifier = cast("bpy.types.ArmatureModifier", mesh_object.modifiers.new(name="Armature", type="ARMATURE"))
         modifier.object = armature_object
         modifier.use_vertex_groups = True
         modifier.name = "mmd_armature"
@@ -581,9 +776,6 @@ class FnModel:
             if not FnModel.is_mesh_object(mesh_object):
                 continue
 
-            if FnModel.find_root_object(mesh_object) is not None:
-                continue
-
             mesh_root_object = __get_root_object(mesh_object)
             original_matrix_world = mesh_root_object.matrix_world
             mesh_root_object.parent_type = "OBJECT"
@@ -592,31 +784,6 @@ class FnModel:
 
             if add_armature_modifier:
                 FnModel._add_armature_modifier(mesh_object, armature_object)
-
-    @staticmethod
-    def add_missing_vertex_groups_from_bones(root_object: bpy.types.Object, mesh_object: bpy.types.Object, search_in_all_meshes: bool):
-        armature_object = FnModel.find_armature_object(root_object)
-        if armature_object is None:
-            raise ValueError(f"Armature object not found in {root_object}")
-
-        vertex_group_names: Set[str] = set()
-
-        search_meshes = FnModel.iterate_mesh_objects(root_object) if search_in_all_meshes else [mesh_object]
-
-        for search_mesh in search_meshes:
-            vertex_group_names.update(search_mesh.vertex_groups.keys())
-
-        pose_bone: bpy.types.PoseBone
-        for pose_bone in armature_object.pose.bones:
-            pose_bone_name = pose_bone.name
-
-            if pose_bone_name in vertex_group_names:
-                continue
-
-            if pose_bone_name.startswith("_"):
-                continue
-
-            mesh_object.vertex_groups.new(name=pose_bone_name)
 
     @staticmethod
     def change_mmd_ik_loop_factor(root_object: bpy.types.Object, new_ik_loop_factor: int):
@@ -628,7 +795,7 @@ class FnModel:
 
         armature_object = FnModel.find_armature_object(root_object)
         for pose_bone in armature_object.pose.bones:
-            for constraint in (cast(bpy.types.KinematicConstraint, c) for c in pose_bone.constraints if c.type == "IK"):
+            for constraint in (cast("bpy.types.KinematicConstraint", c) for c in pose_bone.constraints if c.type == "IK"):
                 iterations = int(constraint.iterations * new_ik_loop_factor / old_ik_loop_factor)
                 logging.info("Update %s of %s: %d -> %d", constraint.name, pose_bone.name, constraint.iterations, iterations)
                 constraint.iterations = iterations
@@ -816,7 +983,7 @@ class Model:
             bone_name_english = "Root"
 
             # Create the root bone
-            with bpyutils.edit_object(armature_object) as data:
+            with edit_object(armature_object) as data:
                 bone = data.edit_bones.new(name=bone_name)
                 bone.head = (0.0, 0.0, 0.0)
                 bone.tail = (0.0, 0.0, getattr(root, Props.empty_display_size))
@@ -852,11 +1019,11 @@ class Model:
         FnMorph.load_morphs(self)
 
     def create_ik_constraint(self, bone, ik_target):
-        """create IK constraint
+        """Create IK constraint
 
         Args:
             bone: A pose bone to add a IK constraint
-            id_target: A pose bone for IK target
+            ik_target: A pose bone for IK target
 
         Returns:
             The bpy.types.KinematicConstraint object created. It is set target
@@ -947,20 +1114,16 @@ class Model:
         return None
 
     def findMesh(self, mesh_name) -> Optional[bpy.types.Object]:
-        """
-        Helper method to find a mesh by name
-        """
+        """Find the mesh by name"""
         if mesh_name == "":
             return None
         for mesh in self.meshes():
-            if mesh.name == mesh_name or mesh.data.name == mesh_name:
+            if mesh_name in {mesh.name, mesh.data.name}:
                 return mesh
         return None
 
     def findMeshByIndex(self, index: int) -> Optional[bpy.types.Object]:
-        """
-        Helper method to find the mesh by index
-        """
+        """Find the mesh by index"""
         if index < 0:
             return None
         for i, mesh in enumerate(self.meshes()):
@@ -969,13 +1132,11 @@ class Model:
         return None
 
     def getMeshIndex(self, mesh_name: str) -> int:
-        """
-        Helper method to get the index of a mesh. Returns -1 if not found
-        """
+        """Get the index of a mesh. Returns -1 if not found"""
         if mesh_name == "":
             return -1
         for i, mesh in enumerate(self.meshes()):
-            if mesh.name == mesh_name or mesh.data.name == mesh_name:
+            if mesh_name in {mesh.name, mesh.data.name}:
                 return i
         return -1
 
@@ -989,9 +1150,7 @@ class Model:
         return FnModel.iterate_temporary_objects(self.__root, rigid_track_only)
 
     def materials(self) -> Iterator[bpy.types.Material]:
-        """
-        Helper method to list all materials in all meshes
-        """
+        """List all materials in all meshes"""
         materials = {}  # Use dict instead of set to guarantee preserve order
         for mesh in self.meshes():
             materials.update((slot.material, 0) for slot in mesh.material_slots if slot.material is not None)
@@ -1059,7 +1218,7 @@ class Model:
             if rigid_type == rigid_body.MODE_STATIC:
                 i.parent_type = "OBJECT"
                 i.parent = self.rigidGroupObject()
-            elif rigid_type in [rigid_body.MODE_DYNAMIC, rigid_body.MODE_DYNAMIC_BONE]:
+            elif rigid_type in {rigid_body.MODE_DYNAMIC, rigid_body.MODE_DYNAMIC_BONE}:
                 arm = relation.target
                 bone_name = relation.subtarget
                 if arm is not None and bone_name != "":
@@ -1092,7 +1251,7 @@ class Model:
 
     def __restoreTransforms(self, obj):
         for attr in ("location", "rotation_euler"):
-            attr_name = "__backup_%s__" % attr
+            attr_name = f"__backup_{attr}__"
             val = obj.get(attr_name, None)
             if val is not None:
                 setattr(obj, attr, val)
@@ -1100,7 +1259,7 @@ class Model:
 
     def __backupTransforms(self, obj):
         for attr in ("location", "rotation_euler"):
-            attr_name = "__backup_%s__" % attr
+            attr_name = f"__backup_{attr}__"
             if attr_name in obj:  # should not happen in normal build/clean cycle
                 continue
             obj[attr_name] = getattr(obj, attr, None)
@@ -1117,7 +1276,7 @@ class Model:
             relation = i.constraints["mmd_tools_local_rigid_parent"]
             relation.mute = True
             # mute IK
-            if int(i.mmd_rigid.type) in [rigid_body.MODE_DYNAMIC, rigid_body.MODE_DYNAMIC_BONE]:
+            if int(i.mmd_rigid.type) in {rigid_body.MODE_DYNAMIC, rigid_body.MODE_DYNAMIC_BONE}:
                 arm = relation.target
                 bone_name = relation.subtarget
                 if arm is not None and bone_name != "":
@@ -1221,7 +1380,7 @@ class Model:
                         fake_child.location = t
                         fake_child.rotation_euler = r.to_euler(fake_child.rotation_mode)
 
-            elif rigid_type in [rigid_body.MODE_DYNAMIC, rigid_body.MODE_DYNAMIC_BONE]:
+            elif rigid_type in {rigid_body.MODE_DYNAMIC, rigid_body.MODE_DYNAMIC_BONE}:
                 m = target_bone.matrix @ target_bone.bone.matrix_local.inverted()
                 self.__rigid_body_matrix_map[rigid_obj] = m
                 t, r, s = (m @ rigid_obj.matrix_local).decompose()
@@ -1272,7 +1431,8 @@ class Model:
 
         rb.collision_shape = rigid.shape
 
-    def __getRigidRange(self, obj):
+    @staticmethod
+    def __getRigidRange(obj):
         return (Vector(obj.bound_box[0]) - Vector(obj.bound_box[6])).length
 
     def __createNonCollisionConstraint(self, nonCollisionJointTable):
@@ -1284,7 +1444,7 @@ class Model:
         logging.debug("-" * 60)
         logging.debug(" creating ncc, counts: %d", total_len)
 
-        ncc_obj = bpyutils.createObject(name="ncc", object_data=None)
+        ncc_obj = createObject(name="ncc", object_data=None)
         ncc_obj.location = [0, 0, 0]
         setattr(ncc_obj, Props.empty_display_type, "ARROWS")
         setattr(ncc_obj, Props.empty_display_size, 0.5 * getattr(self.__root, Props.empty_display_size))
@@ -1296,10 +1456,10 @@ class Model:
         rb = ncc_obj.rigid_body_constraint
         rb.disable_collisions = True
 
-        ncc_objs = bpyutils.duplicateObject(ncc_obj, total_len)
+        ncc_objs = duplicateObject(ncc_obj, total_len)
         logging.debug(" created %d ncc.", len(ncc_objs))
 
-        for ncc_obj, pair in zip(ncc_objs, nonCollisionJointTable):
+        for ncc_obj, pair in zip(ncc_objs, nonCollisionJointTable, strict=False):
             rbc = ncc_obj.rigid_body_constraint
             rbc.object1, rbc.object2 = pair
             ncc_obj.hide_set(True)
@@ -1371,7 +1531,7 @@ class Model:
         armature_object = self.armature()
 
         armature: bpy.types.Armature
-        with bpyutils.edit_object(armature_object) as armature:
+        with edit_object(armature_object) as armature:
             edit_bones = armature.edit_bones
             rigid_body_object: bpy.types.Object
             for rigid_body_object in self.rigidBodies():

--- a/extern_tools/mmd_tools_local/core/morph.py
+++ b/extern_tools/mmd_tools_local/core/morph.py
@@ -2,6 +2,7 @@
 # This file is part of MMD Tools.
 
 import logging
+import math
 import re
 from typing import TYPE_CHECKING, Tuple, cast
 
@@ -141,7 +142,7 @@ class FnMorph:
     @staticmethod
     def overwrite_bone_morphs_from_action_pose(armature_object):
         armature = armature_object.id_data
-        
+
         # Use animation_data and action instead of action_pose
         if armature.animation_data is None or armature.animation_data.action is None:
             logging.warning('[WARNING] armature "%s" has no animation data or action', armature_object.name)
@@ -158,7 +159,7 @@ class FnMorph:
         bone_morphs = mmd_root.bone_morphs
 
         utils.selectAObject(armature_object)
-        original_mode = bpy.context.object.mode
+        original_mode = bpy.context.active_object.mode
         bpy.ops.object.mode_set(mode="POSE")
         try:
             for index, pose_marker in enumerate(pose_markers):
@@ -169,7 +170,7 @@ class FnMorph:
 
                 bpy.ops.pose.select_all(action="SELECT")
                 bpy.ops.pose.transforms_clear()
-                
+
                 frame = pose_marker.frame
                 bpy.context.scene.frame_set(int(frame))
 
@@ -215,7 +216,7 @@ class FnMorph:
             for val in morph.data:
                 i = val.index
                 if i in offset_map:
-                    offset_map[i] = [a + b for a, b in zip(offset_map[i], val.offset)]
+                    offset_map[i] = [a + b for a, b in zip(offset_map[i], val.offset, strict=False)]
                 else:
                     offset_map[i] = val.offset
         return offset_map
@@ -240,9 +241,9 @@ class FnMorph:
         max_value = max(max(abs(x) for x in v) for v in offset_map.values() or ([0],))
         scale = morph.vertex_group_scale = max(abs(morph.vertex_group_scale), max_value)
         for idx, offset in offset_map.items():
-            for val, axis in zip(offset, "XYZW"):
+            for val, axis in zip(offset, "XYZW", strict=False):
                 if abs(val) > 1e-4:
-                    vg_name = "UV_{0}{1}{2}".format(morph_name, "-" if val < 0 else "+", axis)
+                    vg_name = f"UV_{morph_name}{'-' if val < 0 else '+'}{axis}"
                     vg = vertex_groups.get(vg_name, None) or vertex_groups.new(name=vg_name)
                     vg.add(index=[idx], weight=abs(val) / scale, type="REPLACE")
 
@@ -270,24 +271,24 @@ class FnMorph:
         """Clean duplicated material_morphs and data from mmd_root_object.mmd_root.material_morphs[].data[]"""
         mmd_root = mmd_root_object.mmd_root
 
-        def morph_data_equals(l, r) -> bool:
+        def morph_data_equals(left, right) -> bool:
             return (
-                l.related_mesh_data == r.related_mesh_data
-                and l.offset_type == r.offset_type
-                and l.material == r.material
-                and all(a == b for a, b in zip(l.diffuse_color, r.diffuse_color))
-                and all(a == b for a, b in zip(l.specular_color, r.specular_color))
-                and l.shininess == r.shininess
-                and all(a == b for a, b in zip(l.ambient_color, r.ambient_color))
-                and all(a == b for a, b in zip(l.edge_color, r.edge_color))
-                and l.edge_weight == r.edge_weight
-                and all(a == b for a, b in zip(l.texture_factor, r.texture_factor))
-                and all(a == b for a, b in zip(l.sphere_texture_factor, r.sphere_texture_factor))
-                and all(a == b for a, b in zip(l.toon_texture_factor, r.toon_texture_factor))
+                left.related_mesh_data == right.related_mesh_data
+                and left.offset_type == right.offset_type
+                and left.material == right.material
+                and all(a == b for a, b in zip(left.diffuse_color, right.diffuse_color, strict=False))
+                and all(a == b for a, b in zip(left.specular_color, right.specular_color, strict=False))
+                and left.shininess == right.shininess
+                and all(a == b for a, b in zip(left.ambient_color, right.ambient_color, strict=False))
+                and all(a == b for a, b in zip(left.edge_color, right.edge_color, strict=False))
+                and left.edge_weight == right.edge_weight
+                and all(a == b for a, b in zip(left.texture_factor, right.texture_factor, strict=False))
+                and all(a == b for a, b in zip(left.sphere_texture_factor, right.sphere_texture_factor, strict=False))
+                and all(a == b for a, b in zip(left.toon_texture_factor, right.toon_texture_factor, strict=False))
             )
 
-        def morph_equals(l, r) -> bool:
-            return len(l.data) == len(r.data) and all(morph_data_equals(a, b) for a, b in zip(l.data, r.data))
+        def morph_equals(left, right) -> bool:
+            return len(left.data) == len(right.data) and all(morph_data_equals(a, b) for a, b in zip(left.data, right.data, strict=False))
 
         # Remove duplicated mmd_root.material_morphs.data[]
         for material_morph in mmd_root.material_morphs:
@@ -385,7 +386,7 @@ class _MorphSlider:
     def __driver_variables(id_data, path, index=-1):
         d = id_data.driver_add(path, index)
         variables = d.driver.variables
-        for x in variables:
+        for x in reversed(variables):
             variables.remove(x)
         return d.driver, variables
 
@@ -416,21 +417,19 @@ class _MorphSlider:
         return not d or d.driver.expression == "".join(("*w", "+g", "v")[-1 if i < 1 else i % 2] + str(i + 1) for i in range(len(d.driver.variables)))
 
     def __cleanup(self, names_in_use=None):
-        from math import ceil, floor
-
         names_in_use = names_in_use or {}
         rig = self.__rig
         morph_sliders = self.placeholder()
         morph_sliders = morph_sliders.data.shape_keys.key_blocks if morph_sliders else {}
         for mesh_object in rig.meshes():
-            for kb in getattr(mesh_object.data.shape_keys, "key_blocks", cast(Tuple[bpy.types.ShapeKey], ())):
+            for kb in getattr(mesh_object.data.shape_keys, "key_blocks", cast("Tuple[bpy.types.ShapeKey]", ())):
                 if kb.name in names_in_use:
                     continue
 
                 if kb.name.startswith("mmd_bind"):
                     kb.driver_remove("value")
                     ms = morph_sliders[kb.relative_key.name]
-                    kb.relative_key.slider_min, kb.relative_key.slider_max = min(ms.slider_min, floor(ms.value)), max(ms.slider_max, ceil(ms.value))
+                    kb.relative_key.slider_min, kb.relative_key.slider_max = min(ms.slider_min, math.floor(ms.value)), max(ms.slider_max, math.ceil(ms.value))
                     kb.relative_key.value = ms.value
                     kb.relative_key.mute = False
                     FnObject.mesh_remove_shape_key(mesh_object, kb)
@@ -438,9 +437,9 @@ class _MorphSlider:
                 elif kb.name in morph_sliders and self.__shape_key_driver_check(kb):
                     ms = morph_sliders[kb.name]
                     kb.driver_remove("value")
-                    kb.slider_min, kb.slider_max = min(ms.slider_min, floor(kb.value)), max(ms.slider_max, ceil(kb.value))
+                    kb.slider_min, kb.slider_max = min(ms.slider_min, math.floor(kb.value)), max(ms.slider_max, math.ceil(kb.value))
 
-            for m in mesh_object.modifiers:  # uv morph
+            for m in reversed(mesh_object.modifiers):  # uv morph
                 if m.name.startswith("mmd_bind") and m.name not in names_in_use:
                     mesh_object.modifiers.remove(m)
 
@@ -455,7 +454,7 @@ class _MorphSlider:
         attributes = set(TransformConstraintOp.min_max_attributes("LOCATION", "to"))
         attributes |= set(TransformConstraintOp.min_max_attributes("ROTATION", "to"))
         for b in rig.armature().pose.bones:
-            for c in b.constraints:
+            for c in reversed(b.constraints):
                 if c.name.startswith("mmd_bind") and c.name[:-4] not in names_in_use:
                     for attr in attributes:
                         c.driver_remove(attr)
@@ -526,7 +525,7 @@ class _MorphSlider:
                 shape_key_map.setdefault(name_bind, []).append((kb_bind, data_path, groups))
                 group_map.setdefault(("vertex_morphs", kb_name), []).append(groups)
 
-            uv_layers = [l.name for l in mesh_object.data.uv_layers if not l.name.startswith("_")]
+            uv_layers = [layer.name for layer in mesh_object.data.uv_layers if not layer.name.startswith("_")]
             uv_layers += [""] * (5 - len(uv_layers))
             for vg, morph_name, axis in FnMorph.get_uv_morph_vertex_groups(mesh_object):
                 morph = mmd_root.uv_morphs.get(morph_name, None)
@@ -591,7 +590,7 @@ class _MorphSlider:
 
             used_bone_names = bone_offset_map.keys() | uv_morph_map.keys()
             used_bone_names.add(ctrl_base.name)
-            for b in edit_bones:  # cleanup
+            for b in reversed(edit_bones):  # cleanup
                 if b.name.startswith("mmd_bind") and b.name not in used_bone_names:
                     edit_bones.remove(b)
 
@@ -629,7 +628,7 @@ class _MorphSlider:
             return expression
 
         # vertex morphs
-        for kb_bind, morph_data_path, groups in (i for l in shape_key_map.values() for i in l):
+        for kb_bind, morph_data_path, groups in (i for value_list in shape_key_map.values() for i in value_list):
             driver, variables = self.__driver_variables(kb_bind, "value")
             var = self.__add_single_prop(variables, obj, morph_data_path, "v")
             if kb_bind.name.startswith("mmd_bind"):
@@ -654,8 +653,6 @@ class _MorphSlider:
                 sign = "-" if attr.startswith("to_min") else ""
                 driver.expression = f"{sign}{val_str}*({expression})"
 
-        from math import pi
-
         attributes_rot = TransformConstraintOp.min_max_attributes("ROTATION", "to")
         attributes_loc = TransformConstraintOp.min_max_attributes("LOCATION", "to")
         for morph_name, data, bname, morph_data_path, groups in bone_offset_map.values():
@@ -665,7 +662,7 @@ class _MorphSlider:
             b.is_mmd_shadow_bone = True
             b.mmd_shadow_bone_type = "BIND"
             pb = armObj.pose.bones[data.bone]
-            __config_bone_morph(pb.constraints, "ROTATION", attributes_rot, pi, "pi")
+            __config_bone_morph(pb.constraints, "ROTATION", attributes_rot, math.pi, "pi")
             __config_bone_morph(pb.constraints, "LOCATION", attributes_loc, 100, "100")
 
         # uv morphs
@@ -674,7 +671,7 @@ class _MorphSlider:
         b = arm.pose.bones["mmd_bind_ctrl_base"]
         b.is_mmd_shadow_bone = True
         b.mmd_shadow_bone_type = "BIND"
-        for bname, data_path, scale_path, groups in (i for l in uv_morph_map.values() for i in l):
+        for bname, data_path, scale_path, groups in (i for value_list in uv_morph_map.values() for i in value_list):
             b = arm.pose.bones[bname]
             b.is_mmd_shadow_bone = True
             b.mmd_shadow_bone_type = "BIND"
@@ -690,7 +687,7 @@ class _MorphSlider:
 
         def __config_material_morph(mat, morph_list):
             nodes = _MaterialMorph.setup_morph_nodes(mat, tuple(x[1] for x in morph_list))
-            for (morph_name, data, name_bind), node in zip(morph_list, nodes):
+            for (morph_name, data, name_bind), node in zip(morph_list, nodes, strict=False):
                 node.label, node.name = morph_name, name_bind
                 data_path, groups = group_dict[morph_name]
                 driver, variables = self.__driver_variables(mat.node_tree, node.inputs[0].path_from_id("default_value"))
@@ -735,15 +732,14 @@ class MigrationFnMorph:
                                 del morph_data["related_mesh"]
                             continue
 
-                        else:
-                            # Compat case. The new version mmd_tools_local saved. And old version mmd_tools_local edit. Then new version mmd_tools_local load again.
-                            # Go update path.
-                            pass
+                        # Compat case. The new version mmd_tools_local saved. And old version mmd_tools_local edit. Then new version mmd_tools_local load again.
+                        # Go update path.
+                        pass
 
                     morph_data.material_data = None
                     if "material_id" in morph_data:
                         mat_id = morph_data["material_id"]
-                        if mat_id != -1:
+                        if mat_id >= 0:
                             fnMat = FnMaterial.from_material_id(mat_id)
                             if fnMat:
                                 morph_data.material_data = fnMat.material

--- a/extern_tools/mmd_tools_local/core/pmd/__init__.py
+++ b/extern_tools/mmd_tools_local/core/pmd/__init__.py
@@ -69,10 +69,16 @@ class FileReadStream(FileStream):
         return v
 
     def readStr(self, size):
+        r"""Read a string of given byte size from file, decode it as cp932.
+        Example:
+            original = "あ"
+            buf = b"\x82\xa0\x00\xfd\xfd\xfd\xfd\xfd\xfd\xfd\xfd\xfd\xfd\xfd\xfd\xfd\xfd\xfd\xfd\xfd"
+            result = "あ"
+        """
         buf = self.__fin.read(size)
         if buf[0] == b"\xfd":
             return ""
-        return buf.split(b"\x00")[0].decode("shift_jis", errors="replace")
+        return buf.split(b"\x00")[0].decode("cp932", errors="replace")
 
     def readFloat(self):
         (v,) = struct.unpack("<f", self.__fin.read(4))
@@ -158,11 +164,11 @@ class Material:
         tex_path = fs.readStr(20)
         tex_path = tex_path.replace("\\", os.path.sep)
         t = tex_path.split("*")
-        if not re.search(r"\.sp([ha])$", t[0], flags=re.I):
+        if not re.search(r"\.sp([ha])$", t[0], flags=re.IGNORECASE):
             self.texture_path = t.pop(0)
         if len(t) > 0:
             self.sphere_path = t.pop(0)
-            if "aA".find(self.sphere_path[-1]) != -1:
+            if self.sphere_path[-1] in "aA":
                 self.sphere_mode = 2
 
 
@@ -615,8 +621,8 @@ def load(path):
         model = Model()
         try:
             model.load(fs)
-        except struct.error as e:
-            logging.error(" * Corrupted file: %s", e)
+        except struct.error:
+            logging.exception(" * Corrupted file")
             # raise
 
         logging.info(" Finish loading.")

--- a/extern_tools/mmd_tools_local/core/pmd/importer.py
+++ b/extern_tools/mmd_tools_local/core/pmd/importer.py
@@ -3,11 +3,11 @@
 
 import copy
 import logging
+import math
 import os
 import re
-from math import radians
 
-import mathutils
+from mathutils import Vector
 
 from .. import pmd, pmx
 from ..pmx import importer as import_pmx
@@ -93,7 +93,7 @@ def import_pmd_to_pmx(filepath):
         pmx_bone.name_e = bone.name_e
         pmx_bone.location = bone.position
         pmx_bone.parent = bone.parent
-        if bone.type != 9 and bone.type != 8 and bone.tail_bone > 0:
+        if bone.type not in {9, 8} and bone.tail_bone > 0:
             pmx_bone.displayConnection = bone.tail_bone  # Corresponds to 'BONE' type
         else:
             pmx_bone.displayConnection = -1  # Corresponds to 'NONE' type
@@ -121,8 +121,8 @@ def import_pmd_to_pmx(filepath):
             pmx_bone.isMovable = False
         elif bone.type == 8:
             pmx_bone.isMovable = False
-            tail_loc = mathutils.Vector(pmd_model.bones[bone.tail_bone].position)
-            loc = mathutils.Vector(bone.position)
+            tail_loc = Vector(pmd_model.bones[bone.tail_bone].position)
+            loc = Vector(bone.position)
             vec = tail_loc - loc
             vec.normalize()
             pmx_bone.axis = list(vec)
@@ -134,7 +134,7 @@ def import_pmd_to_pmx(filepath):
 
         pmx_model.bones.append(pmx_bone)
 
-        if re.search("ひざ$", pmx_bone.name):
+        if re.search(r"ひざ$", pmx_bone.name):
             knee_bones.append(i)
 
     for i in pmx_model.bones:
@@ -168,8 +168,8 @@ def import_pmd_to_pmx(filepath):
             ik_link = pmx.IKLink()
             ik_link.target = i
             if i in knee_bones:
-                ik_link.maximumAngle = [radians(-0.5), 0.0, 0.0]
-                ik_link.minimumAngle = [radians(-180.0), 0.0, 0.0]
+                ik_link.maximumAngle = [math.radians(-0.5), 0.0, 0.0]
+                ik_link.minimumAngle = [math.radians(-180.0), 0.0, 0.0]
                 logging.info("  Add knee constraints to %s", i)
             logging.debug("  IKLink: %s(index: %d)", pmx_model.bones[i].name, i)
             pmx_bone.ik_links.append(ik_link)
@@ -248,9 +248,7 @@ def import_pmd_to_pmx(filepath):
     else:
         if len(t) > 1:
             logging.warning("Found two or more base morphs.")
-        vertex_map = []
-        for i in t[0].data:
-            vertex_map.append(i.index)
+        vertex_map = [i.index for i in t[0].data]
 
         for morph in pmd_model.morphs:
             logging.debug("Vertex Morph: %s", morph.name)
@@ -312,7 +310,7 @@ def import_pmd_to_pmx(filepath):
             t = 0
         else:
             t = rigid.bone
-        pmx_rigid.location = mathutils.Vector(pmx_model.bones[t].location) + mathutils.Vector(rigid.location)
+        pmx_rigid.location = Vector(pmx_model.bones[t].location) + Vector(rigid.location)
         pmx_rigid.rotation = rigid.rotation
 
         pmx_rigid.mass = rigid.mass

--- a/extern_tools/mmd_tools_local/core/pmx/__init__.py
+++ b/extern_tools/mmd_tools_local/core/pmx/__init__.py
@@ -8,8 +8,11 @@ import struct
 
 class InvalidFileError(Exception):
     pass
+
+
 class UnsupportedVersionError(Exception):
     pass
+
 
 class FileStream:
     def __init__(self, path, file_obj, pmx_header):
@@ -40,25 +43,25 @@ class FileStream:
             self.__file_obj.close()
             self.__file_obj = None
 
+
 class FileReadStream(FileStream):
     def __init__(self, path, pmx_header=None):
-        self.__fin = open(path, 'rb')
+        self.__fin = open(path, "rb")
         FileStream.__init__(self, path, self.__fin, pmx_header)
 
     def __readIndex(self, size, typedict):
         index = None
-        if size in typedict :
+        if size in typedict:
             index, = struct.unpack(typedict[size], self.__fin.read(size))
         else:
-            raise ValueError('invalid data size %s'%str(size))
+            raise ValueError(f"invalid data size {str(size)}")
         return index
 
     def __readSignedIndex(self, size):
-        return self.__readIndex(size, { 1 :"<b", 2 :"<h", 4 :"<i"})
+        return self.__readIndex(size, {1: "<b", 2: "<h", 4: "<i"})
 
     def __readUnsignedIndex(self, size):
-        return self.__readIndex(size, { 1 :"<B", 2 :"<H", 4 :"<I"})
-
+        return self.__readIndex(size, {1: "<B", 2: "<H", 4: "<I"})
 
     # READ methods for indexes
     def readVertexIndex(self):
@@ -81,57 +84,57 @@ class FileReadStream(FileStream):
 
     # READ / WRITE methods for general types
     def readInt(self):
-        v, = struct.unpack('<i', self.__fin.read(4))
+        v, = struct.unpack("<i", self.__fin.read(4))
         return v
 
     def readShort(self):
-        v, = struct.unpack('<h', self.__fin.read(2))
+        v, = struct.unpack("<h", self.__fin.read(2))
         return v
 
     def readUnsignedShort(self):
-        v, = struct.unpack('<H', self.__fin.read(2))
+        v, = struct.unpack("<H", self.__fin.read(2))
         return v
 
     def readStr(self):
         length = self.readInt()
-        buf, = struct.unpack('<%ds'%length, self.__fin.read(length))
-        return str(buf, self.header().encoding.charset, errors='replace')
+        buf, = struct.unpack("<%ds" % length, self.__fin.read(length))
+        return str(buf, self.header().encoding.charset, errors="replace")
 
     def readFloat(self):
-        v, = struct.unpack('<f', self.__fin.read(4))
+        v, = struct.unpack("<f", self.__fin.read(4))
         return v
 
     def readVector(self, size):
-        return struct.unpack('<'+'f'*size, self.__fin.read(4*size))
+        return struct.unpack("<" + "f" * size, self.__fin.read(4 * size))
 
     def readByte(self):
-        v, = struct.unpack('<B', self.__fin.read(1))
+        v, = struct.unpack("<B", self.__fin.read(1))
         return v
 
     def readBytes(self, length):
         return self.__fin.read(length)
 
     def readSignedByte(self):
-        v, = struct.unpack('<b', self.__fin.read(1))
+        v, = struct.unpack("<b", self.__fin.read(1))
         return v
+
 
 class FileWriteStream(FileStream):
     def __init__(self, path, pmx_header=None):
-        self.__fout = open(path, 'wb')
+        self.__fout = open(path, "wb")
         FileStream.__init__(self, path, self.__fout, pmx_header)
 
     def __writeIndex(self, index, size, typedict):
-        if size in typedict :
+        if size in typedict:
             self.__fout.write(struct.pack(typedict[size], int(index)))
         else:
-            raise ValueError('invalid data size %s'%str(size))
-        return
+            raise ValueError(f"invalid data size {str(size)}")
 
     def __writeSignedIndex(self, index, size):
-        return self.__writeIndex(index, size, { 1 :"<b", 2 :"<h", 4 :"<i"})
+        return self.__writeIndex(index, size, {1: "<b", 2: "<h", 4: "<i"})
 
     def __writeUnsignedIndex(self, index, size):
-        return self.__writeIndex(index, size, { 1 :"<B", 2 :"<H", 4 :"<I"})
+        return self.__writeIndex(index, size, {1: "<B", 2: "<H", 4: "<I"})
 
     # WRITE methods for indexes
     def writeVertexIndex(self, index):
@@ -152,15 +155,14 @@ class FileWriteStream(FileStream):
     def writeMaterialIndex(self, index):
         return self.__writeSignedIndex(index, self.header().material_index_size)
 
-
     def writeInt(self, v):
-        self.__fout.write(struct.pack('<i', int(v)))
+        self.__fout.write(struct.pack("<i", int(v)))
 
     def writeShort(self, v):
-        self.__fout.write(struct.pack('<h', int(v)))
+        self.__fout.write(struct.pack("<h", int(v)))
 
     def writeUnsignedShort(self, v):
-        self.__fout.write(struct.pack('<H', int(v)))
+        self.__fout.write(struct.pack("<H", int(v)))
 
     def writeStr(self, v):
         data = v.encode(self.header().encoding.charset)
@@ -168,61 +170,64 @@ class FileWriteStream(FileStream):
         self.__fout.write(data)
 
     def writeFloat(self, v):
-        self.__fout.write(struct.pack('<f', float(v)))
+        self.__fout.write(struct.pack("<f", float(v)))
 
     def writeVector(self, v):
-        self.__fout.write(struct.pack('<'+'f'*len(v), *v))
+        self.__fout.write(struct.pack("<" + "f" * len(v), *v))
 
     def writeByte(self, v):
-        self.__fout.write(struct.pack('<B', int(v)))
+        self.__fout.write(struct.pack("<B", int(v)))
 
     def writeBytes(self, v):
         self.__fout.write(v)
 
     def writeSignedByte(self, v):
-        self.__fout.write(struct.pack('<b', int(v)))
+        self.__fout.write(struct.pack("<b", int(v)))
+
 
 class Encoding:
     _MAP = [
-        (0, 'utf-16-le'),
-        (1, 'utf-8'),
-        ]
+        (0, "utf-16-le"),
+        (1, "utf-8"),
+    ]
 
     def __init__(self, arg):
         self.index = 0
-        self.charset = ''
+        self.charset = ""
         t = None
         if isinstance(arg, str):
-            t = list(filter(lambda x: x[1]==arg, self._MAP))
+            t = list(filter(lambda x: x[1] == arg, self._MAP))
             if len(t) == 0:
-                raise ValueError('invalid charset %s'%arg)
+                raise ValueError(f"invalid charset {arg}")
         elif isinstance(arg, int):
-            t = list(filter(lambda x: x[0]==arg, self._MAP))
+            t = list(filter(lambda x: x[0] == arg, self._MAP))
             if len(t) == 0:
-                raise ValueError('invalid index %d'%arg)
+                raise ValueError("invalid index %d" % arg)
         else:
-            raise ValueError('invalid argument type')
+            raise ValueError("invalid argument type")
         t = t[0]
         self.index = t[0]
-        self.charset  = t[1]
+        self.charset = t[1]
 
     def __repr__(self):
-        return '<Encoding charset %s>'%self.charset
+        return f"<Encoding charset {self.charset}>"
+
 
 class Coordinate:
-    """ """
     def __init__(self, xAxis, zAxis):
         self.x_axis = xAxis
         self.z_axis = zAxis
 
+
 class Header:
-    PMX_SIGN = b'PMX '
+    PMX_SIGN = b"PMX "
     VERSION = 2.0
+
     def __init__(self, model=None):
         self.sign = self.PMX_SIGN
         self.version = 0
 
-        self.encoding = Encoding('utf-16-le')
+        self.encoding = Encoding("utf-16-le")
         self.additional_uvs = 0
 
         self.vertex_index_size = 1
@@ -248,28 +253,27 @@ class Header:
         s = 1
         if signed:
             s = 2
-        if (1<<8)/s > num:
+        if (1 << 8) / s > num:
             return 1
-        elif (1<<16)/s > num:
+        if (1 << 16) / s > num:
             return 2
-        else:
-            return 4
+        return 4
 
     def load(self, fs):
-        logging.info('loading pmx header information...')
+        logging.debug("loading pmx header information...")
         self.sign = fs.readBytes(4)
-        logging.debug('File signature is %s', self.sign)
+        logging.debug("File signature is %s", self.sign)
         if self.sign[:3] != self.PMX_SIGN[:3]:
-            logging.info('File signature is invalid')
-            logging.error('This file is unsupported format, or corrupt file.')
-            raise InvalidFileError('File signature is invalid.')
+            logging.error("File signature is invalid: %s", self.sign)
+            logging.error("This file is unsupported format, or corrupt file.")
+            raise InvalidFileError("File signature is invalid.")
         self.version = fs.readFloat()
-        logging.info('pmx format version: %f', self.version)
+        logging.debug("pmx format version: %f", self.version)
         if self.version != self.VERSION:
-            logging.error('PMX version %.1f is unsupported', self.version)
-            raise UnsupportedVersionError('unsupported PMX version: %.1f'%self.version)
-        if fs.readByte() != 8 or self.sign[3] != self.PMX_SIGN[3]:
-            logging.warning(' * This file might be corrupted.')
+            logging.error("PMX version %.1f is unsupported", self.version)
+            raise UnsupportedVersionError(f"unsupported PMX version: {self.version:.1f}")
+        if fs.readByte() != 8:
+            logging.warning(" * This file might be corrupted.")
         self.encoding = Encoding(fs.readByte())
         self.additional_uvs = fs.readByte()
         self.vertex_index_size = fs.readByte()
@@ -279,19 +283,19 @@ class Header:
         self.morph_index_size = fs.readByte()
         self.rigid_index_size = fs.readByte()
 
-        logging.info('----------------------------')
-        logging.info('pmx header information')
-        logging.info('----------------------------')
-        logging.info('pmx version: %.1f', self.version)
-        logging.info('encoding: %s', str(self.encoding))
-        logging.info('number of uvs: %d', self.additional_uvs)
-        logging.info('vertex index size: %d byte(s)', self.vertex_index_size)
-        logging.info('texture index: %d byte(s)', self.texture_index_size)
-        logging.info('material index: %d byte(s)', self.material_index_size)
-        logging.info('bone index: %d byte(s)', self.bone_index_size)
-        logging.info('morph index: %d byte(s)', self.morph_index_size)
-        logging.info('rigid index: %d byte(s)', self.rigid_index_size)
-        logging.info('----------------------------')
+        logging.info("----------------------------")
+        logging.info("pmx header information")
+        logging.info("----------------------------")
+        logging.info("pmx version: %.1f", self.version)
+        logging.info("encoding: %s", str(self.encoding))
+        logging.info("number of uvs: %d", self.additional_uvs)
+        logging.info("vertex index size: %d byte(s)", self.vertex_index_size)
+        logging.info("texture index: %d byte(s)", self.texture_index_size)
+        logging.info("material index: %d byte(s)", self.material_index_size)
+        logging.info("bone index: %d byte(s)", self.bone_index_size)
+        logging.info("morph index: %d byte(s)", self.morph_index_size)
+        logging.info("rigid index: %d byte(s)", self.rigid_index_size)
+        logging.info("----------------------------")
 
     def save(self, fs):
         fs.writeBytes(self.PMX_SIGN)
@@ -307,7 +311,7 @@ class Header:
         fs.writeByte(self.rigid_index_size)
 
     def __repr__(self):
-        return '<Header encoding %s, uvs %d, vtx %d, tex %d, mat %d, bone %d, morph %d, rigid %d>'%(
+        return "<Header encoding %s, uvs %d, vtx %d, tex %d, mat %d, bone %d, morph %d, rigid %d>" % (
             str(self.encoding),
             self.additional_uvs,
             self.vertex_index_size,
@@ -316,17 +320,18 @@ class Header:
             self.bone_index_size,
             self.morph_index_size,
             self.rigid_index_size,
-            )
+        )
+
 
 class Model:
     def __init__(self):
-        self.filepath = ''
+        self.filepath = ""
         self.header = None
 
-        self.name = ''
-        self.name_e = ''
-        self.comment = ''
-        self.comment_e = ''
+        self.name = ""
+        self.name_e = ""
+        self.comment = ""
+        self.comment_e = ""
 
         self.vertices = []
         self.faces = []
@@ -338,13 +343,13 @@ class Model:
         self.display = []
         dsp_root = Display()
         dsp_root.isSpecial = True
-        dsp_root.name = 'Root'
-        dsp_root.name_e = 'Root'
+        dsp_root.name = "Root"
+        dsp_root.name_e = "Root"
         self.display.append(dsp_root)
         dsp_face = Display()
         dsp_face.isSpecial = True
-        dsp_face.name = '表情'
-        dsp_face.name_e = 'Facial'
+        dsp_face.name = "表情"
+        dsp_face.name_e = "Facial"
         self.display.append(dsp_face)
 
         self.rigids = []
@@ -360,53 +365,53 @@ class Model:
         self.comment = fs.readStr()
         self.comment_e = fs.readStr()
 
-        logging.info('Model name: %s', self.name)
-        logging.info('Model name(english): %s', self.name_e)
-        logging.info('Comment:%s', self.comment)
-        logging.info('Comment(english):%s', self.comment_e)
+        logging.info("Model name: %s", self.name)
+        logging.info("Model name(english): %s", self.name_e)
+        logging.info("Comment:%s", self.comment)
+        logging.info("Comment(english):%s", self.comment_e)
 
-        logging.info('')
-        logging.info('------------------------------')
-        logging.info('Load Vertices')
-        logging.info('------------------------------')
+        logging.info("")
+        logging.info("------------------------------")
+        logging.info("Load Vertices")
+        logging.info("------------------------------")
         num_vertices = fs.readInt()
         self.vertices = []
         for i in range(num_vertices):
             v = Vertex()
             v.load(fs)
             self.vertices.append(v)
-        logging.info('----- Loaded %d vertices', len(self.vertices))
+        logging.info("----- Loaded %d vertices", len(self.vertices))
 
-        logging.info('')
-        logging.info('------------------------------')
-        logging.info(' Load Faces')
-        logging.info('------------------------------')
+        logging.info("")
+        logging.info("------------------------------")
+        logging.info(" Load Faces")
+        logging.info("------------------------------")
         num_faces = fs.readInt()
         self.faces = []
-        for i in range(int(num_faces/3)):
+        for i in range(int(num_faces / 3)):
             f1 = fs.readVertexIndex()
             f2 = fs.readVertexIndex()
             f3 = fs.readVertexIndex()
             self.faces.append((f3, f2, f1))
-        logging.info(' Load %d faces', len(self.faces))
+        logging.info(" Load %d faces", len(self.faces))
 
-        logging.info('')
-        logging.info('------------------------------')
-        logging.info(' Load Textures')
-        logging.info('------------------------------')
+        logging.info("")
+        logging.info("------------------------------")
+        logging.info(" Load Textures")
+        logging.info("------------------------------")
         num_textures = fs.readInt()
         self.textures = []
         for i in range(num_textures):
             t = Texture()
             t.load(fs)
             self.textures.append(t)
-            logging.info('Texture %d: %s', i, t.path)
-        logging.info(' ----- Loaded %d textures', len(self.textures))
+            logging.info("Texture %d: %s", i, t.path)
+        logging.info(" ----- Loaded %d textures", len(self.textures))
 
-        logging.info('')
-        logging.info('------------------------------')
-        logging.info(' Load Materials')
-        logging.info('------------------------------')
+        logging.info("")
+        logging.info("------------------------------")
+        logging.info(" Load Materials")
+        logging.info("------------------------------")
         num_materials = fs.readInt()
         self.materials = []
         for i in range(num_materials):
@@ -414,38 +419,38 @@ class Model:
             m.load(fs, num_textures)
             self.materials.append(m)
 
-            logging.info('Material %d: %s', i, m.name)
-            logging.debug('  Name(english): %s', m.name_e)
-            logging.debug('  Comment: %s', m.comment)
-            logging.debug('  Vertex Count: %d', m.vertex_count)
-            logging.debug('  Diffuse: (%.2f, %.2f, %.2f, %.2f)', *m.diffuse)
-            logging.debug('  Specular: (%.2f, %.2f, %.2f)', *m.specular)
-            logging.debug('  Shininess: %f', m.shininess)
-            logging.debug('  Ambient: (%.2f, %.2f, %.2f)', *m.ambient)
-            logging.debug('  Double Sided: %s', str(m.is_double_sided))
-            logging.debug('  Drop Shadow: %s', str(m.enabled_drop_shadow))
-            logging.debug('  Self Shadow: %s', str(m.enabled_self_shadow))
-            logging.debug('  Self Shadow Map: %s', str(m.enabled_self_shadow_map))
-            logging.debug('  Edge: %s', str(m.enabled_toon_edge))
-            logging.debug('  Edge Color: (%.2f, %.2f, %.2f, %.2f)', *m.edge_color)
-            logging.debug('  Edge Size: %.2f', m.edge_size)
-            if m.texture != -1:
-                logging.debug('  Texture Index: %d', m.texture)
+            logging.info("Material %d: %s", i, m.name)
+            logging.debug("  Name(english): %s", m.name_e)
+            logging.debug("  Comment: %s", m.comment)
+            logging.debug("  Vertex Count: %d", m.vertex_count)
+            logging.debug("  Diffuse: (%.2f, %.2f, %.2f, %.2f)", *m.diffuse)
+            logging.debug("  Specular: (%.2f, %.2f, %.2f)", *m.specular)
+            logging.debug("  Shininess: %f", m.shininess)
+            logging.debug("  Ambient: (%.2f, %.2f, %.2f)", *m.ambient)
+            logging.debug("  Double Sided: %s", str(m.is_double_sided))
+            logging.debug("  Drop Shadow: %s", str(m.enabled_drop_shadow))
+            logging.debug("  Self Shadow: %s", str(m.enabled_self_shadow))
+            logging.debug("  Self Shadow Map: %s", str(m.enabled_self_shadow_map))
+            logging.debug("  Edge: %s", str(m.enabled_toon_edge))
+            logging.debug("  Edge Color: (%.2f, %.2f, %.2f, %.2f)", *m.edge_color)
+            logging.debug("  Edge Size: %.2f", m.edge_size)
+            if m.texture >= 0:
+                logging.debug("  Texture Index: %d", m.texture)
             else:
-                logging.debug('  Texture: None')
-            if m.sphere_texture != -1:
-                logging.debug('  Sphere Texture Index: %d', m.sphere_texture)
-                logging.debug('  Sphere Texture Mode: %d', m.sphere_texture_mode)
+                logging.debug("  Texture: None")
+            if m.sphere_texture >= 0:
+                logging.debug("  Sphere Texture Index: %d", m.sphere_texture)
+                logging.debug("  Sphere Texture Mode: %d", m.sphere_texture_mode)
             else:
-                logging.debug('  Sphere Texture: None')
-            logging.debug('')
+                logging.debug("  Sphere Texture: None")
+            logging.debug("")
 
-        logging.info('----- Loaded %d  materials.', len(self.materials))
+        logging.info("----- Loaded %d  materials.", len(self.materials))
 
-        logging.info('')
-        logging.info('------------------------------')
-        logging.info(' Load Bones')
-        logging.info('------------------------------')
+        logging.info("")
+        logging.info("------------------------------")
+        logging.info(" Load Bones")
+        logging.info("------------------------------")
         num_bones = fs.readInt()
         self.bones = []
         for i in range(num_bones):
@@ -453,50 +458,50 @@ class Model:
             b.load(fs)
             self.bones.append(b)
 
-            logging.info('Bone %d: %s', i, b.name)
-            logging.debug('  Name(english): %s', b.name_e)
-            logging.debug('  Location: (%f, %f, %f)', *b.location)
-            logging.debug('  displayConnection: %s', str(b.displayConnection))
-            logging.debug('  Parent: %s', str(b.parent))
-            logging.debug('  Transform Order: %s', str(b.transform_order))
-            logging.debug('  Rotatable: %s', str(b.isRotatable))
-            logging.debug('  Movable: %s', str(b.isMovable))
-            logging.debug('  Visible: %s', str(b.visible))
-            logging.debug('  Controllable: %s', str(b.isControllable))
-            logging.debug('  Additional Location: %s', str(b.hasAdditionalLocation))
-            logging.debug('  Additional Rotation: %s', str(b.hasAdditionalRotate))
+            logging.info("Bone %d: %s", i, b.name)
+            logging.debug("  Name(english): %s", b.name_e)
+            logging.debug("  Location: (%f, %f, %f)", *b.location)
+            logging.debug("  displayConnection: %s", str(b.displayConnection))
+            logging.debug("  Parent: %s", str(b.parent))
+            logging.debug("  Transform Order: %s", str(b.transform_order))
+            logging.debug("  Rotatable: %s", str(b.isRotatable))
+            logging.debug("  Movable: %s", str(b.isMovable))
+            logging.debug("  Visible: %s", str(b.visible))
+            logging.debug("  Controllable: %s", str(b.isControllable))
+            logging.debug("  Additional Location: %s", str(b.hasAdditionalLocation))
+            logging.debug("  Additional Rotation: %s", str(b.hasAdditionalRotate))
             if b.additionalTransform is not None:
-                logging.debug('  Additional Transform: Bone:%d, influence: %f', *b.additionalTransform)
-            logging.debug('  IK: %s', str(b.isIK))
+                logging.debug("  Additional Transform: Bone:%d, influence: %f", *b.additionalTransform)
+            logging.debug("  IK: %s", str(b.isIK))
             if b.isIK:
-                logging.debug('    Unit Angle: %f', b.rotationConstraint)
-                logging.debug('    Target: %d', b.target)
+                logging.debug("    Unit Angle: %f", b.rotationConstraint)
+                logging.debug("    Target: %d", b.target)
                 for j, link in enumerate(b.ik_links):
-                    logging.debug('    IK Link %d: %d, %s - %s', j, link.target, str(link.minimumAngle), str(link.maximumAngle))
-            logging.debug('')
-        logging.info('----- Loaded %d bones.', len(self.bones))
+                    logging.debug("    IK Link %d: %d, %s - %s", j, link.target, str(link.minimumAngle), str(link.maximumAngle))
+            logging.debug("")
+        logging.info("----- Loaded %d bones.", len(self.bones))
 
-        logging.info('')
-        logging.info('------------------------------')
-        logging.info(' Load Morphs')
-        logging.info('------------------------------')
+        logging.info("")
+        logging.info("------------------------------")
+        logging.info(" Load Morphs")
+        logging.info("------------------------------")
         num_morph = fs.readInt()
         self.morphs = []
-        display_categories = {0: 'System', 1: 'Eyebrow', 2: 'Eye', 3: 'Mouth', 4: 'Other'}
+        display_categories = {0: "System", 1: "Eyebrow", 2: "Eye", 3: "Mouth", 4: "Other"}
         for i in range(num_morph):
             m = Morph.create(fs)
             self.morphs.append(m)
 
-            logging.info('%s %d: %s', m.__class__.__name__, i, m.name)
-            logging.debug('  Name(english): %s', m.name_e)
-            logging.debug('  Category: %s (%d)', display_categories.get(m.category, '#Invalid'), m.category)
-            logging.debug('')
-        logging.info('----- Loaded %d morphs.', len(self.morphs))
+            logging.info("%s %d: %s", m.__class__.__name__, i, m.name)
+            logging.debug("  Name(english): %s", m.name_e)
+            logging.debug("  Category: %s (%d)", display_categories.get(m.category, "#Invalid"), m.category)
+            logging.debug("")
+        logging.info("----- Loaded %d morphs.", len(self.morphs))
 
-        logging.info('')
-        logging.info('------------------------------')
-        logging.info(' Load Display Items')
-        logging.info('------------------------------')
+        logging.info("")
+        logging.info("------------------------------")
+        logging.info(" Load Display Items")
+        logging.info("------------------------------")
         num_disp = fs.readInt()
         self.display = []
         for i in range(num_disp):
@@ -504,44 +509,44 @@ class Model:
             d.load(fs)
             self.display.append(d)
 
-            logging.info('Display Item %d: %s', i, d.name)
-            logging.debug('  Name(english): %s', d.name_e)
-            logging.debug('')
-        logging.info('----- Loaded %d display items.', len(self.display))
+            logging.info("Display Item %d: %s", i, d.name)
+            logging.debug("  Name(english): %s", d.name_e)
+            logging.debug("")
+        logging.info("----- Loaded %d display items.", len(self.display))
 
-        logging.info('')
-        logging.info('------------------------------')
-        logging.info(' Load Rigid Bodies')
-        logging.info('------------------------------')
+        logging.info("")
+        logging.info("------------------------------")
+        logging.info(" Load Rigid Bodies")
+        logging.info("------------------------------")
         num_rigid = fs.readInt()
         self.rigids = []
-        rigid_types = {0: 'Sphere', 1: 'Box', 2: 'Capsule'}
-        rigid_modes = {0: 'Static', 1: 'Dynamic', 2: 'Dynamic(track to bone)'}
+        rigid_types = {0: "Sphere", 1: "Box", 2: "Capsule"}
+        rigid_modes = {0: "Static", 1: "Dynamic", 2: "Dynamic(track to bone)"}
         for i in range(num_rigid):
             r = Rigid()
             r.load(fs)
             self.rigids.append(r)
-            logging.info('Rigid Body %d: %s', i, r.name)
-            logging.debug('  Name(english): %s', r.name_e)
-            logging.debug('  Type: %s', rigid_types[r.type])
-            logging.debug('  Mode: %s (%d)', rigid_modes.get(r.mode, '#Invalid'), r.mode)
-            logging.debug('  Related bone: %s', r.bone)
-            logging.debug('  Collision group: %d', r.collision_group_number)
-            logging.debug('  Collision group mask: 0x%x', r.collision_group_mask)
-            logging.debug('  Size: (%f, %f, %f)', *r.size)
-            logging.debug('  Location: (%f, %f, %f)', *r.location)
-            logging.debug('  Rotation: (%f, %f, %f)', *r.rotation)
-            logging.debug('  Mass: %f', r.mass)
-            logging.debug('  Bounce: %f', r.bounce)
-            logging.debug('  Friction: %f', r.friction)
-            logging.debug('')
+            logging.info("Rigid Body %d: %s", i, r.name)
+            logging.debug("  Name(english): %s", r.name_e)
+            logging.debug("  Type: %s", rigid_types[r.type])
+            logging.debug("  Mode: %s (%d)", rigid_modes.get(r.mode, "#Invalid"), r.mode)
+            logging.debug("  Related bone: %s", r.bone)
+            logging.debug("  Collision group: %d", r.collision_group_number)
+            logging.debug("  Collision group mask: 0x%x", r.collision_group_mask)
+            logging.debug("  Size: (%f, %f, %f)", *r.size)
+            logging.debug("  Location: (%f, %f, %f)", *r.location)
+            logging.debug("  Rotation: (%f, %f, %f)", *r.rotation)
+            logging.debug("  Mass: %f", r.mass)
+            logging.debug("  Bounce: %f", r.bounce)
+            logging.debug("  Friction: %f", r.friction)
+            logging.debug("")
 
-        logging.info('----- Loaded %d rigid bodies.', len(self.rigids))
+        logging.info("----- Loaded %d rigid bodies.", len(self.rigids))
 
-        logging.info('')
-        logging.info('------------------------------')
-        logging.info(' Load Joints')
-        logging.info('------------------------------')
+        logging.info("")
+        logging.info("------------------------------")
+        logging.info(" Load Joints")
+        logging.info("------------------------------")
         num_joints = fs.readInt()
         self.joints = []
         for i in range(num_joints):
@@ -549,19 +554,19 @@ class Model:
             j.load(fs)
             self.joints.append(j)
 
-            logging.info('Joint %d: %s', i, j.name)
-            logging.debug('  Name(english): %s', j.name_e)
-            logging.debug('  Rigid A: %s', j.src_rigid)
-            logging.debug('  Rigid B: %s', j.dest_rigid)
-            logging.debug('  Location: (%f, %f, %f)', *j.location)
-            logging.debug('  Rotation: (%f, %f, %f)', *j.rotation)
-            logging.debug('  Location Limit: (%f, %f, %f) - (%f, %f, %f)', *(j.minimum_location + j.maximum_location))
-            logging.debug('  Rotation Limit: (%f, %f, %f) - (%f, %f, %f)', *(j.minimum_rotation + j.maximum_rotation))
-            logging.debug('  Spring: (%f, %f, %f)', *j.spring_constant)
-            logging.debug('  Spring(rotation): (%f, %f, %f)', *j.spring_rotation_constant)
-            logging.debug('')
+            logging.info("Joint %d: %s", i, j.name)
+            logging.debug("  Name(english): %s", j.name_e)
+            logging.debug("  Rigid A: %s", j.src_rigid)
+            logging.debug("  Rigid B: %s", j.dest_rigid)
+            logging.debug("  Location: (%f, %f, %f)", *j.location)
+            logging.debug("  Rotation: (%f, %f, %f)", *j.rotation)
+            logging.debug("  Location Limit: (%f, %f, %f) - (%f, %f, %f)", *(j.minimum_location + j.maximum_location))
+            logging.debug("  Rotation Limit: (%f, %f, %f) - (%f, %f, %f)", *(j.minimum_rotation + j.maximum_rotation))
+            logging.debug("  Spring: (%f, %f, %f)", *j.spring_constant)
+            logging.debug("  Spring(rotation): (%f, %f, %f)", *j.spring_rotation_constant)
+            logging.debug("")
 
-        logging.info('----- Loaded %d joints.', len(self.joints))
+        logging.info("----- Loaded %d joints.", len(self.joints))
 
     def save(self, fs):
         fs.writeStr(self.name)
@@ -570,81 +575,75 @@ class Model:
         fs.writeStr(self.comment)
         fs.writeStr(self.comment_e)
 
-        logging.info('''exportings pmx model data...
+        logging.info("""exportings pmx model data...
 name: %s
 name(english): %s
 comment:
 %s
 comment(english):
 %s
-''', self.name, self.name_e, self.comment, self.comment_e)
+""", self.name, self.name_e, self.comment, self.comment_e)
 
-        logging.info('exporting vertices... %d', len(self.vertices))
+        logging.info("exporting vertices... %d", len(self.vertices))
         fs.writeInt(len(self.vertices))
         for i in self.vertices:
             i.save(fs)
-        logging.info('finished exporting vertices.')
+        logging.info("finished exporting vertices.")
 
-        logging.info('exporting faces... %d', len(self.faces))
-        fs.writeInt(len(self.faces)*3)
+        logging.info("exporting faces... %d", len(self.faces))
+        fs.writeInt(len(self.faces) * 3)
         for f3, f2, f1 in self.faces:
             fs.writeVertexIndex(f1)
             fs.writeVertexIndex(f2)
             fs.writeVertexIndex(f3)
-        logging.info('finished exporting faces.')
+        logging.info("finished exporting faces.")
 
-        logging.info('exporting textures... %d', len(self.textures))
+        logging.info("exporting textures... %d", len(self.textures))
         fs.writeInt(len(self.textures))
         for i in self.textures:
             i.save(fs)
-        logging.info('finished exporting textures.')
+        logging.info("finished exporting textures.")
 
-        logging.info('exporting materials... %d', len(self.materials))
+        logging.info("exporting materials... %d", len(self.materials))
         fs.writeInt(len(self.materials))
         for i in self.materials:
             i.save(fs)
-        logging.info('finished exporting materials.')
+        logging.info("finished exporting materials.")
 
-        logging.info('exporting bones... %d', len(self.bones))
+        logging.info("exporting bones... %d", len(self.bones))
         fs.writeInt(len(self.bones))
         for i in self.bones:
             i.save(fs)
-        logging.info('finished exporting bones.')
+        logging.info("finished exporting bones.")
 
-        logging.info('exporting morphs... %d', len(self.morphs))
+        logging.info("exporting morphs... %d", len(self.morphs))
         fs.writeInt(len(self.morphs))
         for i in self.morphs:
             i.save(fs)
-        logging.info('finished exporting morphs.')
+        logging.info("finished exporting morphs.")
 
-        logging.info('exporting display items... %d', len(self.display))
+        logging.info("exporting display items... %d", len(self.display))
         fs.writeInt(len(self.display))
         for i in self.display:
             i.save(fs)
-        logging.info('finished exporting display items.')
+        logging.info("finished exporting display items.")
 
-        logging.info('exporting rigid bodies... %d', len(self.rigids))
+        logging.info("exporting rigid bodies... %d", len(self.rigids))
         fs.writeInt(len(self.rigids))
         for i in self.rigids:
             i.save(fs)
-        logging.info('finished exporting rigid bodies.')
+        logging.info("finished exporting rigid bodies.")
 
-        logging.info('exporting joints... %d', len(self.joints))
+        logging.info("exporting joints... %d", len(self.joints))
         fs.writeInt(len(self.joints))
         for i in self.joints:
             i.save(fs)
-        logging.info('finished exporting joints.')
-        logging.info('finished exporting the model.')
-
+        logging.info("finished exporting joints.")
+        logging.info("finished exporting the model.")
 
     def __repr__(self):
-        return '<Model name %s, name_e %s, comment %s, comment_e %s, textures %s>'%(
-            self.name,
-            self.name_e,
-            self.comment,
-            self.comment_e,
-            str(self.textures),
-            )
+        return f"<Model name {self.name}, name_e {self.name_e}, comment {self.comment}, comment_e {self.comment_e}, textures {str(self.textures)}>"
+
 
 class Vertex:
     def __init__(self):
@@ -656,14 +655,7 @@ class Vertex:
         self.edge_scale = 1
 
     def __repr__(self):
-        return '<Vertex co %s, normal %s, uv %s, additional_uvs %s, weight %s, edge_scale %s>'%(
-            str(self.co),
-            str(self.normal),
-            str(self.uv),
-            str(self.additional_uvs),
-            str(self.weight),
-            str(self.edge_scale),
-            )
+        return f"<Vertex co {str(self.co)}, normal {str(self.normal)}, uv {str(self.uv)}, additional_uvs {str(self.additional_uvs)}, weight {str(self.weight)}, edge_scale {str(self.edge_scale)}>"
 
     def load(self, fs):
         self.co = fs.readVector(3)
@@ -680,12 +672,17 @@ class Vertex:
         fs.writeVector(self.co)
         fs.writeVector(self.normal)
         fs.writeVector(self.uv)
+
+        assert len(self.additional_uvs) <= fs.header().additional_uvs
         for i in self.additional_uvs:
+            assert len(i) == 4
             fs.writeVector(i)
-        for i in range(fs.header().additional_uvs-len(self.additional_uvs)):
-            fs.writeVector((0,0,0,0))
+        for i in range(fs.header().additional_uvs - len(self.additional_uvs)):
+            fs.writeVector((0, 0, 0, 0))
+
         self.weight.save(fs)
         fs.writeFloat(self.edge_scale)
+
 
 class BoneWeightSDEF:
     def __init__(self, weight=0, c=None, r0=None, r1=None):
@@ -694,6 +691,7 @@ class BoneWeightSDEF:
         self.r0 = r0
         self.r1 = r1
 
+
 class BoneWeight:
     BDEF1 = 0
     BDEF2 = 1
@@ -701,11 +699,11 @@ class BoneWeight:
     SDEF  = 3
 
     TYPES = [
-        (BDEF1, 'BDEF1'),
-        (BDEF2, 'BDEF2'),
-        (BDEF4, 'BDEF4'),
-        (SDEF, 'SDEF'),
-        ]
+        (BDEF1, "BDEF1"),
+        (BDEF2, "BDEF2"),
+        (BDEF4, "BDEF4"),
+        (SDEF, "SDEF"),
+    ]
 
     def __init__(self):
         self.bones = []
@@ -713,18 +711,16 @@ class BoneWeight:
         self.type = self.BDEF1
 
     def convertIdToName(self, type_id):
-        t = list(filter(lambda x: x[0]==type_id, self.TYPES))
+        t = list(filter(lambda x: x[0] == type_id, self.TYPES))
         if len(t) > 0:
             return t[0][1]
-        else:
-            return None
+        return None
 
     def convertNameToId(self, type_name):
-        t = list(filter(lambda x: x[1]==type_name, self.TYPES))
+        t = list(filter(lambda x: x[1] == type_name, self.TYPES))
         if len(t) > 0:
             return t[0][0]
-        else:
-            return None
+        return None
 
     def load(self, fs):
         self.type = fs.readByte()
@@ -752,7 +748,7 @@ class BoneWeight:
             self.weights.r0 = fs.readVector(3)
             self.weights.r1 = fs.readVector(3)
         else:
-            raise ValueError('invalid weight type %s'%str(self.type))
+            raise ValueError(f"invalid weight type {str(self.type)}")
 
     def save(self, fs):
         fs.writeByte(self.type)
@@ -777,35 +773,41 @@ class BoneWeight:
             fs.writeVector(self.weights.r0)
             fs.writeVector(self.weights.r1)
         else:
-            raise ValueError('invalid weight type %s'%str(self.type))
+            raise ValueError(f"invalid weight type {str(self.type)}")
 
 
 class Texture:
     def __init__(self):
-        self.path = ''
+        self.path = ""
 
     def __repr__(self):
-        return '<Texture path %s>'%str(self.path)
+        return f"<Texture path {str(self.path)}>"
 
     def load(self, fs):
         self.path = fs.readStr()
-        self.path = self.path.replace('\\', os.path.sep)
+        self.path = self.path.replace("\\", os.path.sep)
         if not os.path.isabs(self.path):
             self.path = os.path.normpath(os.path.join(os.path.dirname(fs.path()), self.path))
 
     def save(self, fs):
-        try:
-            relPath = os.path.relpath(self.path, os.path.dirname(fs.path()))
-        except ValueError:
+        if not os.path.isabs(self.path):
             relPath = self.path
-        relPath = relPath.replace(os.path.sep, '\\') # always save using windows path conventions
-        logging.info('writing to pmx file the relative texture path: %s', relPath)
+        else:
+            try:
+                relPath = os.path.relpath(self.path, os.path.dirname(fs.path()))
+            except ValueError:
+                relPath = self.path
+
+        relPath = relPath.replace(os.path.sep, "\\")  # always save using windows path conventions
+        logging.info("writing to pmx file the relative texture path: %s", relPath)
         fs.writeStr(relPath)
+
 
 class SharedTexture(Texture):
     def __init__(self):
         self.number = 0
-        self.prefix = ''
+        self.prefix = ""
+
 
 class Material:
     SPHERE_MODE_OFF = 0
@@ -814,8 +816,8 @@ class Material:
     SPHERE_MODE_SUBTEX = 3
 
     def __init__(self):
-        self.name = ''
-        self.name_e = ''
+        self.name = ""
+        self.name_e = ""
 
         self.diffuse = []
         self.specular = []
@@ -837,28 +839,11 @@ class Material:
         self.is_shared_toon_texture = True
         self.toon_texture = 0
 
-        self.comment = ''
+        self.comment = ""
         self.vertex_count = 0
 
     def __repr__(self):
-        return '<Material name %s, name_e %s, diffuse %s, specular %s, shininess %s, ambient %s, double_side %s, drop_shadow %s, self_shadow_map %s, self_shadow %s, toon_edge %s, edge_color %s, edge_size %s, toon_texture %s, comment %s>'%(
-            self.name,
-            self.name_e,
-            str(self.diffuse),
-            str(self.specular),
-            str(self.shininess),
-            str(self.ambient),
-            str(self.is_double_sided),
-            str(self.enabled_drop_shadow),
-            str(self.enabled_self_shadow_map),
-            str(self.enabled_self_shadow),
-            str(self.enabled_toon_edge),
-            str(self.edge_color),
-            str(self.edge_size),
-            str(self.texture),
-            str(self.sphere_texture),
-            str(self.toon_texture),
-            str(self.comment),)
+        return f"<Material name {self.name}, name_e {self.name_e}, diffuse {str(self.diffuse)}, specular {str(self.specular)}, shininess {str(self.shininess)}, ambient {str(self.ambient)}, is_double_sided {str(self.is_double_sided)}, enabled_drop_shadow {str(self.enabled_drop_shadow)}, enabled_self_shadow_map {str(self.enabled_self_shadow_map)}, enabled_self_shadow {str(self.enabled_self_shadow)}, enabled_toon_edge {str(self.enabled_toon_edge)}, edge_color {str(self.edge_color)}, edge_size {str(self.edge_size)}, texture {str(self.texture)}, sphere_texture {str(self.sphere_texture)}, toon_texture {str(self.toon_texture)}, comment {str(self.comment)}>"
 
     def load(self, fs, num_textures):
         def __tex_index(index):
@@ -933,8 +918,8 @@ class Material:
 
 class Bone:
     def __init__(self):
-        self.name = ''
-        self.name_e = ''
+        self.name = ""
+        self.name_e = ""
 
         self.location = []
         self.parent = None
@@ -982,9 +967,7 @@ class Bone:
         self.ik_links = []
 
     def __repr__(self):
-        return '<Bone name %s, name_e %s>'%(
-            self.name,
-            self.name_e,)
+        return f"<Bone name {self.name}, name_e {self.name_e}>"
 
     def load(self, fs):
         self.name = fs.readStr()
@@ -1015,7 +998,6 @@ class Bone:
             self.additionalTransform = (t, v)
         else:
             self.additionalTransform = None
-
 
         if flags & 0x0400:
             self.axis = fs.readVector(3)
@@ -1110,7 +1092,7 @@ class IKLink:
         self.minimumAngle = None
 
     def __repr__(self):
-        return '<IKLink target %s>'%(str(self.target))
+        return f"<IKLink target {str(self.target)}>"
 
     def load(self, fs):
         self.target = fs.readBoneIndex()
@@ -1131,6 +1113,7 @@ class IKLink:
         else:
             fs.writeByte(0)
 
+
 class Morph:
     CATEGORY_SYSTEM = 0
     CATEGORY_EYEBROW = 1
@@ -1145,7 +1128,7 @@ class Morph:
         self.category = category
 
     def __repr__(self):
-        return '<Morph name %s, name_e %s>'%(self.name, self.name_e)
+        return f"<Morph name {self.name}, name_e {self.name_e}>"
 
     def type_index(self):
         raise NotImplementedError
@@ -1162,20 +1145,19 @@ class Morph:
             6: UVMorph,
             7: UVMorph,
             8: MaterialMorph,
-            }
+        }
 
         name = fs.readStr()
         name_e = fs.readStr()
-        logging.debug('morph: %s', name)
+        logging.debug("morph: %s", name)
         category = fs.readSignedByte()
         typeIndex = fs.readSignedByte()
-        ret = _CLASSES[typeIndex](name, name_e, category, type_index = typeIndex)
+        ret = _CLASSES[typeIndex](name, name_e, category, type_index=typeIndex)
         ret.load(fs)
         return ret
 
     def load(self, fs):
-        """ Implement for loading morph data.
-        """
+        """Implement for loading morph data."""
         raise NotImplementedError
 
     def save(self, fs):
@@ -1186,6 +1168,7 @@ class Morph:
         fs.writeInt(len(self.offsets))
         for i in self.offsets:
             i.save(fs)
+
 
 class VertexMorph(Morph):
     def __init__(self, *args, **kwargs):
@@ -1201,6 +1184,7 @@ class VertexMorph(Morph):
             t.load(fs)
             self.offsets.append(t)
 
+
 class VertexMorphOffset:
     def __init__(self):
         self.index = 0
@@ -1214,9 +1198,10 @@ class VertexMorphOffset:
         fs.writeVertexIndex(self.index)
         fs.writeVector(self.offset)
 
+
 class UVMorph(Morph):
     def __init__(self, *args, **kwargs):
-        self.uv_index = kwargs.get('type_index', 3) - 3
+        self.uv_index = kwargs.get("type_index", 3) - 3
         Morph.__init__(self, *args, **kwargs)
 
     def type_index(self):
@@ -1230,6 +1215,7 @@ class UVMorph(Morph):
             t.load(fs)
             self.offsets.append(t)
 
+
 class UVMorphOffset:
     def __init__(self):
         self.index = 0
@@ -1242,6 +1228,7 @@ class UVMorphOffset:
     def save(self, fs):
         fs.writeVertexIndex(self.index)
         fs.writeVector(self.offset)
+
 
 class BoneMorph(Morph):
     def __init__(self, *args, **kwargs):
@@ -1257,6 +1244,7 @@ class BoneMorph(Morph):
             t = BoneMorphOffset()
             t.load(fs)
             self.offsets.append(t)
+
 
 class BoneMorphOffset:
     def __init__(self):
@@ -1276,6 +1264,7 @@ class BoneMorphOffset:
         fs.writeVector(self.location_offset)
         fs.writeVector(self.rotation_offset)
 
+
 class MaterialMorph(Morph):
     def __init__(self, *args, **kwargs):
         Morph.__init__(self, *args, **kwargs)
@@ -1290,6 +1279,7 @@ class MaterialMorph(Morph):
             t = MaterialMorphOffset()
             t.load(fs)
             self.offsets.append(t)
+
 
 class MaterialMorphOffset:
     TYPE_MULT = 0
@@ -1334,6 +1324,7 @@ class MaterialMorphOffset:
         fs.writeVector(self.sphere_texture_factor)
         fs.writeVector(self.toon_texture_factor)
 
+
 class GroupMorph(Morph):
     def __init__(self, *args, **kwargs):
         Morph.__init__(self, *args, **kwargs)
@@ -1348,6 +1339,7 @@ class GroupMorph(Morph):
             t = GroupMorphOffset()
             t.load(fs)
             self.offsets.append(t)
+
 
 class GroupMorphOffset:
     def __init__(self):
@@ -1365,18 +1357,15 @@ class GroupMorphOffset:
 
 class Display:
     def __init__(self):
-        self.name = ''
-        self.name_e = ''
+        self.name = ""
+        self.name_e = ""
 
         self.isSpecial = False
 
         self.data = []
 
     def __repr__(self):
-        return '<Display name %s, name_e %s>'%(
-            self.name,
-            self.name_e,
-            )
+        return f"<Display name {self.name}, name_e {self.name_e}>"
 
     def load(self, fs):
         self.name = fs.readStr()
@@ -1393,9 +1382,9 @@ class Display:
             elif disp_type == 1:
                 index = fs.readMorphIndex()
             else:
-                raise Exception('invalid value.')
+                raise Exception("invalid value.")
             self.data.append((disp_type, index))
-        logging.debug('the number of display elements: %d', len(self.data))
+        logging.debug("the number of display elements: %d", len(self.data))
 
     def save(self, fs):
         fs.writeStr(self.name)
@@ -1411,7 +1400,8 @@ class Display:
             elif disp_type == 1:
                 fs.writeMorphIndex(index)
             else:
-                raise Exception('invalid value.')
+                raise Exception("invalid value.")
+
 
 class Rigid:
     TYPE_SPHERE = 0
@@ -1421,9 +1411,10 @@ class Rigid:
     MODE_STATIC = 0
     MODE_DYNAMIC = 1
     MODE_DYNAMIC_BONE = 2
+
     def __init__(self):
-        self.name = ''
-        self.name_e = ''
+        self.name = ""
+        self.name_e = ""
 
         self.bone = None
         self.collision_group_number = 0
@@ -1444,17 +1435,14 @@ class Rigid:
         self.mode = 0
 
     def __repr__(self):
-        return '<Rigid name %s, name_e %s>'%(
-            self.name,
-            self.name_e,
-            )
+        return f"<Rigid name {self.name}, name_e {self.name_e}>"
 
     def load(self, fs):
         self.name = fs.readStr()
         self.name_e = fs.readStr()
 
         boneIndex = fs.readBoneIndex()
-        if boneIndex != -1:
+        if boneIndex >= 0:
             self.bone = boneIndex
         else:
             self.bone = None
@@ -1502,11 +1490,13 @@ class Rigid:
 
         fs.writeSignedByte(self.mode)
 
+
 class Joint:
     MODE_SPRING6DOF = 0
+
     def __init__(self):
-        self.name = ''
-        self.name_e = ''
+        self.name = ""
+        self.name_e = ""
 
         self.mode = 0
 
@@ -1525,9 +1515,11 @@ class Joint:
         self.spring_rotation_constant = []
 
     def load(self, fs):
-        try: self._load(fs)
-        except struct.error: # possibly contains truncated data
-            if self.src_rigid is None or self.dest_rigid is None: raise
+        try:
+            self._load(fs)
+        except struct.error:  # possibly contains truncated data
+            if self.src_rigid is None or self.dest_rigid is None:
+                raise
             self.location = self.location or (0, 0, 0)
             self.rotation = self.rotation or (0, 0, 0)
             self.maximum_location = self.maximum_location or (0, 0, 0)
@@ -1588,34 +1580,36 @@ class Joint:
         fs.writeVector(self.spring_rotation_constant)
 
 
-
 def load(path):
     with FileReadStream(path) as fs:
-        logging.info('****************************************')
-        logging.info(' mmd_tools_local.pmx module')
-        logging.info('----------------------------------------')
-        logging.info(' Start to load model data form a pmx file')
-        logging.info('            by the mmd_tools_local.pmx modlue.')
-        logging.info('')
+        logging.info("****************************************")
+        logging.info(" mmd_tools_local.pmx module")
+        logging.info("----------------------------------------")
+        logging.info(" Start to load model data form a pmx file")
+        logging.info("            by the mmd_tools_local.pmx modlue.")
+        logging.info("")
         header = Header()
         header.load(fs)
         fs.setHeader(header)
+
         model = Model()
         try:
             model.load(fs)
-        except struct.error as e:
-            logging.error(' * Corrupted file: %s', e)
-            #raise
-        logging.info(' Finished loading.')
-        logging.info('----------------------------------------')
-        logging.info(' mmd_tools_local.pmx module')
-        logging.info('****************************************')
+        except struct.error:
+            logging.exception(" * Corrupted file")
+            # raise
+
+        logging.info(" Finished loading.")
+        logging.info("----------------------------------------")
+        logging.info(" mmd_tools_local.pmx module")
+        logging.info("****************************************")
         return model
+
 
 def save(path, model, add_uv_count=0):
     with FileWriteStream(path) as fs:
         header = Header(model)
-        header.additional_uvs = max(0, min(4, add_uv_count)) # UV1~UV4
+        header.additional_uvs = max(0, min(4, add_uv_count))  # UV1~UV4
         header.save(fs)
         fs.setHeader(header)
         model.save(fs)

--- a/extern_tools/mmd_tools_local/core/pmx/exporter.py
+++ b/extern_tools/mmd_tools_local/core/pmx/exporter.py
@@ -11,13 +11,14 @@ from collections import OrderedDict
 
 import bmesh
 import bpy
-import mathutils
+from mathutils import Euler, Matrix, Vector
 
 from ...bpyutils import FnContext
 from ...operators.misc import MoveObject
 from ...utils import saferelpath
 from .. import pmx
 from ..material import FnMaterial
+from ..model import FnModel
 from ..morph import FnMorph
 from ..sdef import FnSDEF
 from ..translations import FnTranslations
@@ -60,11 +61,11 @@ class _DefaultMaterial:
         # mat.mmd_material.specular_color = (0, 0, 0)
         # mat.mmd_material.ambient_color = (0, 0, 0)
         self.material = mat
-        logging.debug("create default material: %s", str(self.material))
+        logging.debug("create default material: %s", self.material.name)
 
     def __del__(self):
         if self.material:
-            logging.debug("remove default material: %s", str(self.material))
+            logging.debug("remove default material: %s", self.material.name)
             bpy.data.materials.remove(self.material)
 
 
@@ -74,6 +75,14 @@ class __PmxExporter:
         "EYEBROW": pmx.Morph.CATEGORY_EYEBROW,
         "EYE": pmx.Morph.CATEGORY_EYE,
         "MOUTH": pmx.Morph.CATEGORY_MOUTH,
+    }
+
+    MORPH_TYPES = {
+        pmx.GroupMorph: "group_morphs",
+        pmx.VertexMorph: "vertex_morphs",
+        pmx.BoneMorph: "bone_morphs",
+        pmx.UVMorph: "uv_morphs",
+        pmx.MaterialMorph: "material_morphs",
     }
 
     def __init__(self):
@@ -222,51 +231,82 @@ class __PmxExporter:
             logging.warning("  The texture file does not exist: %s", t.path)
         return len(self.__model.textures) - 1
 
-    def __copy_textures(self, output_dir, base_folder=""):
+    def __copy_textures(self, output_dir, base_folder="", copy_textures_mode="NONE"):
+        # Step 0: Store original paths for Step 2
+        original_paths = {texture: texture.path for texture in self.__model.textures}
+
+        # Step 1: Set PMX texture relative paths
         tex_dir_fallback = os.path.join(output_dir, "textures")
         tex_dir_preference = FnContext.get_addon_preferences_attribute(FnContext.ensure_context(), "base_texture_folder", "")
 
-        path_set = set()  # to prevent overwriting
-        tex_copy_list = []
         for texture in self.__model.textures:
-            path = texture.path
-            tex_dir = output_dir  # restart to the default directory at each loop
-            if not os.path.isfile(path):
-                logging.warning("*** skipping texture file which does not exist: %s", path)
-                path_set.add(os.path.normcase(path))
-                continue
-            dst_name = os.path.basename(path)
+            current_path = original_paths[texture]
+
+            # Calculate the ideal destination filename and directory based on preference
+            dst_name = os.path.basename(current_path)
+            tex_dir = output_dir  # Restart to the default directory at each loop
             if base_folder:
-                dst_name = saferelpath(path, base_folder, strategy="outside")
+                dst_name = saferelpath(current_path, base_folder, strategy="outside")
                 if dst_name.startswith(".."):
-                    # Check if the texture comes from the preferred folder
                     if tex_dir_preference:
-                        dst_name = saferelpath(path, tex_dir_preference, strategy="outside")
+                        dst_name = saferelpath(current_path, tex_dir_preference, strategy="outside")
                     if dst_name.startswith(".."):
-                        # If the code reaches here the texture is somewhere else
-                        logging.warning("The texture %s is not inside the base texture folder", path)
-                        # Fall back to basename and textures folder
-                        dst_name = os.path.basename(path)
+                        logging.warning("The texture %s is not inside the base texture folder", current_path)
+                        dst_name = os.path.basename(current_path)
                         tex_dir = tex_dir_fallback
             else:
                 tex_dir = tex_dir_fallback
-            dest_path = os.path.join(tex_dir, dst_name)
-            if os.path.normcase(path) != os.path.normcase(dest_path):  # Only copy if the paths are different
-                tex_copy_list.append((texture, path, dest_path))
-            else:
-                path_set.add(os.path.normcase(path))
 
-        for texture, path, dest_path in tex_copy_list:
-            counter = 1
-            base, ext = os.path.splitext(dest_path)
-            while os.path.normcase(dest_path) in path_set:
-                dest_path = "%s_%d%s" % (base, counter, ext)
-                counter += 1
-            path_set.add(os.path.normcase(dest_path))
-            os.makedirs(os.path.dirname(dest_path), exist_ok=True)
-            shutil.copyfile(path, dest_path)
-            logging.info("Copy file %s --> %s", path, dest_path)
-            texture.path = dest_path
+            # Determine the full destination path and the final PMX relative path
+            full_dest_path = os.path.join(tex_dir, dst_name)
+            final_relative_path = os.path.relpath(full_dest_path, start=output_dir).replace("\\", "/")
+
+            texture.path = final_relative_path
+
+        # Step 2: Copy textures
+        if copy_textures_mode in {"SKIP_EXISTING", "OVERWRITE"}:
+            for texture in self.__model.textures:
+                src_path = original_paths[texture]
+                dest_relative_path = texture.path
+                # Reconstruct the absolute destination path from the PMX's new relative path
+                full_dest_path = os.path.abspath(os.path.join(output_dir, dest_relative_path))
+
+                if os.path.exists(full_dest_path) and copy_textures_mode == "SKIP_EXISTING":
+                    logging.info("Skipping copy for existing texture: '%s'", full_dest_path)
+                    continue
+
+                os.makedirs(os.path.dirname(full_dest_path), exist_ok=True)
+
+                # Check if the source is a packed image
+                packed_image = None
+                for image in bpy.data.images:
+                    if image.packed_file and (image.filepath == src_path or os.path.basename(image.filepath) == os.path.basename(src_path)):
+                        packed_image = image
+                        break
+
+                # Handle packed images first by extracting them
+                if packed_image:
+                    logging.info("Extracting packed texture '%s' -> '%s'", packed_image.name, full_dest_path)
+                    try:
+                        with open(full_dest_path, "wb") as f:
+                            f.write(packed_image.packed_file.data)
+                    except PermissionError:
+                        logging.warning(f"Permission denied. Could not write texture to '{full_dest_path}'. Skipping.")
+                    except Exception as e:
+                        logging.exception(f"An unexpected error occurred while writing packed texture: {e}")
+
+                # If not packed, handle existing external files by copying them
+                elif os.path.isfile(src_path):
+                    if os.path.normcase(src_path) != os.path.normcase(full_dest_path):
+                        logging.info("Copying external texture '%s' -> '%s'", src_path, full_dest_path)
+                        try:
+                            shutil.copy2(src_path, full_dest_path)
+                        except PermissionError:
+                            logging.warning(f"Permission denied. Could not copy texture to '{full_dest_path}'. Skipping.")
+                        except Exception as e:
+                            logging.exception(f"An unexpected error occurred while copying external texture: {e}")
+                else:
+                    logging.warning("Source for texture '%s' not found. Cannot copy.", src_path)
 
     def __exportMaterial(self, material, num_faces):
         p_mat = pmx.Material()
@@ -315,8 +355,7 @@ class __PmxExporter:
     def __countBoneDepth(cls, bone):
         if bone.parent is None:
             return 0
-        else:
-            return cls.__countBoneDepth(bone.parent) + 1
+        return cls.__countBoneDepth(bone.parent) + 1
 
     def __exportBones(self, root, meshes):
         """Export bones.
@@ -333,9 +372,9 @@ class __PmxExporter:
         world_mat = arm.matrix_world
         r = {}
 
-        sorted_bones = sorted(pose_bones, key=lambda x: x.mmd_bone.bone_id if x.mmd_bone.bone_id >= 0 else float("inf"))
+        sorted_bones = sorted(pose_bones, key=lambda x: (x.mmd_bone.bone_id if x.mmd_bone.bone_id >= 0 else float("inf"), x.name))
+        bone_id_map = {p_bone.mmd_bone.bone_id: p_bone for p_bone in sorted_bones}
 
-        Vector = mathutils.Vector
         pmx_matrix = world_mat * self.__scale
         pmx_matrix[1], pmx_matrix[2] = pmx_matrix[2].copy(), pmx_matrix[1].copy()
 
@@ -389,21 +428,29 @@ class __PmxExporter:
                     )
                     and p_bone.parent.mmd_bone.is_tip
                 ):
-                    logging.debug(' * fix location of bone %s, parent %s is tip', bone.name, pmx_bone.parent.name)
+                    logging.debug(" * fix location of bone %s, parent %s is tip", bone.name, pmx_bone.parent.name)
                     pmx_bone.location = boneMap[pmx_bone.parent].location
                 # fmt: on
 
-                if mmd_bone.display_connection_type == "BONE":
-                    if mmd_bone.is_tip:
+                if mmd_bone.is_tip:
+                    if mmd_bone.display_connection_type == "BONE":
                         pmx_bone.displayConnection = -1
-                    else:
-                        pmx_bone.displayConnection = mmd_bone.display_connection_bone_id
-                elif mmd_bone.display_connection_type == "OFFSET":
-                    if mmd_bone.is_tip:
+                    elif mmd_bone.display_connection_type == "OFFSET":
                         pmx_bone.displayConnection = (0.0, 0.0, 0.0)
-                    else:
+                elif mmd_bone.display_connection_type == "BONE" and mmd_bone.display_connection_bone_id >= 0:
+                    target_bone_id = mmd_bone.display_connection_bone_id
+                    target_p_bone = bone_id_map.get(target_bone_id)
+
+                    # Force OFFSET if target bone is too far.
+                    if target_p_bone and (target_p_bone.head - p_bone.tail).length > 0.01:
+                        logging.warning('Bone "%s": Target bone "%s" is too far. Automatically switching display connection to OFFSET.', p_bone.name, target_p_bone.name)
                         tail_loc = __to_pmx_location(p_bone.tail)
                         pmx_bone.displayConnection = tail_loc - pmx_bone.location
+                    else:
+                        pmx_bone.displayConnection = target_bone_id
+                else:  # mmd_bone.display_connection_type == "OFFSET" or display_connection_bone_id invalid
+                    tail_loc = __to_pmx_location(p_bone.tail)
+                    pmx_bone.displayConnection = tail_loc - pmx_bone.location
 
                 if mmd_bone.enabled_fixed_axis:
                     pmx_bone.axis = __to_pmx_axis(mmd_bone.fixed_axis, p_bone)
@@ -435,7 +482,7 @@ class __PmxExporter:
         self.__exportIK(root, r)
         return r
 
-    def __exportIKLinks(self, pose_bone, count, bone_map, ik_links, custom_bone):
+    def __exportIKLinks(self, pose_bone, count, bone_map, ik_links, custom_bone, ik_export_option):
         if count <= 0 or pose_bone is None or pose_bone.name not in bone_map:
             return ik_links
 
@@ -443,31 +490,37 @@ class __PmxExporter:
         ik_link = pmx.IKLink()
         ik_link.target = bone_map[pose_bone.name]
 
-        from math import pi
-
-        minimum, maximum = [-pi] * 3, [pi] * 3
+        minimum, maximum = [-math.pi] * 3, [math.pi] * 3
         unused_counts = 0
-        ik_limit_custom = next((c for c in custom_bone.constraints if c.type == "LIMIT_ROTATION" and c.name == "mmd_ik_limit_custom%d" % len(ik_links)), None)
-        ik_limit_override = next((c for c in pose_bone.constraints if c.type == "LIMIT_ROTATION" and not c.mute), None)
-        for i, axis in enumerate("xyz"):
-            if ik_limit_custom:  # custom ik limits for MMD only
-                if getattr(ik_limit_custom, "use_limit_" + axis):
-                    minimum[i] = getattr(ik_limit_custom, "min_" + axis)
-                    maximum[i] = getattr(ik_limit_custom, "max_" + axis)
+
+        if ik_export_option == "IGNORE_ALL":
+            unused_counts = 3
+        else:
+            ik_limit_custom = next((c for c in custom_bone.constraints if c.type == "LIMIT_ROTATION" and c.name == "mmd_ik_limit_custom%d" % len(ik_links)), None)
+            ik_limit_override = next((c for c in pose_bone.constraints if c.type == "LIMIT_ROTATION" and not c.mute), None)
+
+            for i, axis in enumerate("xyz"):
+                if ik_limit_custom:  # custom ik limits for MMD only
+                    if getattr(ik_limit_custom, "use_limit_" + axis):
+                        minimum[i] = getattr(ik_limit_custom, "min_" + axis)
+                        maximum[i] = getattr(ik_limit_custom, "max_" + axis)
+                    else:
+                        unused_counts += 1
+                    continue
+
+                if getattr(pose_bone, "lock_ik_" + axis):
+                    minimum[i] = maximum[i] = 0
+                elif ik_limit_override is not None and getattr(ik_limit_override, "use_limit_" + axis):
+                    minimum[i] = getattr(ik_limit_override, "min_" + axis)
+                    maximum[i] = getattr(ik_limit_override, "max_" + axis)
+                elif ik_limit_override is not None and ik_export_option == "OVERRIDE_CONTROLLED":
+                    # mmd_ik_limit_override exists but axis disabled, don't check other sources
+                    unused_counts += 1
+                elif getattr(pose_bone, "use_ik_limit_" + axis):
+                    minimum[i] = getattr(pose_bone, "ik_min_" + axis)
+                    maximum[i] = getattr(pose_bone, "ik_max_" + axis)
                 else:
                     unused_counts += 1
-                continue
-
-            if getattr(pose_bone, "lock_ik_" + axis):
-                minimum[i] = maximum[i] = 0
-            elif ik_limit_override is not None and getattr(ik_limit_override, "use_limit_" + axis):
-                minimum[i] = getattr(ik_limit_override, "min_" + axis)
-                maximum[i] = getattr(ik_limit_override, "max_" + axis)
-            elif getattr(pose_bone, "use_ik_limit_" + axis):
-                minimum[i] = getattr(pose_bone, "ik_min_" + axis)
-                maximum[i] = getattr(pose_bone, "ik_max_" + axis)
-            else:
-                unused_counts += 1
 
         if unused_counts < 3:
             convertIKLimitAngles = pmx.importer.PMXImporter.convertIKLimitAngles
@@ -476,7 +529,7 @@ class __PmxExporter:
             ik_link.minimumAngle = list(minimum)
             ik_link.maximumAngle = list(maximum)
 
-        return self.__exportIKLinks(pose_bone.parent, count - 1, bone_map, ik_links + [ik_link], custom_bone)
+        return self.__exportIKLinks(pose_bone.parent, count - 1, bone_map, ik_links + [ik_link], custom_bone, ik_export_option)
 
     def __exportIK(self, root, bone_map):
         """Export IK constraints
@@ -486,6 +539,8 @@ class __PmxExporter:
         arm = self.__armature
         ik_loop_factor = root.mmd_root.ik_loop_factor
         pose_bones = arm.pose.bones
+
+        logging.info("IK angle limits handling: %s", self.__ik_angle_limits)
 
         ik_target_custom_map = {getattr(b.constraints.get("mmd_ik_target_custom", None), "subtarget", None): b for b in pose_bones if not b.is_mmd_shadow_bone}
 
@@ -529,7 +584,7 @@ class __PmxExporter:
                     else:
                         pmx_ik_bone.rotationConstraint = bone.mmd_bone.ik_rotation_constraint
                     pmx_ik_bone.target = bone_map[ik_target_bone.name]
-                    pmx_ik_bone.ik_links = self.__exportIKLinks(ik_chain0, c.chain_count, bone_map, [], ik_pose_bone)
+                    pmx_ik_bone.ik_links = self.__exportIKLinks(ik_chain0, c.chain_count, bone_map, [], ik_pose_bone, self.__ik_angle_limits)
 
     def __get_ik_control_bone(self, ik_constraint):
         arm = ik_constraint.target
@@ -587,13 +642,13 @@ class __PmxExporter:
             for vtx_morph in root.mmd_root.vertex_morphs:
                 morph_english_names[vtx_morph.name] = vtx_morph.name_e
                 morph_categories[vtx_morph.name] = categories.get(vtx_morph.category, pmx.Morph.CATEGORY_OHTER)
-            shape_key_names.sort(key=lambda x: root.mmd_root.vertex_morphs.find(x))
+            shape_key_names.sort(key=root.mmd_root.vertex_morphs.find)
 
         for i in shape_key_names:
             morph = pmx.VertexMorph(name=i, name_e=morph_english_names.get(i, ""), category=morph_categories.get(i, pmx.Morph.CATEGORY_OHTER))
             self.__model.morphs.append(morph)
 
-        append_table = dict(zip(shape_key_names, [m.offsets.append for m in self.__model.morphs]))
+        append_table = dict(zip(shape_key_names, [m.offsets.append for m in self.__model.morphs], strict=False))
         for v in self.__exported_vertices:
             for i, offset in v.offsets.items():
                 mo = pmx.VertexMorphOffset()
@@ -630,7 +685,7 @@ class __PmxExporter:
             self.__model.morphs.append(mat_morph)
 
     def __sortMaterials(self):
-        """sort materials for alpha blending
+        """Sort materials for alpha blending
 
         モデル内全頂点の平均座標をモデルの中心と考えて、
         モデル中心座標とマテリアルがアサインされている全ての面の構成頂点との平均距離を算出。
@@ -638,23 +693,24 @@ class __PmxExporter:
         モデル中心座標から離れている位置で使用されているマテリアルほどリストの後ろ側にくるように。
         かなりいいかげんな実装
         """
-        center = mathutils.Vector([0, 0, 0])
         vertices = self.__model.vertices
         vert_num = len(vertices)
-        for v in self.__model.vertices:
-            center += mathutils.Vector(v.co) / vert_num
+        if vert_num > 0:
+            center = sum((Vector(v.co) for v in vertices), Vector((0, 0, 0))) / vert_num
+        else:
+            center = Vector((0, 0, 0))
 
         faces = self.__model.faces
         offset = 0
         distances = []
-        for mat, bl_mat_name in zip(self.__model.materials, self.__material_name_table):
+        for mat, bl_mat_name in zip(self.__model.materials, self.__material_name_table, strict=False):
             d = 0
             face_num = int(mat.vertex_count / 3)
             for i in range(offset, offset + face_num):
                 face = faces[i]
-                d += (mathutils.Vector(vertices[face[0]].co) - center).length
-                d += (mathutils.Vector(vertices[face[1]].co) - center).length
-                d += (mathutils.Vector(vertices[face[2]].co) - center).length
+                d += (Vector(vertices[face[0]].co) - center).length
+                d += (Vector(vertices[face[1]].co) - center).length
+                d += (Vector(vertices[face[2]].co) - center).length
             distances.append((d / mat.vertex_count, mat, offset, face_num, bl_mat_name))
             offset += face_num
         sorted_faces = []
@@ -759,8 +815,8 @@ class __PmxExporter:
             group_morph = pmx.GroupMorph(name=morph.name, name_e=morph.name_e, category=categories.get(morph.category, pmx.Morph.CATEGORY_OHTER))
             self.__model.morphs.append(group_morph)
 
-        morph_map = self.__get_pmx_morph_map()
-        for morph, group_morph in zip(mmd_root.group_morphs, self.__model.morphs[start_index:]):
+        morph_map = self.__get_pmx_morph_map(root)
+        for morph, group_morph in zip(mmd_root.group_morphs, self.__model.morphs[start_index:], strict=False):
             for data in morph.data:
                 morph_index = morph_map.get((data.morph_type, data.name), -1)
                 if morph_index < 0:
@@ -773,7 +829,7 @@ class __PmxExporter:
 
     def __exportDisplayItems(self, root, bone_map):
         res = []
-        morph_map = self.__get_pmx_morph_map()
+        morph_map = self.__get_pmx_morph_map(root)
         for i in root.mmd_root.display_item_frames:
             d = pmx.Display()
             d.name = i.name
@@ -784,32 +840,63 @@ class __PmxExporter:
                 if j.type == "BONE" and j.name in bone_map:
                     items.append((0, bone_map[j.name]))
                 elif j.type == "MORPH" and (j.morph_type, j.name) in morph_map:
-                    items.append((1, morph_map[(j.morph_type, j.name)]))
+                    items.append((1, morph_map[j.morph_type, j.name]))
                 else:
                     logging.warning("Display item (%s, %s) was not found.", j.type, j.name)
             d.data = items
             res.append(d)
         self.__model.display = res
 
-    def __get_pmx_morph_map(self):
-        morph_types = {
-            pmx.GroupMorph: "group_morphs",
-            pmx.VertexMorph: "vertex_morphs",
-            pmx.BoneMorph: "bone_morphs",
-            pmx.UVMorph: "uv_morphs",
-            pmx.MaterialMorph: "material_morphs",
-        }
+    def __get_facial_frame(self, root):
+        for frame in root.mmd_root.display_item_frames:
+            if frame.name == "表情":
+                return frame
+        return None
+
+    def __get_pmx_morph_map(self, root):
+        assert root is not None, "root should not be None when __get_pmx_morph_map is called"
+
         morph_map = {}
-        for i, m in enumerate(self.__model.morphs):
-            morph_map[(morph_types[type(m)], m.name)] = i
+        index = 0
+
+        # Build set of actually existing morphs to filter against
+        existing_morphs = set()
+        existing_morphs.update((self.MORPH_TYPES[type(m)], m.name) for m in self.__model.morphs)
+
+        # Priority: Display Panel order (only for existing morphs)
+        facial_frame = self.__get_facial_frame(root)
+        if facial_frame:
+            for item in facial_frame.data:
+                if item.type == "MORPH":
+                    key = (item.morph_type, item.name)
+                    # Only add if morph actually exists and not already mapped
+                    if key not in morph_map and key in existing_morphs:
+                        morph_map[key] = index
+                        index += 1
+
+        # Fallback: remaining morphs in original order
+        for m in self.__model.morphs:
+            key = (self.MORPH_TYPES[type(m)], m.name)
+            if key not in morph_map:
+                morph_map[key] = index
+                index += 1
+
         return morph_map
 
     def __exportRigidBodies(self, rigid_bodies, bone_map):
         rigid_map = {}
         rigid_cnt = 0
-        Vector = mathutils.Vector
         for obj in rigid_bodies:
             t, r, s = obj.matrix_world.decompose()
+            if any(math.isnan(val) for val in t):
+                logging.warning(f"Rigid body '{obj.name}' has invalid position coordinates, using default position")
+                t = Vector((0.0, 0.0, 0.0))
+            if any(math.isnan(val) for val in r):
+                logging.warning(f"Rigid body '{obj.name}' has invalid rotation coordinates, using default rotation")
+                r = Euler((0.0, 0.0, 0.0), "YXZ")
+            if any(math.isnan(val) for val in s):
+                logging.warning(f"Rigid body '{obj.name}' has invalid scale coordinates, using default scale")
+                s = Vector((1.0, 1.0, 1.0))
             r = r.to_euler("YXZ")
             rb = obj.rigid_body
             if rb is None:
@@ -857,7 +944,6 @@ class __PmxExporter:
         return rigid_map
 
     def __exportJoints(self, joints, rigid_map):
-        Vector = mathutils.Vector
         for joint in joints:
             t, r, s = joint.matrix_world.decompose()
             r = r.to_euler("YXZ")
@@ -885,21 +971,67 @@ class __PmxExporter:
     @staticmethod
     def __convertFaceUVToVertexUV(vert_index, uv, normal, vertices_map):
         vertices = vertices_map[vert_index]
+        assert vertices, f"Empty vertices list for vertex index {vert_index}"
+
         for i in vertices:
             if i.uv is None:
                 i.uv = uv
                 i.normal = normal
                 return i
-            elif (i.uv - uv).length < 0.001 and (normal - i.normal).length < 0.01:
+            if (i.uv - uv).length < 0.001 and (normal - i.normal).length < 0.01:
                 return i
-        n = copy.copy(i)  # shallow copy should be fine
+        n = copy.copy(vertices[0])  # shallow copy should be fine
         n.uv = uv
         n.normal = normal
         vertices.append(n)
         return n
 
+    def __convertFaceUVToVertexUVSmooth(self, vert_index, uv, normal, vertices_map, face_area, loop_angle):
+        """Convert face UV to vertex UV with weighted normal averaging."""
+        vertices = vertices_map[vert_index]
+        assert vertices, f"Empty vertices list for vertex index {vert_index}"
+
+        v = None
+        for i in vertices:
+            if i.uv is None:
+                i.uv = uv
+                v = i
+                break
+            if (i.uv - uv).length < 0.001:  # UV requires exact matching
+                v = i
+                break
+
+        if v is None:
+            # Create new vertex for different UV
+            v = copy.copy(vertices[0])
+            v.uv = uv
+            vertices.append(v)
+
+        # Initialize averaging lists if needed
+        for attr_name in ["_normal_list", "_area_list", "_angle_list"]:
+            if not hasattr(v, attr_name):
+                setattr(v, attr_name, [])
+
+        # Append current values to averaging lists
+        v._normal_list.append(normal)
+        v._area_list.append(face_area)
+        v._angle_list.append(loop_angle)
+
+        # Average normals
+        if v._normal_list.count(v._normal_list[0]) == len(v._normal_list):  # All normals identical
+            v.normal = normal
+        else:
+            weights = [angle * area for angle, area in zip(v._angle_list, v._area_list, strict=False)]
+            total_weight = sum(weights) or 1.0  # Avoid division by zero
+            weighted_normal_sum = sum((n * w for n, w in zip(v._normal_list, weights, strict=False)), Vector((0, 0, 0)))
+            v.normal = (weighted_normal_sum / total_weight).normalized()
+
+        return v
+
     @staticmethod
     def __convertAddUV(vert, adduv, addzw, uv_index, vertices, rip_vertices):
+        assert vertices, "Empty vertices list for additional UV processing"
+
         if vert.add_uvs[uv_index] is None:
             vert.add_uvs[uv_index] = (adduv, addzw)
             return vert
@@ -916,45 +1048,6 @@ class __PmxExporter:
         return n
 
     @staticmethod
-    def __triangulate(mesh, custom_normals):
-        bm = bmesh.new()
-        bm.from_mesh(mesh)
-
-        is_triangulated = True
-        face_verts_to_loop_id_map = {}
-
-        loop_id = 0
-        for f in bm.faces:
-            vert_to_loop_id = face_verts_to_loop_id_map.setdefault(f, {})
-            if is_triangulated and len(f.verts) != 3:
-                is_triangulated = False
-            for v in f.verts:
-                vert_to_loop_id[v] = loop_id
-                loop_id += 1
-
-        loop_normals, face_indices = None, None
-        if is_triangulated:
-            loop_normals = custom_normals
-        else:
-            face_map = bmesh.ops.triangulate(bm, faces=bm.faces, quad_method="FIXED", ngon_method="EAR_CLIP")["face_map"]
-            logging.debug(" - Remapping custom normals...")
-            loop_normals, face_indices = [], []
-            for f in bm.faces:
-                f_orig = face_map.get(f, f)
-                face_indices.append(f_orig.index)
-                vert_to_loop_id = face_verts_to_loop_id_map[f_orig]
-                for v in f.verts:
-                    loop_normals.append(custom_normals[vert_to_loop_id[v]])
-            logging.debug("   - Done (faces:%d)", len(bm.faces))
-            bm.to_mesh(mesh)
-            face_map.clear()
-        face_verts_to_loop_id_map.clear()
-        bm.free()
-
-        assert len(loop_normals) == len(mesh.loops)
-        return loop_normals, face_indices
-
-    @staticmethod
     def __get_normals(mesh, matrix):
         logging.debug(" - Get normals...")
         custom_normals = [(matrix @ cn.vector).normalized() for cn in mesh.corner_normals]
@@ -962,28 +1055,76 @@ class __PmxExporter:
         return custom_normals
 
     def __doLoadMeshData(self, meshObj, bone_map):
-        vg_to_bone = {i: bone_map[x.name] for i, x in enumerate(meshObj.vertex_groups) if x.name in bone_map}
-        vg_edge_scale = meshObj.vertex_groups.get("mmd_edge_scale", None)
-        vg_vertex_order = meshObj.vertex_groups.get("mmd_vertex_order", None)
-
-        pmx_matrix = meshObj.matrix_world * self.__scale
-        pmx_matrix[1], pmx_matrix[2] = pmx_matrix[2].copy(), pmx_matrix[1].copy()
-        sx, sy, sz = meshObj.matrix_world.to_scale()
-        normal_matrix = pmx_matrix.to_3x3()
-        if not (sx == sy == sz):
-            invert_scale_matrix = mathutils.Matrix([[1.0 / sx, 0, 0], [0, 1.0 / sy, 0], [0, 0, 1.0 / sz]])
-            normal_matrix = normal_matrix @ invert_scale_matrix  # reset the scale of meshObj.matrix_world
-            normal_matrix = normal_matrix @ invert_scale_matrix  # the scale transform of normals
-
         def _to_mesh(obj):
             bpy.context.view_layer.update()
             depsgraph = bpy.context.evaluated_depsgraph_get()
             return obj.evaluated_get(depsgraph).to_mesh(depsgraph=depsgraph, preserve_all_data_layers=True)
 
-        _to_mesh_clear = lambda obj, mesh: obj.to_mesh_clear()
+        def _to_mesh_clear(obj, mesh):
+            return obj.to_mesh_clear()
 
-        base_mesh = _to_mesh(meshObj)
-        loop_normals, face_indices = self.__triangulate(base_mesh, self.__get_normals(base_mesh, normal_matrix))
+        # Use try-finally pattern to guarantee temporary modifier cleanup, preventing scene pollution
+        base_mesh = None
+        temp_tri_mod = None
+        original_smooth_states = None
+        try:
+            # Clear any existing mesh data before processing
+            _to_mesh_clear(meshObj, base_mesh)
+
+            # SMOOTH_KEEP_SHARP: Apply smooth shading while preserving sharp edges
+            if self.__normal_handling == "SMOOTH_KEEP_SHARP":
+                # Save original smooth states
+                original_smooth_states = [False] * len(meshObj.data.polygons)
+                meshObj.data.polygons.foreach_get("use_smooth", original_smooth_states)
+                meshObj.data.polygons.foreach_set("use_smooth", [True] * len(meshObj.data.polygons))
+
+            # Check if triangulation is needed
+            base_mesh = _to_mesh(meshObj)
+            needs_triangulation = any(len(poly.vertices) > 3 for poly in base_mesh.polygons)
+            if needs_triangulation:
+                # Add triangulation modifier
+                temp_tri_mod = meshObj.modifiers.new(name="temp_triangulate_modifier", type="TRIANGULATE")
+                temp_tri_mod.quad_method = "BEAUTY"
+                temp_tri_mod.ngon_method = "BEAUTY"
+                temp_tri_mod.keep_custom_normals = True
+
+            # Re-evaluate mesh with all modifiers applied
+            base_mesh = _to_mesh(meshObj)
+        except Exception:
+            logging.exception("Error occurred while applying mesh modifiers")
+            raise
+        finally:
+            # Restore original smooth states
+            if original_smooth_states is not None:
+                meshObj.data.polygons.foreach_set("use_smooth", original_smooth_states)
+            # Clean up modifier
+            if temp_tri_mod:
+                meshObj.modifiers.remove(temp_tri_mod)
+
+        # Process vertex groups after triangulation
+        vg_to_bone = {i: bone_map[x.name] for i, x in enumerate(meshObj.vertex_groups) if x.name in bone_map}
+        vg_edge_scale = meshObj.vertex_groups.get("mmd_edge_scale", None)
+        vg_vertex_order = meshObj.vertex_groups.get("mmd_vertex_order", None)
+
+        # Setup transformation matrices
+        pmx_matrix = meshObj.matrix_world * self.__scale
+        pmx_matrix[1], pmx_matrix[2] = pmx_matrix[2].copy(), pmx_matrix[1].copy()
+        sx, sy, sz = meshObj.matrix_world.to_scale()
+        normal_matrix = pmx_matrix.to_3x3()
+        if not (sx == sy == sz):
+            invert_scale_matrix = Matrix([[1.0 / sx, 0, 0], [0, 1.0 / sy, 0], [0, 0, 1.0 / sz]])
+            normal_matrix @= invert_scale_matrix  # reset the scale of meshObj.matrix_world
+            normal_matrix @= invert_scale_matrix  # the scale transform of normals
+
+        # Extract normals and angles before apply transformation
+        loop_normals = self.__get_normals(base_mesh, normal_matrix)
+        bm_temp = bmesh.new()
+        bm_temp.from_mesh(base_mesh)
+        loop_angles = []
+        for face in bm_temp.faces:
+            loop_angles.extend(loop.calc_angle() for loop in face.loops)
+        bm_temp.free()
+        # Apply transformation to triangulated mesh
         base_mesh.transform(pmx_matrix)
 
         def _get_weight(vertex_group_index, vertex, default_weight):
@@ -994,32 +1135,38 @@ class __PmxExporter:
 
         get_edge_scale = None
         if vg_edge_scale:
-            get_edge_scale = lambda x: _get_weight(vg_edge_scale.index, x, 1)
+            def get_edge_scale(x):
+                return _get_weight(vg_edge_scale.index, x, 1)
         else:
-            get_edge_scale = lambda x: 1
+            def get_edge_scale(x):
+                return 1
 
         get_vertex_order = None
         if self.__vertex_order_map:  # sort vertices
             mesh_id = self.__vertex_order_map.setdefault("mesh_id", 0)
             self.__vertex_order_map["mesh_id"] += 1
             if vg_vertex_order and self.__vertex_order_map["method"] == "CUSTOM":
-                get_vertex_order = lambda x: (mesh_id, _get_weight(vg_vertex_order.index, x, 2), x.index)
+                def get_vertex_order(x):
+                    return (mesh_id, _get_weight(vg_vertex_order.index, x, 2), x.index)
             else:
-                get_vertex_order = lambda x: (mesh_id, x.index)
+                def get_vertex_order(x):
+                    return (mesh_id, x.index)
         else:
-            get_vertex_order = lambda x: None
+            def get_vertex_order(x):
+                return None
 
         uv_morph_names = {g.index: (n, x) for g, n, x in FnMorph.get_uv_morph_vertex_groups(meshObj)}
-
+        AXIS_MAP = {"X": 0, "Y": 1, "Z": 2, "W": 3}
         def get_uv_offsets(v):
             uv_offsets = {}
             for x in v.groups:
-                if x.group in uv_morph_names and x.weight > 0:
+                if x.weight > 0 and x.group in uv_morph_names:
                     name, axis = uv_morph_names[x.group]
                     d = uv_offsets.setdefault(name, [0, 0, 0, 0])
-                    d["XYZW".index(axis[1])] += -x.weight if axis[0] == "-" else x.weight
+                    d[AXIS_MAP[axis[1]]] += -x.weight if axis[0] == "-" else x.weight
             return uv_offsets
 
+        # Create base vertices from triangulated mesh
         base_vertices = {}
         for v in base_mesh.vertices:
             base_vertices[v.index] = [
@@ -1030,17 +1177,50 @@ class __PmxExporter:
                     get_edge_scale(v),
                     get_vertex_order(v),
                     get_uv_offsets(v),
-                )
+                ),
             ]
 
-        # load face data
+        # Extract vertex colors as ADD UV2
+        vertex_colors = None
+        vertex_colors_data = None
+        if self.__export_vertex_colors_as_adduv2:
+            vertex_colors = base_mesh.vertex_colors.active
+            if vertex_colors:
+                vertex_colors_data = [c.color for c in vertex_colors.data]
+
+                if "UV1" not in base_mesh.uv_layers:
+                    uv1_layer = base_mesh.uv_layers.new(name="UV1")
+                    for loop_data in uv1_layer.data:
+                        loop_data.uv = (0, 1.0)
+
+                if "UV2" not in base_mesh.uv_layers:
+                    base_mesh.uv_layers.new(name="UV2")
+                if "_UV2" not in base_mesh.uv_layers:
+                    base_mesh.uv_layers.new(name="_UV2")
+
+                uv2_layer = base_mesh.uv_layers["UV2"]
+                uv2_zw_layer = base_mesh.uv_layers["_UV2"]
+
+                for loop_idx, color in enumerate(vertex_colors_data):
+                    if loop_idx < len(uv2_layer.data):
+                        # Pre-flip V coordinates to compensate for flipUV_V processing
+                        uv2_layer.data[loop_idx].uv = (color[0], 1.0 - color[1])
+                        uv2_zw_layer.data[loop_idx].uv = (color[2], 1.0 - color[3])
+                logging.info("Export vertex colors as ADD UV2")
+
+        # Process UV layers
+        bl_add_uvs = [i for i in base_mesh.uv_layers[1:] if not i.name.startswith("_")]
+        self.__add_uv_count = min(max(self.__add_uv_count, len(bl_add_uvs)), 4)
+
+        # Process faces from triangulated mesh
         class _DummyUV:
-            uv1 = uv2 = uv3 = mathutils.Vector((0, 1))
+            uv1 = uv2 = uv3 = Vector((0, 1))
 
             def __init__(self, uvs):
                 self.uv1, self.uv2, self.uv3 = (v.uv.copy() for v in uvs)
 
-        _UVWrapper = lambda x: (_DummyUV(x[i : i + 3]) for i in range(0, len(x), 3))
+        def _UVWrapper(x):
+            return (_DummyUV(x[i : i + 3]) for i in range(0, len(x), 3))
 
         material_faces = {}
         uv_data = base_mesh.uv_layers.active
@@ -1048,45 +1228,52 @@ class __PmxExporter:
             uv_data = _UVWrapper(uv_data.data)
         else:
             uv_data = iter(lambda: _DummyUV, None)
-        face_seq = []
-        for face, uv, face_index in zip(base_mesh.polygons, uv_data, face_indices or iter(lambda: -1, None)):
-            if len(face.vertices) != 3:
-                raise Exception
-            idx = face.index * 3
-            n1, n2, n3 = loop_normals[idx : idx + 3]
-            v1 = self.__convertFaceUVToVertexUV(face.vertices[0], uv.uv1, n1, base_vertices)
-            v2 = self.__convertFaceUVToVertexUV(face.vertices[1], uv.uv2, n2, base_vertices)
-            v3 = self.__convertFaceUVToVertexUV(face.vertices[2], uv.uv3, n3, base_vertices)
 
-            t = _Face([v1, v2, v3], face_index)
+        face_seq = []
+        for face_idx, (face, uv) in enumerate(zip(base_mesh.polygons, uv_data, strict=False)):
+            if len(face.vertices) != 3:
+                raise ValueError(f"Face should be triangulated. Face index: {face.index}, Mesh name: {base_mesh.name}")
+
+            loop_indices = list(face.loop_indices)
+            n1, n2, n3 = [loop_normals[idx] for idx in loop_indices]
+            a1, a2, a3 = [loop_angles[idx] for idx in loop_indices]
+            face_area = face.area
+
+            if self.__normal_handling == "SMOOTH_ALL_NORMALS":
+                v1 = self.__convertFaceUVToVertexUVSmooth(face.vertices[0], uv.uv1, n1, base_vertices, face_area, a1)
+                v2 = self.__convertFaceUVToVertexUVSmooth(face.vertices[1], uv.uv2, n2, base_vertices, face_area, a2)
+                v3 = self.__convertFaceUVToVertexUVSmooth(face.vertices[2], uv.uv3, n3, base_vertices, face_area, a3)
+            else:  # PRESERVE_ALL_NORMALS, SMOOTH_KEEP_SHARP(Already smoothed using modifier)
+                v1 = self.__convertFaceUVToVertexUV(face.vertices[0], uv.uv1, n1, base_vertices)
+                v2 = self.__convertFaceUVToVertexUV(face.vertices[1], uv.uv2, n2, base_vertices)
+                v3 = self.__convertFaceUVToVertexUV(face.vertices[2], uv.uv3, n3, base_vertices)
+
+            t = _Face([v1, v2, v3], face.index)
             face_seq.append(t)
             if face.material_index not in material_faces:
                 material_faces[face.material_index] = []
             material_faces[face.material_index].append(t)
 
-        if face_indices:
-            for f in material_faces.values():
-                f.sort(key=lambda x: x.index)
-        _mat_name = lambda x: x.name if x else self.__getDefaultMaterial().name
+        def _mat_name(x):
+            return x.name if x else self.__getDefaultMaterial().name
         material_names = {i: _mat_name(m) for i, m in enumerate(base_mesh.materials)}
-        material_names = {i: material_names.get(i, None) or _mat_name(None) for i in material_faces.keys()}
+        material_names = {i: material_names.get(i) or _mat_name(None) for i in material_faces.keys()}
 
-        # export add UV
-        bl_add_uvs = [i for i in base_mesh.uv_layers[1:] if not i.name.startswith("_")]
-        self.__add_uv_count = max(self.__add_uv_count, len(bl_add_uvs))
+        # Export additional UV layers
         for uv_n, uv_tex in enumerate(bl_add_uvs):
             if uv_n > 3:
-                logging.warning(" * extra addUV%d+ are not supported", uv_n + 1)
-                break
+                logging.warning(f" * extra addUV{uv_n + 1} ({uv_tex.name}) are not supported")
+                continue
             uv_data = _UVWrapper(uv_tex.data)
             zw_data = base_mesh.uv_layers.get("_" + uv_tex.name, None)
-            logging.info(" # exporting addUV%d: %s [zw: %s]", uv_n + 1, uv_tex.name, zw_data)
+            logging.info(f" # exporting addUV{uv_n + 1}: {uv_tex.name} [zw: {zw_data.name if zw_data else zw_data}]")
             if zw_data:
                 zw_data = _UVWrapper(zw_data.data)
             else:
                 zw_data = iter(lambda: _DummyUV, None)
             rip_vertices_map = {}
-            for f, face, uv, zw in zip(face_seq, base_mesh.polygons, uv_data, zw_data):
+
+            for f, face, uv, zw in zip(face_seq, base_mesh.polygons, uv_data, zw_data, strict=False):
                 vertices = [base_vertices[x] for x in face.vertices]
                 rip_vertices = [rip_vertices_map.setdefault(x, [x]) for x in f.vertices]
                 f.vertices[0] = self.__convertAddUV(f.vertices[0], uv.uv1, zw.uv1, uv_n, vertices[0], rip_vertices[0])
@@ -1095,7 +1282,7 @@ class __PmxExporter:
 
         _to_mesh_clear(meshObj, base_mesh)
 
-        # calculate offsets
+        # Calculate shape key offsets
         shape_key_list = []
         if meshObj.data.shape_keys:
             for i, kb in enumerate(meshObj.data.shape_keys.key_blocks):
@@ -1160,6 +1347,18 @@ class __PmxExporter:
         return _Mesh(material_faces, shape_key_names, material_names)
 
     def __loadMeshData(self, meshObj, bone_map):
+        # Check if object is excluded from view layer
+        # Note: Use meshObj.name instead of meshObj with the 'in' operator,
+        # because bpy_prop_collection.__contains__ expects a string or a tuple of strings.
+        if meshObj.name not in bpy.context.view_layer.objects:
+            logging.info("Skipping mesh excluded from view layer: %s", meshObj.name)
+            return _Mesh({}, [], {})
+
+        # Check if mesh has valid geometry
+        if not meshObj.data or len(meshObj.data.vertices) == 0:
+            logging.info("Skipping empty mesh: %s", meshObj.name)
+            return _Mesh({}, [], {})
+
         show_only_shape_key = meshObj.show_only_shape_key
         active_shape_key_index = meshObj.active_shape_key_index
         meshObj.active_shape_key_index = 0
@@ -1195,7 +1394,7 @@ class __PmxExporter:
         FnTranslations.clear_data(root_object.mmd_root.translation)
 
     def execute(self, filepath, **args):
-        root = args.get("root", None)
+        root = args.get("root")
         self.__model = pmx.Model()
         self.__model.name = "test"
         self.__model.name_e = "test eng"
@@ -1203,7 +1402,11 @@ class __PmxExporter:
         self.__model.comment_e = "exported by mmd_tools_local"
 
         if root is not None:
-            self.__model.name = root.mmd_root.name or root.name
+            if root.mmd_root.name:
+                self.__model.name = root.mmd_root.name
+            else:
+                logging.warning(f"Model name is empty, using root object name '{root.name}' instead")
+                self.__model.name = root.name
             self.__model.name_e = root.mmd_root.name_e
             txt = bpy.data.texts.get(root.mmd_root.comment_text, None)
             if txt:
@@ -1212,15 +1415,20 @@ class __PmxExporter:
             if txt:
                 self.__model.comment_e = txt.as_string().replace("\n", "\r\n")
 
-        self.__armature = args.get("armature", None)
+        self.__armature = args.get("armature")
         meshes = sorted(args.get("meshes", []), key=lambda x: x.name)
         rigids = sorted(args.get("rigid_bodies", []), key=lambda x: x.name)
         joints = sorted(args.get("joints", []), key=lambda x: x.name)
 
-        bpy.ops.mmd_tools_local.fix_bone_order()
+        FnModel.clean_invalid_bone_id_references(root)
+        if args.get("fix_bone_order", True):
+            bpy.ops.mmd_tools_local.fix_bone_order()
 
         self.__scale = args.get("scale", 1.0)
         self.__disable_specular = args.get("disable_specular", False)
+        self.__normal_handling = args.get("normal_handling", "SMOOTH_KEEP_SHARP")
+        self.__export_vertex_colors_as_adduv2 = args.get("export_vertex_colors_as_adduv2", False)
+        self.__ik_angle_limits = args.get("ik_angle_limits", "EXPORT_ALL")
         sort_vertices = args.get("sort_vertices", "NONE")
         if sort_vertices != "NONE":
             self.__vertex_order_map = {"method": sort_vertices}
@@ -1244,28 +1452,53 @@ class __PmxExporter:
             self.__export_material_morphs(root)
             self.__export_uv_morphs(root)
             self.__export_group_morphs(root)
+
+            # Sort morphs by Display Panel facial frame order for PMX export
+            # Reference: https://github.com/MMD-Blender/blender_mmd_tools_local/issues/77
+            morph_map = self.__get_pmx_morph_map(root)
+            self.__model.morphs.sort(key=lambda m: morph_map.get((self.MORPH_TYPES[type(m)], m.name), float("inf")))
+
             self.__exportDisplayItems(root, nameMap)
 
         rigid_map = self.__exportRigidBodies(rigids, nameMap)
         self.__exportJoints(joints, rigid_map)
 
-        if args.get("copy_textures", False):
-            output_dir = os.path.dirname(filepath)
-            import_folder = root.get("import_folder", "") if root else ""
-            base_folder = FnContext.get_addon_preferences_attribute(FnContext.ensure_context(), "base_texture_folder", "")
-            self.__copy_textures(output_dir, import_folder or base_folder)
+        output_dir = os.path.dirname(filepath)
+        import_folder = root.get("import_folder", "") if root else ""
+        base_folder = FnContext.get_addon_preferences_attribute(FnContext.ensure_context(), "base_texture_folder", "")
+        self.__copy_textures(output_dir, import_folder or base_folder, copy_textures_mode=args.get("copy_textures_mode", "NONE"))
+
+        # Output Changes in Vertex and Face Count
+        original_vertex_count = 0
+        original_face_count = 0
+        depsgraph = bpy.context.evaluated_depsgraph_get()
+        for mesh_obj in meshes:
+            obj_eval = mesh_obj.evaluated_get(depsgraph)
+            mesh_eval = obj_eval.data
+            original_vertex_count += len(mesh_eval.vertices)
+            original_face_count += len(mesh_eval.polygons)
+        final_vertex_count = len(self.__model.vertices)
+        final_face_count = len(self.__model.faces)
+        vertex_diff = final_vertex_count - original_vertex_count
+        face_diff = final_face_count - original_face_count
+        triangulation_ratio = final_face_count / original_face_count if original_face_count > 0 else 0
+        logging.info("Changes in Vertex and Face Count:")
+        logging.info("  Normal Handling: %s", self.__normal_handling)
+        logging.info("  Vertices: Original %d -> Output %d (%+d)", original_vertex_count, final_vertex_count, vertex_diff)
+        logging.info("  Faces: Original %d -> Output %d (%+d)", original_face_count, final_face_count, face_diff)
+        logging.info("  Face Triangulation Ratio: %.2fx (Output / Original)", triangulation_ratio)
 
         pmx.save(filepath, self.__model, add_uv_count=self.__add_uv_count)
 
 
 def export(filepath, **kwargs):
     logging.info("****************************************")
-    logging.info(" %s module" % __name__)
+    logging.info(" %s module", __name__)
     logging.info("----------------------------------------")
     start_time = time.time()
     exporter = __PmxExporter()
     exporter.execute(filepath, **kwargs)
     logging.info(" Finished exporting the model in %f seconds.", time.time() - start_time)
     logging.info("----------------------------------------")
-    logging.info(" %s module" % __name__)
+    logging.info(" %s module", __name__)
     logging.info("****************************************")

--- a/extern_tools/mmd_tools_local/core/pmx/importer.py
+++ b/extern_tools/mmd_tools_local/core/pmx/importer.py
@@ -3,8 +3,10 @@
 
 import collections
 import logging
+import math
 import os
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional
 
 import bpy
@@ -81,7 +83,7 @@ class PMXImporter:
     def __createObjects(self):
         """Create main objects and link them to scene."""
         pmxModel = self.__model
-        obj_name = self.__safe_name(bpy.path.display_name(pmxModel.filepath), max_length=54)
+        obj_name = self.__safe_name(bpy.path.display_name_from_filepath(pmxModel.filepath), max_length=54)
         self.__rig = Model.create(pmxModel.name, pmxModel.name_e, self.__scale, obj_name)
         root = self.__rig.rootObject()
         mmd_root: MMDRoot = root.mmd_root
@@ -158,7 +160,7 @@ class PMXImporter:
                 vertex_group_table[pv_bones[0]].add(index=idx, weight=pv_weights[0], type="ADD")
                 vertex_group_table[pv_bones[1]].add(index=idx, weight=1.0 - pv_weights[0], type="ADD")
             elif len(pv_bones) == 4:
-                for bone, weight in zip(pv_bones, pv_weights):
+                for bone, weight in zip(pv_bones, pv_weights, strict=False):
                     vertex_group_table[bone].add(index=idx, weight=weight, type="ADD")
             else:
                 raise Exception("unkown bone weight type.")
@@ -186,10 +188,10 @@ class PMXImporter:
 
         self.__textureTable = []
         for i in pmxModel.textures:
-            self.__textureTable.append(bpy.path.resolve_ncase(path=i.path))
+            self.__textureTable.append(str(Path(i.path).resolve()))
 
     def __createEditBones(self, obj, pmx_bones):
-        """create EditBones from pmx file data.
+        """Create EditBones from pmx file data.
         @return the list of bone names which can be accessed by the bone index of pmx data.
         """
         editBoneTable = []
@@ -198,15 +200,13 @@ class PMXImporter:
         dependency_cycle_ik_bones = []
         # for i, p_bone in enumerate(pmx_bones):
         #    if p_bone.isIK:
-        #        if p_bone.target != -1:
+        #        if p_bone.target >= 0:
         #            t = pmx_bones[p_bone.target]
         #            if p_bone.parent == t.parent:
         #                dependency_cycle_ik_bones.append(i)
 
-        from math import isfinite
-
         def _VectorXZY(v):
-            return Vector(v).xzy if all(isfinite(n) for n in v) else Vector((0, 0, 0))
+            return Vector(v).xzy if all(math.isfinite(n) for n in v) else Vector((0, 0, 0))
 
         with bpyutils.edit_object(obj) as data:
             for i in pmx_bones:
@@ -216,16 +216,16 @@ class PMXImporter:
                 editBoneTable.append(bone)
                 nameTable.append(bone.name)
 
-            for i, (b_bone, m_bone) in enumerate(zip(editBoneTable, pmx_bones)):
-                if m_bone.parent != -1:
+            for i, (b_bone, m_bone) in enumerate(zip(editBoneTable, pmx_bones, strict=False)):
+                if m_bone.parent >= 0:
                     if i not in dependency_cycle_ik_bones:
                         b_bone.parent = editBoneTable[m_bone.parent]
                     else:
                         b_bone.parent = editBoneTable[m_bone.parent].parent
 
-            for b_bone, m_bone in zip(editBoneTable, pmx_bones):
+            for b_bone, m_bone in zip(editBoneTable, pmx_bones, strict=False):
                 if isinstance(m_bone.displayConnection, int):
-                    if m_bone.displayConnection != -1:
+                    if m_bone.displayConnection >= 0:
                         b_bone.tail = editBoneTable[m_bone.displayConnection].head
                     else:
                         b_bone.tail = b_bone.head
@@ -233,13 +233,13 @@ class PMXImporter:
                     loc = _VectorXZY(m_bone.displayConnection) * self.__scale
                     b_bone.tail = b_bone.head + loc
 
-            for b_bone, m_bone in zip(editBoneTable, pmx_bones):
-                if m_bone.isIK and m_bone.target != -1:
+            for b_bone, m_bone in zip(editBoneTable, pmx_bones, strict=False):
+                if m_bone.isIK and m_bone.target >= 0:
                     logging.debug(" - checking IK links of %s", b_bone.name)
                     b_target = editBoneTable[m_bone.target]
                     for i in range(len(m_bone.ik_links)):
                         b_bone_link = editBoneTable[m_bone.ik_links[i].target]
-                        if self.__fix_IK_links or b_bone_link.length < 0.001:
+                        if self.__fix_ik_links or b_bone_link.length < 0.001:
                             b_bone_tail = b_target if i == 0 else editBoneTable[m_bone.ik_links[i - 1].target]
                             loc = b_bone_tail.head - b_bone_link.head
                             if loc.length < 0.001:
@@ -250,7 +250,7 @@ class PMXImporter:
                                 logging.debug("   * fix IK link %s", b_bone_link.name)
                                 b_bone_link.tail = b_bone_link.head + loc
 
-            for b_bone, m_bone in zip(editBoneTable, pmx_bones):
+            for b_bone, m_bone in zip(editBoneTable, pmx_bones, strict=False):
                 # Set the length of too short bones to 1 because Blender delete them.
                 if b_bone.length < 0.001:
                     if not self.__apply_bone_fixed_axis and m_bone.axis is not None:
@@ -261,11 +261,11 @@ class PMXImporter:
                             b_bone.tail = b_bone.head + Vector((0, 0, 1)) * self.__scale
                     else:
                         b_bone.tail = b_bone.head + Vector((0, 0, 1)) * self.__scale
-                    if m_bone.displayConnection != -1 and m_bone.displayConnection != [0.0, 0.0, 0.0]:
+                    if m_bone.displayConnection not in (-1, (0.0, 0.0, 0.0), [0.0, 0.0, 0.0]):
                         logging.debug(" * special tip bone %s, display %s", b_bone.name, str(m_bone.displayConnection))
                         specialTipBones.append(b_bone.name)
 
-            for b_bone, m_bone in zip(editBoneTable, pmx_bones):
+            for b_bone, m_bone in zip(editBoneTable, pmx_bones, strict=False):
                 if m_bone.localCoordinate is not None:
                     FnBone.update_bone_roll(b_bone, m_bone.localCoordinate.x_axis, m_bone.localCoordinate.z_axis)
                 elif FnBone.has_auto_local_axis(m_bone.name):
@@ -274,9 +274,7 @@ class PMXImporter:
         return nameTable, specialTipBones
 
     def __sortPoseBonesByBoneIndex(self, pose_bones: List[bpy.types.PoseBone], bone_names):
-        r: List[bpy.types.PoseBone] = []
-        for i in bone_names:
-            r.append(pose_bones[i])
+        r: List[bpy.types.PoseBone] = [pose_bones[i] for i in bone_names]
         return r
 
     @staticmethod
@@ -308,13 +306,12 @@ class PMXImporter:
         return new_min_angle, new_max_angle
 
     def __applyIk(self, index, pmx_bone, pose_bones):
-        """create a IK bone constraint
+        """Create a IK bone constraint
         If the IK bone and the target bone is separated, a dummy IK target bone is created as a child of the IK bone.
         @param index the bone index
         @param pmx_bone pmx.Bone
         @param pose_bones the list of PoseBones sorted by the bone index
         """
-
         # for tracking mmd ik target, simple explaination:
         # + Root
         # | + link1
@@ -341,7 +338,7 @@ class PMXImporter:
             if not is_valid_ik:
                 ik_constraint_bone = ik_constraint_bone_real
                 logging.warning(" * IK bone (%s) warning: IK target (%s) is not a child of IK link 0 (%s)", ik_bone.name, ik_target.name, ik_constraint_bone.name)
-            elif any(pose_bones[i.target].parent != pose_bones[j.target] for i, j in zip(pmx_bone.ik_links, pmx_bone.ik_links[1:])):
+            elif any(pose_bones[i.target].parent != pose_bones[j.target] for i, j in zip(pmx_bone.ik_links, pmx_bone.ik_links[1:], strict=False)):
                 logging.warning(" * Invalid IK bone (%s): IK chain does not follow parent-child relationship", ik_bone.name)
                 return
         if ik_constraint_bone is None or len(pmx_bone.ik_links) < 1:
@@ -423,7 +420,7 @@ class PMXImporter:
             else:  # vector offset
                 mmd_bone.display_connection_type = "OFFSET"
 
-            if pmx_bone.displayConnection == -1 or pmx_bone.displayConnection == (0.0, 0.0, 0.0):
+            if pmx_bone.displayConnection in (-1, (0.0, 0.0, 0.0), [0.0, 0.0, 0.0]):
                 mmd_bone.is_tip = True
             elif b_bone.name in specialTipBones:
                 mmd_bone.is_tip = True
@@ -446,7 +443,7 @@ class PMXImporter:
                 mmd_bone.has_additional_location = pmx_bone.hasAdditionalLocation
                 mmd_bone.additional_transform_influence = influ
                 if 0 <= bone_index < len(pose_bones):
-                    mmd_bone.additional_transform_bone = pose_bones[bone_index].name
+                    mmd_bone.additional_transform_bone_id = bone_index
 
             if pmx_bone.localCoordinate is not None:
                 mmd_bone.enabled_local_axes = True
@@ -463,14 +460,29 @@ class PMXImporter:
                     b_bone.lock_scale = [True, True, True]
 
     def __importRigids(self):
+        if len(self.__model.rigids) == 0:
+            logging.info("No rigid bodies to import, skipping rigid body creation.")
+            return
         start_time = time.time()
         self.__rigidTable = {}
         context = FnContext.ensure_context()
         rigid_pool = FnRigidBody.new_rigid_body_objects(context, FnModel.ensure_rigid_group_object(context, self.__rig.rootObject()), len(self.__model.rigids))
-        for i, (rigid, rigid_obj) in enumerate(zip(self.__model.rigids, rigid_pool)):
-            loc = Vector(rigid.location).xzy * self.__scale
-            rot = Vector(rigid.rotation).xzy * -1
-            size = Vector(rigid.size).xzy if rigid.type == pmx.Rigid.TYPE_BOX else Vector(rigid.size)
+        for i, (rigid, rigid_obj) in enumerate(zip(self.__model.rigids, rigid_pool, strict=False)):
+            loc_data = rigid.location
+            rot_data = rigid.rotation
+            size_data = rigid.size
+            if any(math.isnan(val) for val in loc_data):
+                logging.warning(f"Rigid body '{rigid.name}' has invalid location data, using default location")
+                loc_data = (0.0, 0.0, 0.0)
+            if any(math.isnan(val) for val in rot_data):
+                logging.warning(f"Rigid body '{rigid.name}' has invalid rotation data, using default rotation")
+                rot_data = (0.0, 0.0, 0.0)
+            if any(math.isnan(val) for val in size_data):
+                logging.warning(f"Rigid body '{rigid.name}' has invalid size data, using default size")
+                size_data = (1.0, 1.0, 1.0)
+            loc = Vector(loc_data).xzy * self.__scale
+            rot = Vector(rot_data).xzy * -1
+            size = Vector(size_data).xzy if rigid.type == pmx.Rigid.TYPE_BOX else Vector(size_data)
 
             obj = FnRigidBody.setup_rigid_body_object(
                 obj=rigid_obj,
@@ -497,10 +509,13 @@ class PMXImporter:
         logging.debug("Finished importing rigid bodies in %f seconds.", time.time() - start_time)
 
     def __importJoints(self):
+        if len(self.__model.joints) == 0:
+            logging.info("No joints to import, skipping joint creation.")
+            return
         start_time = time.time()
         context = FnContext.ensure_context()
         joint_pool = FnRigidBody.new_joint_objects(context, FnModel.ensure_joint_group_object(context, self.__rig.rootObject()), len(self.__model.joints), FnModel.get_empty_display_size(self.__rig.rootObject()))
-        for i, (joint, joint_obj) in enumerate(zip(self.__model.joints, joint_pool)):
+        for i, (joint, joint_obj) in enumerate(zip(self.__model.joints, joint_pool, strict=False)):
             loc = Vector(joint.location).xzy * self.__scale
             rot = Vector(joint.rotation).xzy * -1
 
@@ -553,7 +568,7 @@ class PMXImporter:
             self.__materialFaceCountTable.append(int(i.vertex_count / 3))
             self.__meshObj.data.materials.append(mat)
             fnMat = FnMaterial(mat)
-            if i.texture != -1:
+            if i.texture >= 0:
                 texture_slot = fnMat.create_texture(self.__textureTable[i.texture])
                 texture_slot.texture.use_mipmap = self.__use_mipmap
                 self.__imageTable[len(self.__materialTable) - 1] = texture_slot.texture.image
@@ -570,7 +585,7 @@ class PMXImporter:
                 amount = self.__spa_blend_factor
             else:
                 amount = self.__sph_blend_factor
-            if i.sphere_texture != -1 and amount != 0.0:
+            if i.sphere_texture >= 0 and amount != 0.0:
                 texture_slot = fnMat.create_sphere_texture(self.__textureTable[i.sphere_texture])
                 texture_slot.diffuse_color_factor = amount
                 if i.sphere_texture_mode == 3 and getattr(pmxModel.header, "additional_uvs", 0):
@@ -602,13 +617,30 @@ class PMXImporter:
         uv_layer.data.foreach_set("uv", tuple(v for i in loop_indices_orig for v in uv_table[i]))
 
         if hasattr(mesh, "uv_textures"):
-            for bf, mi in zip(uv_tex.data, material_indices):
+            for bf, mi in zip(uv_tex.data, material_indices, strict=False):
                 bf.image = self.__imageTable.get(mi, None)
+
+        # Import ADD UV2 as vertex colors
+        if self.__import_adduv2_as_vertex_colors and pmxModel.header and pmxModel.header.additional_uvs >= 2:
+            # Create vertex color layer
+            vertex_colors = mesh.vertex_colors.new(name="Color")
+            color_data = []
+            for loop_index in loop_indices_orig:
+                vertex = pmxModel.vertices[loop_index]
+                if len(vertex.additional_uvs) >= 2:
+                    uv2_data = vertex.additional_uvs[1]  # ADD UV2 data (X,Y,Z,W)
+                    # Convert UV data to vertex color (XYZW -> RGBA)
+                    color_data.extend([uv2_data[0], uv2_data[1], uv2_data[2], uv2_data[3]])
+                else:
+                    color_data.extend([1.0, 1.0, 1.0, 1.0])
+            vertex_colors.data.foreach_set("color", color_data)
+            logging.info("Imported ADD UV2 as vertex colors")
 
         if pmxModel.header and pmxModel.header.additional_uvs:
             logging.info("Importing %d additional uvs", pmxModel.header.additional_uvs)
             zw_data_map = collections.OrderedDict()
-            split_uvzw = lambda uvi: (self.flipUV_V(uvi[:2]), uvi[2:])
+            def split_uvzw(uvi):
+                return (self.flipUV_V(uvi[:2]), uvi[2:])
             for i in range(pmxModel.header.additional_uvs):
                 add_uv = uv_layers[uv_textures.new(name="UV" + str(i + 1)).name]
                 logging.info(" - %s...(uv channels)", add_uv.name)
@@ -661,15 +693,38 @@ class PMXImporter:
         mmd_root = self.__root.mmd_root
         categories = self.CATEGORIES
         self.__createBasisShapeKey()
+
+        # Pre-fetch basis coordinates for batch processing
+        basis_coords = []
+        shape_keys = self.__meshObj.data.shape_keys
+        if shape_keys and shape_keys.key_blocks:
+            basis_shape = shape_keys.key_blocks[0]
+            basis_coords = [0.0] * (len(basis_shape.data) * 3)
+            basis_shape.data.foreach_get("co", basis_coords)
+
         for morph in (x for x in self.__model.morphs if isinstance(x, pmx.VertexMorph)):
             shapeKey = self.__meshObj.shape_key_add(name=morph.name)
+            shapeKey.value = 0.0
+
             vtx_morph = mmd_root.vertex_morphs.add()
             vtx_morph.name = morph.name
             vtx_morph.name_e = morph.name_e
             vtx_morph.category = categories.get(morph.category, "OTHER")
-            for md in morph.offsets:
-                shapeKeyPoint = shapeKey.data[md.index]
-                shapeKeyPoint.co += Vector(md.offset).xzy * self.__scale
+
+            if morph.offsets and basis_coords:
+                # Copy basis coordinates as starting point
+                shape_coords = basis_coords.copy()
+
+                # Apply morphing offsets to specific vertices
+                for md in morph.offsets:
+                    offset = Vector(md.offset).xzy * self.__scale
+                    base_idx = md.index * 3
+                    shape_coords[base_idx] += offset[0]
+                    shape_coords[base_idx + 1] += offset[1]
+                    shape_coords[base_idx + 2] += offset[2]
+
+                # Batch set all coordinates at once
+                shapeKey.data.foreach_set("co", shape_coords)
 
     def __importMaterialMorphs(self):
         mmd_root = self.__root.mmd_root
@@ -717,7 +772,10 @@ class PMXImporter:
         mmd_root = self.__root.mmd_root
         categories = self.CATEGORIES
         __OffsetData = collections.namedtuple("OffsetData", "index, offset")
-        __convert_offset = lambda x: (x[0], -x[1], x[2], -x[3])
+
+        def __convert_offset(x):
+            return (x[0], -x[1], x[2], -x[3])
+
         for morph in (x for x in self.__model.morphs if isinstance(x, pmx.UVMorph)):
             uv_morph = mmd_root.uv_morphs.add()
             uv_morph.name = morph.name
@@ -759,17 +817,26 @@ class PMXImporter:
             frame.name_e = i.name_e
             frame.is_special = i.isSpecial
             for disp_type, index in i.data:
-                item = frame.data.add()
                 if disp_type == 0:
-                    item.type = "BONE"
-                    item.name = self.__boneTable[index].name
+                    # Check bone index bounds
+                    if 0 <= index < len(self.__boneTable):
+                        item = frame.data.add()
+                        item.type = "BONE"
+                        item.name = self.__boneTable[index].name
+                    else:
+                        logging.warning("Invalid bone index %d in display frame '%s', skipping item", index, i.name)
                 elif disp_type == 1:
-                    item.type = "MORPH"
-                    morph = pmxModel.morphs[index]
-                    item.name = morph.name
-                    item.morph_type = morph_types[morph.type_index()]
+                    # Check morph index bounds
+                    if 0 <= index < len(pmxModel.morphs):
+                        item = frame.data.add()
+                        item.type = "MORPH"
+                        morph = pmxModel.morphs[index]
+                        item.name = morph.name
+                        item.morph_type = morph_types[morph.type_index()]
+                    else:
+                        logging.warning("Invalid morph index %d in display frame '%s', skipping item", index, i.name)
                 else:
-                    raise Exception("Unknown display item type.")
+                    logging.warning("Unknown display item type %d in display frame '%s', skipping item", disp_type, i.name)
 
         FnBone.sync_bone_collections_from_display_item_frames(self.__armObj)
 
@@ -782,8 +849,37 @@ class PMXImporter:
         armModifier.show_render = armModifier.show_viewport = len(meshObj.data.vertices) > 0
 
     def __assignCustomNormals(self):
+        # NOTE: This uses the older Blender API instead of the newer mesh.attributes approach
+        # because it requires "INT16_2D" format for proper functionality.
+        # Manual calculation of normals in INT16_2D format is overly complex.
+        # The newer implementation was removed in commit [ad47b9a] due to these issues.
+        # The current implementation uses normals_split_custom_set() with 179-degree sharp edge
+        # marking as a workaround. While not ideal, this remains the most practical solution
+        # for preserving custom normals in most cases.
+
         mesh: bpy.types.Mesh = self.__meshObj.data
         logging.info("Setting custom normals...")
+        # CRITICAL: Mark sharp edges (based on angle) BEFORE setting custom normals
+        # For mesh.normals_split_custom_set() to work as expected, two conditions must be met:
+        # 1. The normal vectors must be non-zero (mentioned in Blender documentation)
+        # 2. Some edges must be marked as sharp (NOT mentioned in Blender documentation)
+        # An angle of 179 degrees is confirmed to be sufficient to preserve all custom normals.
+        # 180 degrees does not work because it misses some sharp edges required for normals_split_custom_set to work 100% correctly.
+        current_mode = bpy.context.active_object.mode
+        bpy.ops.object.mode_set(mode="OBJECT")
+        bpy.ops.object.select_all(action="DESELECT")
+        bpy.context.view_layer.objects.active = self.__meshObj
+        # Mark sharp edges
+        bpy.ops.object.mode_set(mode="EDIT")
+        bpy.ops.mesh.select_all(action="DESELECT")
+        bpy.ops.mesh.edges_select_sharp(sharpness=math.radians(179))
+        bpy.ops.mesh.mark_sharp()
+        bpy.ops.object.mode_set(mode="OBJECT")
+        # Logging
+        total_edges = len(mesh.edges)
+        sharp_edges = sum(1 for edge in mesh.edges if edge.use_edge_sharp)
+        percentage = (sharp_edges / total_edges) * 100 if total_edges > 0 else 0
+        logging.info(f"   - Marked {sharp_edges}/{total_edges} ({percentage:.2f}%) sharp edges with angle: 179 degrees")
         if self.__vertex_map:
             verts, faces = self.__model.vertices, self.__model.faces
             custom_normals = [(Vector(verts[i].normal).xzy).normalized() for f in faces for i in f]
@@ -791,6 +887,7 @@ class PMXImporter:
         else:
             custom_normals = [(Vector(v.normal).xzy).normalized() for v in self.__model.vertices]
             mesh.normals_split_custom_set_from_vertices(custom_normals)
+        bpy.ops.object.mode_set(mode=current_mode)
         logging.info("   - Done!!")
 
     def __renameLRBones(self, use_underscore):
@@ -820,13 +917,16 @@ class PMXImporter:
         types = args.get("types", set())
         clean_model = args.get("clean_model", False)
         remove_doubles = args.get("remove_doubles", False)
+        self.__import_adduv2_as_vertex_colors = args.get("import_adduv2_as_vertex_colors", False)
         self.__scale = args.get("scale", 1.0)
         self.__use_mipmap = args.get("use_mipmap", True)
         self.__sph_blend_factor = args.get("sph_blend_factor", 1.0)
         self.__spa_blend_factor = args.get("spa_blend_factor", 1.0)
-        self.__fix_IK_links = args.get("fix_IK_links", False)
+        self.__fix_ik_links = args.get("fix_ik_links", False)
         self.__apply_bone_fixed_axis = args.get("apply_bone_fixed_axis", False)
-        self.__translator = args.get("translator", None)
+        self.__bone_disp_mode = args.get("bone_disp_mode", "OCTAHEDRAL")
+        self.__translator = args.get("translator")
+        self.__add_rigid_body_world = args.get("add_rigid_body_world", True)
 
         logging.info("****************************************")
         logging.info(" mmd_tools_local.import_pmx module")
@@ -858,6 +958,8 @@ class PMXImporter:
                 self.__createMeshObject()
                 self.__importVertexGroup()
             self.__importBones()
+            if args.get("fix_bone_order", True):
+                bpy.ops.mmd_tools_local.fix_bone_order()
             if args.get("rename_LR_bones", False):
                 use_underscore = args.get("use_underscore", False)
                 self.__renameLRBones(use_underscore)
@@ -865,11 +967,31 @@ class PMXImporter:
                 self.__translateBoneNames()
             if self.__apply_bone_fixed_axis:
                 FnBone.apply_bone_fixed_axis(self.__armObj)
+            self.__armObj.data.display_type = self.__bone_disp_mode
             FnBone.apply_additional_transformation(self.__armObj)
 
         if "PHYSICS" in types:
-            self.__importRigids()
-            self.__importJoints()
+            rigidbody_world = bpy.context.scene.rigidbody_world
+            original_enabled = None
+
+            try:
+                self.__importRigids()
+
+                # Temporarily disable physics to prevent rigid bodies from moving to origin during import
+                # See: https://github.com/MMD-Blender/blender_mmd_tools_local/issues/255
+                if rigidbody_world:
+                    original_enabled = rigidbody_world.enabled
+                    rigidbody_world.enabled = False
+
+                self.__importJoints()
+
+            finally:
+                if rigidbody_world and original_enabled is not None:
+                    rigidbody_world.enabled = original_enabled
+
+                # Remove the automatically created rigid body world if it was not intended
+                if not self.__add_rigid_body_world and rigidbody_world is None:
+                    bpy.ops.rigidbody.world_remove()
 
         if "DISPLAY" in types:
             self.__importDisplayFrames()
@@ -904,7 +1026,7 @@ class _PMXCleaner:
         pmx_vertices = pmx_model.vertices
 
         # clean face/vertex
-        cls.__clean_pmx_faces(pmx_faces, pmx_model.materials, lambda f: frozenset(f))
+        cls.__clean_pmx_faces(pmx_faces, pmx_model.materials, frozenset)
 
         index_map = {v: v for f in pmx_faces for v in f}
         is_index_clean = len(index_map) == len(pmx_vertices)
@@ -969,8 +1091,10 @@ class _PMXCleaner:
             return None
 
         # clean face
-        # face_key_func = lambda f: frozenset(vertex_map[x][0] for x in f)
-        face_key_func = lambda f: frozenset({vertex_map[x][0]: tuple(pmx_vertices[x].uv) for x in f}.items())
+        # def face_key_func(f):
+        #     return frozenset(vertex_map[x][0] for x in f)
+        def face_key_func(f):
+            return frozenset({vertex_map[x][0]: tuple(pmx_vertices[x].uv) for x in f}.items())
         cls.__clean_pmx_faces(pmx_model.faces, pmx_model.materials, face_key_func)
 
         if mesh_only:

--- a/extern_tools/mmd_tools_local/core/rigid_body.py
+++ b/extern_tools/mmd_tools_local/core/rigid_body.py
@@ -1,6 +1,7 @@
 # Copyright 2014 MMD Tools authors
 # This file is part of MMD Tools.
 
+import logging
 from typing import List, Optional
 
 import bpy
@@ -176,22 +177,23 @@ class FnRigidBody:
 
         x0, y0, z0 = obj.bound_box[0]
         x1, y1, z1 = obj.bound_box[6]
-        assert x1 >= x0 and y1 >= y0 and z1 >= z0
+        if not (x1 >= x0 and y1 >= y0 and z1 >= z0):
+            logging.warning(f"Rigid body '{obj.name}' has invalid bounding box coordinates, using default size")
+            return (1.0, 1.0, 1.0)
 
         shape = obj.mmd_rigid.shape
         if shape == "SPHERE":
             radius = (z1 - z0) / 2
             return (radius, 0.0, 0.0)
-        elif shape == "BOX":
+        if shape == "BOX":
             x, y, z = (x1 - x0) / 2, (y1 - y0) / 2, (z1 - z0) / 2
             return (x, y, z)
-        elif shape == "CAPSULE":
+        if shape == "CAPSULE":
             diameter = x1 - x0
             radius = diameter / 2
             height = abs((z1 - z0) - diameter)
             return (radius, height, 0.0)
-        else:
-            raise ValueError(f"Invalid shape type: {shape}")
+        raise ValueError(f"Invalid shape type: {shape}")
 
     @staticmethod
     def new_joint_object(context: bpy.types.Context, parent_object: bpy.types.Object, empty_display_size: float) -> bpy.types.Object:

--- a/extern_tools/mmd_tools_local/core/sdef.py
+++ b/extern_tools/mmd_tools_local/core/sdef.py
@@ -5,6 +5,7 @@ import logging
 import time
 
 import bpy
+import numpy as np
 from mathutils import Matrix, Vector
 
 from ..bpyutils import FnObject
@@ -13,10 +14,9 @@ from ..bpyutils import FnObject
 def _hash(v):
     if isinstance(v, (bpy.types.Object, bpy.types.PoseBone)):
         return hash(type(v).__name__ + v.name)
-    elif isinstance(v, bpy.types.Pose):
+    if isinstance(v, bpy.types.Pose):
         return hash(type(v).__name__ + v.id_data.name)
-    else:
-        raise NotImplementedError("hash")
+    raise NotImplementedError("hash")
 
 
 class FnSDEF:
@@ -80,6 +80,8 @@ class FnSDEF:
 
     @staticmethod
     def has_sdef_data(obj):
+        if obj is None or not hasattr(obj, "modifiers") or not hasattr(obj, "data") or obj.data is None:
+            return False
         mod = obj.modifiers.get("mmd_armature")
         if mod and mod.type == "ARMATURE" and mod.object:
             kb = getattr(obj.data.shape_keys, "key_blocks", None)
@@ -89,6 +91,7 @@ class FnSDEF:
     @classmethod
     def __find_vertices(cls, obj):
         if not cls.has_sdef_data(obj):
+            logging.debug(f"SDEF vertex search skipped for '{obj.name}': No SDEF data found")
             return {}
 
         vertices = {}
@@ -107,7 +110,7 @@ class FnSDEF:
                     # preprocessing
                     w0, w1 = bgs[0].weight, bgs[1].weight
                     # w0 + w1 == 1
-                    w0 = w0 / (w0 + w1)
+                    w0 /= (w0 + w1)
                     w1 = 1 - w0
 
                     c, r0, r1 = sdef_c[i].co, sdef_r0[i].co, sdef_r1[i].co
@@ -125,12 +128,18 @@ class FnSDEF:
 
     @classmethod
     def driver_function_wrap(cls, obj_name, bulk_update, use_skip, use_scale):
+        if obj_name not in bpy.data.objects:
+            logging.warning(f"SDEF driver wrap: Object '{obj_name}' not found")
+            return 0.0
         obj = bpy.data.objects[obj_name]
         shapekey = obj.data.shape_keys.key_blocks[cls.SHAPEKEY_NAME]
         return cls.driver_function(shapekey, obj_name, bulk_update, use_skip, use_scale)
 
     @classmethod
     def driver_function(cls, shapekey, obj_name, bulk_update, use_skip, use_scale):
+        if obj_name not in bpy.data.objects:
+            logging.warning(f"SDEF driver: Object '{obj_name}' not found, driver will be inactive")
+            return 0.0
         obj = bpy.data.objects[obj_name]
         if getattr(shapekey.id_data, "is_evaluated", False):
             # For Blender 2.8x, we should use evaluated object, and the only reference is the "obj" variable of SDEF driver
@@ -182,8 +191,6 @@ class FnSDEF:
         else:  # bulk update
             shapekey_data = cls.g_shapekey_data[_hash(obj)]
             if shapekey_data is None:
-                import numpy as np
-
                 shapekey_data = np.zeros(len(shapekey.data) * 3, dtype=np.float32)
                 shapekey.data.foreach_get("co", shapekey_data)
                 shapekey_data = cls.g_shapekey_data[_hash(obj)] = shapekey_data.reshape(len(shapekey.data), 3)
@@ -202,7 +209,7 @@ class FnSDEF:
                         rot1 = -rot1
                     s0, s1 = mat0.to_scale(), mat1.to_scale()
 
-                    def scale(mat_rot, w0, w1):
+                    def scale(mat_rot, w0, w1, s0, s1):
                         s = s0 * w0 + s1 * w1
                         return mat_rot @ Matrix([(s[0], 0, 0), (0, s[1], 0), (0, 0, s[2])])
 
@@ -210,7 +217,7 @@ class FnSDEF:
                         delta = sum(((key.data[vid].co - key.relative_key.data[vid].co) * key.value for key in key_blocks), Vector())  # assuming key.vertex_group = ''
                         return (mat_rot @ (pos_c + delta)) - delta
 
-                    shapekey_data[vids] = [offset(scale((rot0 * w0 + rot1 * w1).normalized().to_matrix(), w0, w1), pos_c, vid) + (mat0 @ cr0) * w0 + (mat1 @ cr1) * w1 for vid, w0, w1, pos_c, cr0, cr1 in sdef_data]
+                    shapekey_data[vids] = [offset(scale((rot0 * w0 + rot1 * w1).normalized().to_matrix(), w0, w1, s0, s1), pos_c, vid) + (mat0 @ cr0) * w0 + (mat1 @ cr1) * w1 for vid, w0, w1, pos_c, cr0, cr1 in sdef_data]
             else:
                 # bulk update
                 for bone0, bone1, sdef_data, vids in cls.g_verts[_hash(obj)].values():
@@ -260,6 +267,7 @@ class FnSDEF:
         # Unbind first
         cls.unbind(obj)
         if not cls.has_sdef_data(obj):
+            logging.debug(f"SDEF bind skipped for '{obj.name}': No SDEF data found")
             return False
         # Create the shapekey for the driver
         shapekey = obj.shape_key_add(name=cls.SHAPEKEY_NAME, from_mix=False)
@@ -278,18 +286,15 @@ class FnSDEF:
         ov.type = "SINGLE_PROP"
         ov.targets[0].id = obj
         ov.targets[0].data_path = "name"
-        if not bulk_update and use_skip:  # FIXME: force disable use_skip=True for bulk_update=False on 2.8
-            use_skip = False
         mod = obj.modifiers.get("mmd_armature")
         variables = f.driver.variables
-        for name in set(data[i].name for data in cls.g_verts[_hash(obj)].values() for i in range(2)):  # add required bones for dependency graph
+        for name in {data[i].name for data in cls.g_verts[_hash(obj)].values() for i in range(2)}:  # add required bones for dependency graph
             var = variables.new()
             var.type = "TRANSFORMS"
             var.targets[0].id = mod.object
             var.targets[0].bone_target = name
         f.driver.use_self = True
-        param = (bulk_update, use_skip, use_scale)
-        f.driver.expression = "mmd_sdef_driver(self, obj, bulk_update={}, use_skip={}, use_scale={})".format(*param)
+        f.driver.expression = f"mmd_sdef_driver(self, obj, bulk_update={bulk_update}, use_skip={use_skip}, use_scale={use_scale})"
         return True
 
     @classmethod
@@ -309,7 +314,7 @@ class FnSDEF:
     @classmethod
     def clear_cache(cls, obj=None, unused_only=False):
         if unused_only:
-            valid_keys = set(_hash(i) for i in bpy.data.objects if i.type == "MESH" and i != obj)
+            valid_keys = {_hash(i) for i in bpy.data.objects if i.type == "MESH" and i != obj}
             for key in cls.g_verts.keys() - valid_keys:
                 del cls.g_verts[key]
             for key in cls.g_shapekey_data.keys() - cls.g_verts.keys():

--- a/extern_tools/mmd_tools_local/core/shader.py
+++ b/extern_tools/mmd_tools_local/core/shader.py
@@ -9,7 +9,7 @@ import bpy
 class _NodeTreeUtils:
     def __init__(self, shader: bpy.types.ShaderNodeTree):
         self.shader = shader
-        self.nodes: bpy.types.bpy_prop_collection[bpy.types.ShaderNode] = shader.nodes  # type: ignore
+        self.nodes: bpy.types.bpy_prop_collection[bpy.types.ShaderNode] = shader.nodes  # type: ignore[assignment]
         self.links = shader.links
 
     def _find_node(self, node_type: str) -> Optional[bpy.types.ShaderNode]:
@@ -64,13 +64,13 @@ class _NodeGroupUtils(_NodeTreeUtils):
     @property
     def node_input(self) -> bpy.types.NodeGroupInput:
         if not self.__node_input:
-            self.__node_input = cast(bpy.types.NodeGroupInput, self._find_node("NodeGroupInput") or self.new_node("NodeGroupInput", (-2, 0)))
+            self.__node_input = cast("bpy.types.NodeGroupInput", self._find_node("NodeGroupInput") or self.new_node("NodeGroupInput", (-2, 0)))
         return self.__node_input
 
     @property
     def node_output(self) -> bpy.types.NodeGroupOutput:
         if not self.__node_output:
-            self.__node_output = cast(bpy.types.NodeGroupOutput, self._find_node("NodeGroupOutput") or self.new_node("NodeGroupOutput", (2, 0)))
+            self.__node_output = cast("bpy.types.NodeGroupOutput", self._find_node("NodeGroupOutput") or self.new_node("NodeGroupOutput", (2, 0)))
         return self.__node_output
 
     def hide_nodes(self, hide_sockets=True):
@@ -99,7 +99,7 @@ class _NodeGroupUtils(_NodeTreeUtils):
             if not min_max:
                 if idname.endswith("Factor") or io_name.endswith("Alpha"):
                     interface_socket.min_value, interface_socket.max_value = 0, 1
-                elif idname.endswith("Float") or idname.endswith("Vector"):
+                elif idname.endswith(("Float", "Vector")):
                     interface_socket.min_value, interface_socket.max_value = -10, 10
         if socket is not None:
             self.links.new(io_sockets[io_name], socket)
@@ -141,7 +141,7 @@ class _MaterialMorph:
     def __update_morph_links(cls, node, reset=False):
         nodes, links = node.id_data.nodes, node.id_data.links
         if reset:
-            if any(l.from_node.name.startswith("mmd_bind") for i in node.inputs for l in i.links):
+            if any(link.from_node.name.startswith("mmd_bind") for i in node.inputs for link in i.links):
                 return
 
             def __init_link(socket_morph, socket_shader):
@@ -263,8 +263,8 @@ class _MaterialMorph:
             # https://github.com/blender/blender/blob/594f47ecd2d5367ca936cf6fc6ec8168c2b360d0/source/blender/blenkernel/intern/material.c#L1400
             node_mix = ng.new_mix_node("MULTIPLY" if use_mul else "ADD", (pos[0] + 1, pos[1]))
             links.new(node_input.outputs["Fac"], node_mix.inputs["Fac"])
-            ng.new_input_socket("%s1" % id_name + tag, node_mix.inputs["Color1"])
-            ng.new_input_socket("%s2" % id_name + tag, node_mix.inputs["Color2"], socket_type="NodeSocketVector")
+            ng.new_input_socket(f"{id_name}1" + tag, node_mix.inputs["Color1"])
+            ng.new_input_socket(f"{id_name}2" + tag, node_mix.inputs["Color2"], socket_type="NodeSocketVector")
             ng.new_output_socket(id_name + tag, node_mix.outputs["Color"])
             return node_mix
 

--- a/extern_tools/mmd_tools_local/core/translations.py
+++ b/extern_tools/mmd_tools_local/core/translations.py
@@ -29,11 +29,7 @@ class MMDTranslationElementType(Enum):
 
 
 class MMDDataHandlerABC(ABC):
-    @classmethod
-    @property
-    @abstractmethod
-    def type_name(cls) -> str:
-        pass
+    type_name: str
 
     @classmethod
     @abstractmethod
@@ -63,7 +59,8 @@ class MMDDataHandlerABC(ABC):
     @classmethod
     @abstractmethod
     def get_names(cls, mmd_translation_element: "MMDTranslationElement") -> Tuple[str, str, str]:
-        """Returns (name, name_j, name_e)"""
+        """Return (name, name_j, name_e)"""
+        pass
 
     @classmethod
     def is_restorable(cls, mmd_translation_element: "MMDTranslationElement") -> bool:
@@ -71,7 +68,7 @@ class MMDDataHandlerABC(ABC):
 
     @classmethod
     def check_data_visible(cls, filter_selected: bool, filter_visible: bool, select: bool, hide: bool) -> bool:
-        return filter_selected and not select or filter_visible and hide
+        return (filter_selected and not select) or (filter_visible and hide)
 
     @classmethod
     def prop_restorable(cls, layout: bpy.types.UILayout, mmd_translation_element: "MMDTranslationElement", prop_name: str, original_value: str, index: int):
@@ -96,10 +93,7 @@ class MMDDataHandlerABC(ABC):
 
 
 class MMDBoneHandler(MMDDataHandlerABC):
-    @classmethod
-    @property
-    def type_name(cls) -> str:
-        return MMDTranslationElementType.BONE.name
+    type_name = MMDTranslationElementType.BONE.name
 
     @classmethod
     def draw_item(cls, layout: bpy.types.UILayout, mmd_translation_element: "MMDTranslationElement", index: int):
@@ -110,18 +104,18 @@ class MMDBoneHandler(MMDDataHandlerABC):
         cls.prop_restorable(prop_row, mmd_translation_element, "name", pose_bone.name, index)
         cls.prop_restorable(prop_row, mmd_translation_element, "name_j", pose_bone.mmd_bone.name_j, index)
         cls.prop_restorable(prop_row, mmd_translation_element, "name_e", pose_bone.mmd_bone.name_e, index)
-        row.prop(pose_bone.bone, "select", text="", emboss=False, icon_only=True, icon="RESTRICT_SELECT_OFF" if pose_bone.bone.select else "RESTRICT_SELECT_ON")
-        row.prop(pose_bone.bone, "hide", text="", emboss=False, icon_only=True, icon="HIDE_ON" if pose_bone.bone.hide else "HIDE_OFF")
+        row.prop(pose_bone.bone, "select", text="", emboss=False, icon_only=True, icon="RESTRICT_SELECT_OFF" if pose_bone.select else "RESTRICT_SELECT_ON")
+        row.prop(pose_bone.bone, "hide", text="", emboss=False, icon_only=True)
 
     @classmethod
     def collect_data(cls, mmd_translation: "MMDTranslation"):
         armature_object: bpy.types.Object = FnModel.find_armature_object(mmd_translation.id_data)
         pose_bone: bpy.types.PoseBone
         for index, pose_bone in enumerate(armature_object.pose.bones):
-            if not any(c.is_visible for c in pose_bone.bone.collections):
+            if pose_bone.bone.hide or (pose_bone.bone.collections and not any(c.is_visible for c in pose_bone.bone.collections)):
                 continue
 
-            mmd_translation_element: "MMDTranslationElement" = mmd_translation.translation_elements.add()
+            mmd_translation_element: MMDTranslationElement = mmd_translation.translation_elements.add()
             mmd_translation_element.type = MMDTranslationElementType.BONE.name
             mmd_translation_element.object = armature_object
             mmd_translation_element.data_path = f"pose.bones[{index}]"
@@ -136,14 +130,14 @@ class MMDBoneHandler(MMDDataHandlerABC):
 
     @classmethod
     def update_query(cls, mmd_translation: "MMDTranslation", filter_selected: bool, filter_visible: bool, check_blank_name: Callable[[str, str], bool]):
-        mmd_translation_element: "MMDTranslationElement"
+        mmd_translation_element: MMDTranslationElement
         for index, mmd_translation_element in enumerate(mmd_translation.translation_elements):
             if mmd_translation_element.type != MMDTranslationElementType.BONE.name:
                 continue
 
             pose_bone: bpy.types.PoseBone = mmd_translation_element.object.path_resolve(mmd_translation_element.data_path)
 
-            if cls.check_data_visible(filter_selected, filter_visible, pose_bone.bone.select, pose_bone.bone.hide):
+            if cls.check_data_visible(filter_selected, filter_visible, pose_bone.select, pose_bone.bone.hide):
                 continue
 
             if check_blank_name(mmd_translation_element.name_j, mmd_translation_element.name_e):
@@ -152,7 +146,7 @@ class MMDBoneHandler(MMDDataHandlerABC):
             if mmd_translation.filter_restorable and not cls.is_restorable(mmd_translation_element):
                 continue
 
-            mmd_translation_element_index: "MMDTranslationElementIndex" = mmd_translation.filtered_translation_element_indices.add()
+            mmd_translation_element_index: MMDTranslationElementIndex = mmd_translation.filtered_translation_element_indices.add()
             mmd_translation_element_index.value = index
 
     @classmethod
@@ -172,14 +166,11 @@ class MMDBoneHandler(MMDDataHandlerABC):
 
 
 class MMDMorphHandler(MMDDataHandlerABC):
-    @classmethod
-    @property
-    def type_name(cls) -> str:
-        return MMDTranslationElementType.MORPH.name
+    type_name = MMDTranslationElementType.MORPH.name
 
     @classmethod
     def draw_item(cls, layout: bpy.types.UILayout, mmd_translation_element: "MMDTranslationElement", index: int):
-        morph: "_MorphBase" = mmd_translation_element.object.path_resolve(mmd_translation_element.data_path)
+        morph: _MorphBase = mmd_translation_element.object.path_resolve(mmd_translation_element.data_path)
         row = layout.row(align=True)
         row.label(text="", icon="SHAPEKEY_DATA")
         prop_row = row.row()
@@ -194,7 +185,7 @@ class MMDMorphHandler(MMDDataHandlerABC):
     @classmethod
     def collect_data(cls, mmd_translation: "MMDTranslation"):
         root_object: bpy.types.Object = mmd_translation.id_data
-        mmd_root: "MMDRoot" = root_object.mmd_root
+        mmd_root: MMDRoot = root_object.mmd_root
 
         for morphs_name, morphs in {
             "material_morphs": mmd_root.material_morphs,
@@ -203,9 +194,9 @@ class MMDMorphHandler(MMDDataHandlerABC):
             "vertex_morphs": mmd_root.vertex_morphs,
             "group_morphs": mmd_root.group_morphs,
         }.items():
-            morph: "_MorphBase"
+            morph: _MorphBase
             for index, morph in enumerate(morphs):
-                mmd_translation_element: "MMDTranslationElement" = mmd_translation.translation_elements.add()
+                mmd_translation_element: MMDTranslationElement = mmd_translation.translation_elements.add()
                 mmd_translation_element.type = MMDTranslationElementType.MORPH.name
                 mmd_translation_element.object = root_object
                 mmd_translation_element.data_path = f"mmd_root.{morphs_name}[{index}]"
@@ -224,24 +215,24 @@ class MMDMorphHandler(MMDDataHandlerABC):
 
     @classmethod
     def update_query(cls, mmd_translation: "MMDTranslation", filter_selected: bool, filter_visible: bool, check_blank_name: Callable[[str, str], bool]):
-        mmd_translation_element: "MMDTranslationElement"
+        mmd_translation_element: MMDTranslationElement
         for index, mmd_translation_element in enumerate(mmd_translation.translation_elements):
             if mmd_translation_element.type != MMDTranslationElementType.MORPH.name:
                 continue
 
-            morph: "_MorphBase" = mmd_translation_element.object.path_resolve(mmd_translation_element.data_path)
+            morph: _MorphBase = mmd_translation_element.object.path_resolve(mmd_translation_element.data_path)
             if check_blank_name(morph.name, morph.name_e):
                 continue
 
             if mmd_translation.filter_restorable and not cls.is_restorable(mmd_translation_element):
                 continue
 
-            mmd_translation_element_index: "MMDTranslationElementIndex" = mmd_translation.filtered_translation_element_indices.add()
+            mmd_translation_element_index: MMDTranslationElementIndex = mmd_translation.filtered_translation_element_indices.add()
             mmd_translation_element_index.value = index
 
     @classmethod
     def set_names(cls, mmd_translation_element: "MMDTranslationElement", name: Optional[str], name_j: Optional[str], name_e: Optional[str]):
-        morph: "_MorphBase" = mmd_translation_element.object.path_resolve(mmd_translation_element.data_path)
+        morph: _MorphBase = mmd_translation_element.object.path_resolve(mmd_translation_element.data_path)
         if name is not None:
             morph.name = name
         if name_e is not None:
@@ -249,15 +240,12 @@ class MMDMorphHandler(MMDDataHandlerABC):
 
     @classmethod
     def get_names(cls, mmd_translation_element: "MMDTranslationElement") -> Tuple[str, str, str]:
-        morph: "_MorphBase" = mmd_translation_element.object.path_resolve(mmd_translation_element.data_path)
+        morph: _MorphBase = mmd_translation_element.object.path_resolve(mmd_translation_element.data_path)
         return (morph.name, "", morph.name_e)
 
 
 class MMDMaterialHandler(MMDDataHandlerABC):
-    @classmethod
-    @property
-    def type_name(cls) -> str:
-        return MMDTranslationElementType.MATERIAL.name
+    type_name = MMDTranslationElementType.MATERIAL.name
 
     @classmethod
     def draw_item(cls, layout: bpy.types.UILayout, mmd_translation_element: "MMDTranslationElement", index: int):
@@ -270,7 +258,7 @@ class MMDMaterialHandler(MMDDataHandlerABC):
         cls.prop_restorable(prop_row, mmd_translation_element, "name_j", material.mmd_material.name_j, index)
         cls.prop_restorable(prop_row, mmd_translation_element, "name_e", material.mmd_material.name_e, index)
         row.prop(mesh_object, "select", text="", emboss=False, icon_only=True, icon="RESTRICT_SELECT_OFF" if mesh_object.select_get() else "RESTRICT_SELECT_ON")
-        row.prop(mesh_object, "hide", text="", emboss=False, icon_only=True, icon="HIDE_ON" if mesh_object.hide_get() else "HIDE_OFF")
+        row.prop(mesh_object, "hide", text="", emboss=False, icon_only=True)
 
     MATERIAL_DATA_PATH_EXTRACT = re.compile(r"data\.materials\[(?P<index>\d*)\]")
 
@@ -289,7 +277,7 @@ class MMDMaterialHandler(MMDDataHandlerABC):
                 if not hasattr(material, "mmd_material"):
                     continue
 
-                mmd_translation_element: "MMDTranslationElement" = mmd_translation.translation_elements.add()
+                mmd_translation_element: MMDTranslationElement = mmd_translation.translation_elements.add()
                 mmd_translation_element.type = MMDTranslationElementType.MATERIAL.name
                 mmd_translation_element.object = mesh_object
                 mmd_translation_element.data_path = f"data.materials[{index}]"
@@ -310,7 +298,7 @@ class MMDMaterialHandler(MMDDataHandlerABC):
 
     @classmethod
     def update_query(cls, mmd_translation: "MMDTranslation", filter_selected: bool, filter_visible: bool, check_blank_name: Callable[[str, str], bool]):
-        mmd_translation_element: "MMDTranslationElement"
+        mmd_translation_element: MMDTranslationElement
         for index, mmd_translation_element in enumerate(mmd_translation.translation_elements):
             if mmd_translation_element.type != MMDTranslationElementType.MATERIAL.name:
                 continue
@@ -326,7 +314,7 @@ class MMDMaterialHandler(MMDDataHandlerABC):
             if mmd_translation.filter_restorable and not cls.is_restorable(mmd_translation_element):
                 continue
 
-            mmd_translation_element_index: "MMDTranslationElementIndex" = mmd_translation.filtered_translation_element_indices.add()
+            mmd_translation_element_index: MMDTranslationElementIndex = mmd_translation.filtered_translation_element_indices.add()
             mmd_translation_element_index.value = index
 
     @classmethod
@@ -346,10 +334,7 @@ class MMDMaterialHandler(MMDDataHandlerABC):
 
 
 class MMDDisplayHandler(MMDDataHandlerABC):
-    @classmethod
-    @property
-    def type_name(cls) -> str:
-        return MMDTranslationElementType.DISPLAY.name
+    type_name = MMDTranslationElementType.DISPLAY.name
 
     @classmethod
     def draw_item(cls, layout: bpy.types.UILayout, mmd_translation_element: "MMDTranslationElement", index: int):
@@ -362,7 +347,7 @@ class MMDDisplayHandler(MMDDataHandlerABC):
         cls.prop_disabled(prop_row, mmd_translation_element, "name")
         cls.prop_disabled(prop_row, mmd_translation_element, "name_e")
         row.prop(mmd_translation_element.object, "select", text="", emboss=False, icon_only=True, icon="RESTRICT_SELECT_OFF" if mmd_translation_element.object.select_get() else "RESTRICT_SELECT_ON")
-        row.prop(mmd_translation_element.object, "hide", text="", emboss=False, icon_only=True, icon="HIDE_ON" if mmd_translation_element.object.hide_get() else "HIDE_OFF")
+        row.prop(mmd_translation_element.object, "hide", text="", emboss=False, icon_only=True)
 
     DISPLAY_DATA_PATH_EXTRACT = re.compile(r"data\.collections\[(?P<index>\d*)\]")
 
@@ -371,7 +356,7 @@ class MMDDisplayHandler(MMDDataHandlerABC):
         armature_object: bpy.types.Object = FnModel.find_armature_object(mmd_translation.id_data)
         bone_collection: bpy.types.BoneCollection
         for index, bone_collection in enumerate(armature_object.data.collections):
-            mmd_translation_element: "MMDTranslationElement" = mmd_translation.translation_elements.add()
+            mmd_translation_element: MMDTranslationElement = mmd_translation.translation_elements.add()
             mmd_translation_element.type = MMDTranslationElementType.DISPLAY.name
             mmd_translation_element.object = armature_object
             mmd_translation_element.data_path = f"data.collections[{index}]"
@@ -392,7 +377,7 @@ class MMDDisplayHandler(MMDDataHandlerABC):
 
     @classmethod
     def update_query(cls, mmd_translation: "MMDTranslation", filter_selected: bool, filter_visible: bool, check_blank_name: Callable[[str, str], bool]):
-        mmd_translation_element: "MMDTranslationElement"
+        mmd_translation_element: MMDTranslationElement
         for index, mmd_translation_element in enumerate(mmd_translation.translation_elements):
             if mmd_translation_element.type != MMDTranslationElementType.DISPLAY.name:
                 continue
@@ -408,7 +393,7 @@ class MMDDisplayHandler(MMDDataHandlerABC):
             if mmd_translation.filter_restorable and not cls.is_restorable(mmd_translation_element):
                 continue
 
-            mmd_translation_element_index: "MMDTranslationElementIndex" = mmd_translation.filtered_translation_element_indices.add()
+            mmd_translation_element_index: MMDTranslationElementIndex = mmd_translation.filtered_translation_element_indices.add()
             mmd_translation_element_index.value = index
 
     @classmethod
@@ -424,10 +409,7 @@ class MMDDisplayHandler(MMDDataHandlerABC):
 
 
 class MMDPhysicsHandler(MMDDataHandlerABC):
-    @classmethod
-    @property
-    def type_name(cls) -> str:
-        return MMDTranslationElementType.PHYSICS.name
+    type_name = MMDTranslationElementType.PHYSICS.name
 
     @classmethod
     def draw_item(cls, layout: bpy.types.UILayout, mmd_translation_element: "MMDTranslationElement", index: int):
@@ -447,7 +429,7 @@ class MMDPhysicsHandler(MMDDataHandlerABC):
         cls.prop_restorable(prop_row, mmd_translation_element, "name_j", mmd_object.name_j, index)
         cls.prop_restorable(prop_row, mmd_translation_element, "name_e", mmd_object.name_e, index)
         row.prop(obj, "select", text="", emboss=False, icon_only=True, icon="RESTRICT_SELECT_OFF" if obj.select_get() else "RESTRICT_SELECT_ON")
-        row.prop(obj, "hide", text="", emboss=False, icon_only=True, icon="HIDE_ON" if obj.hide_get() else "HIDE_OFF")
+        row.prop(obj, "hide", text="", emboss=False, icon_only=True)
 
     @classmethod
     def collect_data(cls, mmd_translation: "MMDTranslation"):
@@ -456,7 +438,7 @@ class MMDPhysicsHandler(MMDDataHandlerABC):
 
         obj: bpy.types.Object
         for obj in model.rigidBodies():
-            mmd_translation_element: "MMDTranslationElement" = mmd_translation.translation_elements.add()
+            mmd_translation_element: MMDTranslationElement = mmd_translation.translation_elements.add()
             mmd_translation_element.type = MMDTranslationElementType.PHYSICS.name
             mmd_translation_element.object = obj
             mmd_translation_element.data_path = "mmd_rigid"
@@ -466,7 +448,7 @@ class MMDPhysicsHandler(MMDDataHandlerABC):
 
         obj: bpy.types.Object
         for obj in model.joints():
-            mmd_translation_element: "MMDTranslationElement" = mmd_translation.translation_elements.add()
+            mmd_translation_element: MMDTranslationElement = mmd_translation.translation_elements.add()
             mmd_translation_element.type = MMDTranslationElementType.PHYSICS.name
             mmd_translation_element.object = obj
             mmd_translation_element.data_path = "mmd_joint"
@@ -480,7 +462,7 @@ class MMDPhysicsHandler(MMDDataHandlerABC):
 
     @classmethod
     def update_query(cls, mmd_translation: "MMDTranslation", filter_selected: bool, filter_visible: bool, check_blank_name: Callable[[str, str], bool]):
-        mmd_translation_element: "MMDTranslationElement"
+        mmd_translation_element: MMDTranslationElement
         for index, mmd_translation_element in enumerate(mmd_translation.translation_elements):
             if mmd_translation_element.type != MMDTranslationElementType.PHYSICS.name:
                 continue
@@ -500,7 +482,7 @@ class MMDPhysicsHandler(MMDDataHandlerABC):
             if mmd_translation.filter_restorable and not cls.is_restorable(mmd_translation_element):
                 continue
 
-            mmd_translation_element_index: "MMDTranslationElementIndex" = mmd_translation.filtered_translation_element_indices.add()
+            mmd_translation_element_index: MMDTranslationElementIndex = mmd_translation.filtered_translation_element_indices.add()
             mmd_translation_element_index.value = index
 
     @classmethod
@@ -532,10 +514,7 @@ class MMDPhysicsHandler(MMDDataHandlerABC):
 
 
 class MMDInfoHandler(MMDDataHandlerABC):
-    @classmethod
-    @property
-    def type_name(cls) -> str:
-        return MMDTranslationElementType.INFO.name
+    type_name = MMDTranslationElementType.INFO.name
 
     TYPE_TO_ICONS = {
         "EMPTY": "EMPTY_DATA",
@@ -553,7 +532,7 @@ class MMDInfoHandler(MMDDataHandlerABC):
         cls.prop_disabled(prop_row, mmd_translation_element, "name")
         cls.prop_disabled(prop_row, mmd_translation_element, "name_e")
         row.prop(info_object, "select", text="", emboss=False, icon_only=True, icon="RESTRICT_SELECT_OFF" if info_object.select_get() else "RESTRICT_SELECT_ON")
-        row.prop(info_object, "hide", text="", emboss=False, icon_only=True, icon="HIDE_ON" if info_object.hide_get() else "HIDE_OFF")
+        row.prop(info_object, "hide", text="", emboss=False, icon_only=True)
 
     @classmethod
     def collect_data(cls, mmd_translation: "MMDTranslation"):
@@ -564,7 +543,7 @@ class MMDInfoHandler(MMDDataHandlerABC):
             info_objects.append(armature_object)
 
         for info_object in itertools.chain(info_objects, FnModel.iterate_mesh_objects(root_object)):
-            mmd_translation_element: "MMDTranslationElement" = mmd_translation.translation_elements.add()
+            mmd_translation_element: MMDTranslationElement = mmd_translation.translation_elements.add()
             mmd_translation_element.type = MMDTranslationElementType.INFO.name
             mmd_translation_element.object = info_object
             mmd_translation_element.data_path = ""
@@ -578,7 +557,7 @@ class MMDInfoHandler(MMDDataHandlerABC):
 
     @classmethod
     def update_query(cls, mmd_translation: "MMDTranslation", filter_selected: bool, filter_visible: bool, check_blank_name: Callable[[str, str], bool]):
-        mmd_translation_element: "MMDTranslationElement"
+        mmd_translation_element: MMDTranslationElement
         for index, mmd_translation_element in enumerate(mmd_translation.translation_elements):
             if mmd_translation_element.type != MMDTranslationElementType.INFO.name:
                 continue
@@ -593,7 +572,7 @@ class MMDInfoHandler(MMDDataHandlerABC):
             if mmd_translation.filter_restorable and not cls.is_restorable(mmd_translation_element):
                 continue
 
-            mmd_translation_element_index: "MMDTranslationElementIndex" = mmd_translation.filtered_translation_element_indices.add()
+            mmd_translation_element_index: MMDTranslationElementIndex = mmd_translation.filtered_translation_element_indices.add()
             mmd_translation_element_index.value = index
 
     @classmethod
@@ -623,10 +602,10 @@ MMD_DATA_TYPE_TO_HANDLERS: Dict[str, MMDDataHandlerABC] = {h.type_name: h for h 
 class FnTranslations:
     @staticmethod
     def apply_translations(root_object: bpy.types.Object):
-        mmd_translation: "MMDTranslation" = root_object.mmd_root.translation
-        mmd_translation_element_index: "MMDTranslationElementIndex"
+        mmd_translation: MMDTranslation = root_object.mmd_root.translation
+        mmd_translation_element_index: MMDTranslationElementIndex
         for mmd_translation_element_index in mmd_translation.filtered_translation_element_indices:
-            mmd_translation_element: "MMDTranslationElement" = mmd_translation.translation_elements[mmd_translation_element_index.value]
+            mmd_translation_element: MMDTranslationElement = mmd_translation.translation_elements[mmd_translation_element_index.value]
             handler: MMDDataHandlerABC = MMD_DATA_TYPE_TO_HANDLERS[mmd_translation_element.type]
             name, name_j, name_e = handler.get_names(mmd_translation_element)
             handler.set_names(
@@ -638,7 +617,7 @@ class FnTranslations:
 
     @staticmethod
     def execute_translation_batch(root_object: bpy.types.Object) -> Tuple[Dict[str, str], Optional[bpy.types.Text]]:
-        mmd_translation: "MMDTranslation" = root_object.mmd_root.translation
+        mmd_translation: MMDTranslation = root_object.mmd_root.translation
         batch_operation_script = mmd_translation.batch_operation_script
         if not batch_operation_script:
             return ({}, None)
@@ -653,9 +632,9 @@ class FnTranslations:
         batch_operation_script_ast = compile(mmd_translation.batch_operation_script, "<string>", "eval")
         batch_operation_target: str = mmd_translation.batch_operation_target
 
-        mmd_translation_element_index: "MMDTranslationElementIndex"
+        mmd_translation_element_index: MMDTranslationElementIndex
         for mmd_translation_element_index in mmd_translation.filtered_translation_element_indices:
-            mmd_translation_element: "MMDTranslationElement" = mmd_translation.translation_elements[mmd_translation_element_index.value]
+            mmd_translation_element: MMDTranslationElement = mmd_translation.translation_elements[mmd_translation_element_index.value]
 
             handler: MMDDataHandlerABC = MMD_DATA_TYPE_TO_HANDLERS[mmd_translation_element.type]
 
@@ -680,7 +659,7 @@ class FnTranslations:
                         "org_name_j": org_name_j,
                         "org_name_e": org_name_e,
                     },
-                )
+                ),
             )
 
             if batch_operation_target == "BLENDER":
@@ -697,8 +676,8 @@ class FnTranslations:
         if mmd_translation.filtered_translation_element_indices_active_index < 0:
             return
 
-        mmd_translation_element_index: "MMDTranslationElementIndex" = mmd_translation.filtered_translation_element_indices[mmd_translation.filtered_translation_element_indices_active_index]
-        mmd_translation_element: "MMDTranslationElement" = mmd_translation.translation_elements[mmd_translation_element_index.value]
+        mmd_translation_element_index: MMDTranslationElementIndex = mmd_translation.filtered_translation_element_indices[mmd_translation.filtered_translation_element_indices_active_index]
+        mmd_translation_element: MMDTranslationElement = mmd_translation.translation_elements[mmd_translation_element_index.value]
 
         MMD_DATA_TYPE_TO_HANDLERS[mmd_translation_element.type].update_index(mmd_translation_element)
 
@@ -720,7 +699,7 @@ class FnTranslations:
         filter_visible: bool = mmd_translation.filter_visible
 
         def check_blank_name(name_j: str, name_e: str) -> bool:
-            return filter_japanese_blank and name_j or filter_english_blank and name_e
+            return (filter_japanese_blank and name_j) or (filter_english_blank and name_e)
 
         for handler in MMD_DATA_HANDLERS:
             if handler.type_name in mmd_translation.filter_types:

--- a/extern_tools/mmd_tools_local/core/vmd/importer.py
+++ b/extern_tools/mmd_tools_local/core/vmd/importer.py
@@ -10,6 +10,7 @@ import bpy
 from mathutils import Quaternion, Vector
 
 from ... import utils
+from ...compat import action_compat
 from .. import vmd
 from ..camera import MMDCamera
 from ..lamp import MMDLamp
@@ -50,6 +51,8 @@ class RenamedBoneMapper:
         return self
 
     def get(self, bone_name, default=None):
+        if self.__pose_bones is None:
+            return default
         bl_bone_name = bone_name
         if self.__rename_LR_bones:
             bl_bone_name = utils.convertNameToLR(bl_bone_name, self.__use_underscore)
@@ -61,11 +64,11 @@ class RenamedBoneMapper:
 class _InterpolationHelper:
     def __init__(self, mat):
         self.__indices = indices = [0, 1, 2]
-        l = sorted((-abs(mat[i][j]), i, j) for i in range(3) for j in range(3))
-        _, i, j = l[0]
+        sorted_list = sorted((-abs(mat[i][j]), i, j) for i in range(3) for j in range(3))
+        _, i, j = sorted_list[0]
         if i != j:
             indices[i], indices[j] = indices[j], indices[i]
-        _, i, j = next(k for k in l if k[1] != i and k[2] != j)
+        _, i, j = next(k for k in sorted_list if k[1] != i and k[2] != j)
         if indices[i] != j:
             idx = indices.index(j)
             indices[i], indices[idx] = indices[idx], indices[i]
@@ -87,10 +90,17 @@ class BoneConverter:
     def convert_location(self, location):
         return (self.__mat @ Vector(location)) * self.__scale
 
+    # # old implementation
+    # def convert_rotation(self, rotation_xyzw):
+    #     x, y, z, w = rotation_xyzw
+    #     rot = Quaternion((w, x, y, z))
+    #     return Quaternion((self.__mat @ rot.axis) * -1, rot.angle).normalized()
     def convert_rotation(self, rotation_xyzw):
-        rot = Quaternion()
-        rot.x, rot.y, rot.z, rot.w = rotation_xyzw
-        return Quaternion((self.__mat @ rot.axis) * -1, rot.angle).normalized()
+        x, y, z, w = rotation_xyzw
+        rot = Quaternion((w, x, y, z))
+        q = self.__mat.to_quaternion()
+        result = q @ rot @ q.conjugated()
+        return result.normalized()
 
 
 class BoneConverterPoseMode:
@@ -135,6 +145,7 @@ class _FnBezier:
     @classmethod
     def from_fcurve(cls, kp0, kp1):
         p0, p1, p2, p3 = kp0.co, kp0.handle_right, kp1.handle_left, kp1.co
+        # Clamp for using Cardano's cubic formula
         if p1.x > p3.x:
             t = (p3.x - p0.x) / (p1.x - p0.x)
             p1 = (1 - t) * p0 + p1 * t
@@ -177,6 +188,7 @@ class _FnBezier:
         return self.evaluate(self.axis_to_t(x))
 
     def axis_to_t(self, val, axis=0):
+        """Find parameter t using Cardano's cubic formula"""
         p0, p1, p2, p3 = self._p0[axis], self._p1[axis], self._p2[axis], self._p3[axis]
         a = p3 - p0 + 3 * (p1 - p2)
         b = 3 * (p0 - 2 * p1 + p2)
@@ -205,7 +217,7 @@ class _FnBezier:
                 D = c * c - 4 * b * d
                 if D < 0:
                     return
-                D = D**0.5
+                D **= 0.5
                 b2 = 2 * b
                 t = (-c + D) / b2
                 if 0 <= t <= 1:
@@ -218,13 +230,13 @@ class _FnBezier:
         def _sqrt3(v):
             return -((-v) ** (1 / 3)) if v < 0 else v ** (1 / 3)
 
-        A = b * c / (6 * a * a) - b * b * b / (27 * a * a * a) - d / (2 * a)
-        B = c / (3 * a) - b * b / (9 * a * a)
+        A = ((b * c / 6 - b * b * b / (27 * a)) / a - d / 2) / a
+        B = (c - b * b / (3 * a)) / (3 * a)
         b_3a = -b / (3 * a)
         D = A * A + B * B * B
 
         if D > 0:
-            D = D**0.5
+            D **= 0.5
             t = b_3a + _sqrt3(A + D) + _sqrt3(A - D)
             if 0 <= t <= 1:
                 yield t
@@ -253,7 +265,7 @@ class HasAnimationData:
 
 
 class VMDImporter:
-    def __init__(self, filepath, scale=1.0, bone_mapper=None, use_pose_mode=False, convert_mmd_camera=True, convert_mmd_lamp=True, frame_margin=5, use_mirror=False, use_NLA=False):
+    def __init__(self, filepath, scale=1.0, bone_mapper=None, use_pose_mode=False, convert_mmd_camera=True, convert_mmd_lamp=True, frame_margin=5, use_mirror=False, use_nla=False, detect_camera_changes=True, detect_lamp_changes=True):
         self.__vmdFile = vmd.File()
         self.__vmdFile.load(filepath=filepath)
         logging.debug(str(self.__vmdFile.header))
@@ -262,9 +274,12 @@ class VMDImporter:
         self.__convert_mmd_lamp = convert_mmd_lamp
         self.__bone_mapper = bone_mapper
         self.__bone_util_cls = BoneConverterPoseMode if use_pose_mode else BoneConverter
-        self.__frame_margin = frame_margin + 1
+        self.__frame_start = bpy.context.scene.frame_current
+        self.__frame_margin = frame_margin if self.__frame_start in {0, 1} else 0  # only applies if current frame is 0 or 1
         self.__mirror = use_mirror
-        self.__use_NLA = use_NLA
+        self.__use_nla = use_nla
+        self.__detect_camera_changes = detect_camera_changes
+        self.__detect_lamp_changes = detect_lamp_changes
 
     @staticmethod
     def __minRotationDiff(prev_q, curr_q):
@@ -276,15 +291,23 @@ class VMDImporter:
 
     @staticmethod
     def __setInterpolation(bezier, kp0, kp1):
-        if bezier[0] == bezier[1] and bezier[2] == bezier[3]:
-            kp0.interpolation = "LINEAR"
-        else:
-            kp0.interpolation = "BEZIER"
+        # Always use BEZIER to match Blender's default behavior
+        kp0.interpolation = "BEZIER"
         kp0.handle_right_type = "FREE"
         kp1.handle_left_type = "FREE"
-        d = (kp1.co - kp0.co) / 127.0
-        kp0.handle_right = kp0.co + Vector((d.x * bezier[0], d.y * bezier[1]))
-        kp1.handle_left = kp0.co + Vector((d.x * bezier[2], d.y * bezier[3]))
+
+        d = kp1.co - kp0.co
+        dy = d.y
+
+        # Reset handles if the value doesn't change much (dy is small enough) or the bezier is linear
+        # When dy is small enough, the curve is meaningless and will lose data during import; there's no difference in resetting it
+        # When the bezier is linear, the resulting curve is equivalent to the original
+        if abs(dy) < 1e-4 or (bezier[0] == bezier[1] and bezier[2] == bezier[3]):
+            bezier = [20, 20, 107, 107]
+
+        # Always multiply before dividing to reduce precision errors
+        kp0.handle_right = kp0.co + Vector((d.x * bezier[0] / 127.0, d.y * bezier[1] / 127.0))
+        kp1.handle_left = kp0.co + Vector((d.x * bezier[2] / 127.0, d.y * bezier[3] / 127.0))
 
     @staticmethod
     def __fixFcurveHandles(fcurve):
@@ -296,14 +319,14 @@ class VMDImporter:
         kp.handle_right = kp.co + Vector((1, 0))
 
     @staticmethod
-    def __keyframe_insert_inner(fcurves: bpy.types.ActionFCurves, path: str, index: int, frame: float, value: float):
+    def __keyframe_insert_inner(fcurves: action_compat.FCurvesCollection, path: str, index: int, frame: float, value: float):
         fcurve = fcurves.find(path, index=index)
         if fcurve is None:
             fcurve = fcurves.new(path, index=index)
         fcurve.keyframe_points.insert(frame, value, options={"FAST"})
 
     @staticmethod
-    def __keyframe_insert(fcurves: bpy.types.ActionFCurves, path: str, frame: float, value: Union[int, float, Vector]):
+    def __keyframe_insert(fcurves: action_compat.FCurvesCollection, path: str, frame: float, value: Union[int, float, Vector]):
         if isinstance(value, (int, float)):
             VMDImporter.__keyframe_insert_inner(fcurves, path, 0, frame, value)
 
@@ -313,7 +336,7 @@ class VMDImporter:
             VMDImporter.__keyframe_insert_inner(fcurves, path, 2, frame, value[2])
 
         else:
-            raise TypeError("Unsupported type: {0}".format(type(value)))
+            raise TypeError(f"Unsupported type: {type(value)}")
 
     def __getBoneConverter(self, bone):
         converter = self.__bone_util_cls(bone, self.__scale)
@@ -346,8 +369,13 @@ class VMDImporter:
                     return (angle, x, y, z)
 
             else:
-                convert_rotation = lambda rot: converter.convert_rotation(rot).to_euler(mode)
-                compatible_rotation = lambda prev, curr: curr.make_compatible(prev) or curr
+                @staticmethod
+                def convert_rotation(rot):
+                    return converter.convert_rotation(rot).to_euler(mode)
+
+                @staticmethod
+                def compatible_rotation(prev, curr):
+                    return curr.make_compatible(prev) or curr
 
         return _ConverterWrap
 
@@ -355,14 +383,51 @@ class VMDImporter:
         if target.animation_data is None:
             target.animation_data_create()
 
-        if not self.__use_NLA:
-            target.animation_data.action = action
+        if not self.__use_nla:
+            if target.animation_data.action:
+                return target.animation_data.action
+            action_compat.assign_action_to_datablock(target, action)
         else:
             frame_current = bpy.context.scene.frame_current
             target_track: bpy.types.NlaTrack = target.animation_data.nla_tracks.new()
             target_track.name = action.name
             target_strip = target_track.strips.new(action.name, frame_current, action)
             target_strip.blend_type = "COMBINE"
+
+        return action
+
+    def __get_or_create_action(self, target, action_name):
+        """Get existing action or create a new one depending on settings."""
+        # Handle different target types to find the correct animation_data
+        if hasattr(target, "data") and hasattr(target.data, "shape_keys") and target.data.shape_keys:
+            animation_data = target.data.shape_keys.animation_data
+        else:
+            animation_data = getattr(target, "animation_data", None)
+
+        if animation_data and animation_data.action:
+            return animation_data.action
+
+        return bpy.data.actions.new(name=action_name)
+
+    def __get_or_create_fcurve(self, action, data_path, index, action_group_name="", id_type="OBJECT"):
+        """Get existing F-Curve or create a new one."""
+        fcurve = action.fcurves.find(data_path, index=index)
+
+        if fcurve is None:
+            fcurve = action_compat.new_fcurve(action, data_path, index=index, group_name=action_group_name, id_type=id_type)
+        # Ensure F-Curve belongs to the correct action group
+        elif action_group_name and (fcurve.group is None or fcurve.group.name != action_group_name):
+            # Find or create the action group
+            group = None
+            for g in action.groups:
+                if g.name == action_group_name:
+                    group = g
+                    break
+            if group is None:
+                group = action.groups.new(action_group_name)
+            fcurve.group = group
+
+        return fcurve
 
     def __assignToArmature(self, armObj, action_name=None):
         boneAnim = self.__vmdFile.boneAnimation
@@ -371,15 +436,18 @@ class VMDImporter:
             return
 
         action_name = action_name or armObj.name
-        action = bpy.data.actions.new(name=action_name)
+        action = self.__get_or_create_action(armObj, action_name)
 
-        extra_frame = 1 if self.__frame_margin > 1 else 0
+        extra_frame = 1 if self.__frame_margin > 0 else 0
 
         pose_bones = armObj.pose.bones
         if self.__bone_mapper:
             pose_bones = self.__bone_mapper(armObj)
 
-        _loc = _rot = lambda i: i
+        def _identity(i):
+            return i
+
+        _loc = _rot = _identity
         if self.__mirror:
             pose_bones = _MirrorMapper(pose_bones)
             _loc, _rot = _MirrorMapper.get_location, _MirrorMapper.get_rotation
@@ -406,37 +474,63 @@ class VMDImporter:
             fcurves = [dummy_keyframe_points] * 7  # x, y, z, r0, r1, r2, (r3)
             data_path_rot = prop_rot_map.get(bone.rotation_mode, "rotation_euler")
             bone_rotation = getattr(bone, data_path_rot)
-            default_values = list(bone.location) + list(bone_rotation)
-            data_path = 'pose.bones["%s"].location' % bone.name
+            default_values = tuple(bone.location) + tuple(bone_rotation)
+            data_path = f'pose.bones["{bone.name}"].location'
             for axis_i in range(3):
-                fcurves[axis_i] = action.fcurves.new(data_path=data_path, index=axis_i, action_group=bone.name)
-            data_path = 'pose.bones["%s"].%s' % (bone.name, data_path_rot)
+                fcurves[axis_i] = self.__get_or_create_fcurve(action, data_path, axis_i, bone.name)
+            data_path = f'pose.bones["{bone.name}"].{data_path_rot}'
             for axis_i in range(len(bone_rotation)):
-                fcurves[3 + axis_i] = action.fcurves.new(data_path=data_path, index=axis_i, action_group=bone.name)
+                fcurves[3 + axis_i] = self.__get_or_create_fcurve(action, data_path, axis_i, bone.name)
 
             for i in range(len(default_values)):
                 c = fcurves[i]
+                original_count = len(c.keyframe_points)
                 c.keyframe_points.add(extra_frame + num_frame)
-                kp_iter = iter(c.keyframe_points)
+                new_keyframes = c.keyframe_points[original_count:]
+                kp_iter = iter(new_keyframes)
                 if extra_frame:
                     kp = next(kp_iter)
-                    kp.co = (1, default_values[i])
-                    kp.interpolation = "LINEAR"
+                    kp.co = (self.__frame_start, default_values[i])
+                    kp.interpolation = "BEZIER"
                 fcurves[i] = kp_iter
 
             converter = self.__getBoneConverter(bone)
             prev_rot = bone_rotation if extra_frame else None
             prev_kps, indices = None, tuple(converter.convert_interpolation((0, 16, 32))) + (48,) * len(bone_rotation)
             keyFrames.sort(key=lambda x: x.frame_number)
-            for k, x, y, z, r0, r1, r2, r3 in zip(keyFrames, *fcurves):
-                frame = k.frame_number + self.__frame_margin
+            for k, x, y, z, r0, r1, r2, r3 in zip(keyFrames, *fcurves, strict=False):
+                frame = k.frame_number + self.__frame_start + self.__frame_margin
                 loc = converter.convert_location(_loc(k.location))
                 curr_rot = converter.convert_rotation(_rot(k.rotation))
                 if prev_rot is not None:
                     curr_rot = converter.compatible_rotation(prev_rot, curr_rot)
-                    # FIXME the rotation interpolation has slightly different result
+                    # NOTE the rotation interpolation has slightly different result
                     #   Blender: rot(x) = prev_rot*(1 - bezier(t)) + curr_rot*bezier(t)
                     #       MMD: rot(x) = prev_rot.slerp(curr_rot, factor=bezier(t))
+                    #
+                    # Technical details:
+                    # - MMD internally uses quaternions with Slerp interpolation (Quaternion + Slerp)
+                    # - Blender supports either:
+                    #   * Quaternion mode with Nlerp interpolation (Quaternion + Nlerp)
+                    #   * Euler mode with Slerp interpolation (Euler + Slerp)
+                    # - Blender does NOT support Quaternion + Slerp combination, which is exactly what MMD uses
+                    #
+                    # Since the quaternion vs euler difference has a much larger impact than the Slerp vs Nlerp difference,
+                    # MMD Tools chooses to use Quaternion + Nlerp to prioritize quaternion accuracy over interpolation method.
+                    # This is why we cannot perfectly match MMD's rotation behavior in Blender.
+                    #
+                    # Observed behavior in Blender:
+                    #     In Quaternion mode:
+                    #          0    1    2    3    4    5    6    7    8    9   10
+                    #     W  1.0  0.9  0.8  0.7  0.6  0.5  0.4  0.3  0.2  0.1  0.0
+                    #     X  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
+                    #     Y  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
+                    #     Z  0.0  0.1  0.2  0.3  0.4  0.5  0.6  0.7  0.8  0.9  1.0
+                    #     In XYZ Euler mode:
+                    #          0    1    2    3    4    5    6    7    8    9   10
+                    #     X   0d   0d   0d   0d   0d   0d   0d   0d   0d   0d   0d
+                    #     Y   0d   0d   0d   0d   0d   0d   0d   0d   0d   0d   0d
+                    #     Z   0d  18d  36d  54d  72d  90d 108d 126d 144d 162d 180d
                 prev_rot = curr_rot
 
                 x.co = (frame, loc[0])
@@ -450,12 +544,13 @@ class VMDImporter:
                 curr_kps = (x, y, z, r0, r1, r2, r3)
                 if prev_kps is not None:
                     interp = k.interp
-                    for idx, prev_kp, kp in zip(indices, prev_kps, curr_kps):
+                    for idx, prev_kp, kp in zip(indices, prev_kps, curr_kps, strict=False):
                         self.__setInterpolation(interp[idx : idx + 16 : 4], prev_kp, kp)
                 prev_kps = curr_kps
 
-        for c in action.fcurves:
-            self.__fixFcurveHandles(c)
+        for fcurve in action.fcurves:
+            fcurve.update()  # After keyframe_points.add(), call update() to sort and remove duplicate keyframes
+            self.__fixFcurveHandles(fcurve)
 
         # property animation
         propertyAnim = self.__vmdFile.propertyAnimation
@@ -463,7 +558,7 @@ class VMDImporter:
             logging.info("---- IK animations:%5d  target: %s", len(propertyAnim), armObj.name)
             for keyFrame in propertyAnim:
                 logging.debug("(IK) frame:%5d  list: %s", keyFrame.frame_number, keyFrame.ik_states)
-                frame = keyFrame.frame_number + self.__frame_margin
+                frame = keyFrame.frame_number + self.__frame_start + self.__frame_margin
                 for ikName, enable in keyFrame.ik_states:
                     bone = pose_bones.get(ikName, None)
                     if not bone:
@@ -477,17 +572,12 @@ class VMDImporter:
         if len(propertyAnim) > 0:
             # Collect IK states from the first frame
             first_frame_ik_states = {}
-            first_frame = float('inf')
+            first_frame = float("inf")
             for keyFrame in propertyAnim:
                 frame_num = keyFrame.frame_number
-                if frame_num < first_frame:
+                if frame_num <= first_frame:
                     first_frame = frame_num
-                    for ikName, enable in keyFrame.ik_states:
-                        first_frame_ik_states[ikName] = enable
-                elif frame_num == first_frame:
-                    for ikName, enable in keyFrame.ik_states:
-                        if ikName not in first_frame_ik_states:
-                            first_frame_ik_states[ikName] = enable
+                    first_frame_ik_states.update(keyFrame.ik_states)
             # Set the mmd_ik_toggle property for each bone based on the collected first frame IK states
             for ikName, enable in first_frame_ik_states.items():
                 bone = pose_bones.get(ikName, None)
@@ -501,7 +591,7 @@ class VMDImporter:
             return
 
         action_name = action_name or meshObj.name
-        action = bpy.data.actions.new(name=action_name)
+        action = self.__get_or_create_action(meshObj.data.shape_keys, action_name)
 
         mirror_map = _MirrorMapper(meshObj.data.shape_keys.key_blocks) if self.__mirror else {}
         shapeKeyDict = {k: mirror_map.get(k, v) for k, v in meshObj.data.shape_keys.key_blocks.items()}
@@ -515,10 +605,7 @@ class VMDImporter:
             mmd_root = root_object.mmd_root
             # Check all types of morphs in the model
             for morph_type in ["vertex_morphs", "uv_morphs", "bone_morphs", "material_morphs", "group_morphs"]:
-                for morph in getattr(mmd_root, morph_type, []):
-                    model_morph_names.add(morph.name)
-
-        from math import ceil, floor
+                model_morph_names.update(morph.name for morph in getattr(mmd_root, morph_type, []))
 
         for name, keyFrames in shapeKeyAnim.items():
             if name not in shapeKeyDict:
@@ -532,15 +619,22 @@ class VMDImporter:
                 continue
             logging.info("(mesh) frames:%5d  name: %s", len(keyFrames), name)
             shapeKey = shapeKeyDict[name]
-            fcurve = action.fcurves.new(data_path='key_blocks["%s"].value' % shapeKey.name)
+            data_path = f'key_blocks["{shapeKey.name}"].value'
+            fcurve = self.__get_or_create_fcurve(action, data_path, 0, id_type="KEY")
+
+            original_count = len(fcurve.keyframe_points)
             fcurve.keyframe_points.add(len(keyFrames))
+            new_keyframes = fcurve.keyframe_points[original_count:]
+
             keyFrames.sort(key=lambda x: x.frame_number)
-            for k, v in zip(keyFrames, fcurve.keyframe_points):
-                v.co = (k.frame_number + self.__frame_margin, k.weight)
+            for k, v in zip(keyFrames, new_keyframes, strict=False):
+                v.co = (k.frame_number + self.__frame_start + self.__frame_margin, k.weight)
                 v.interpolation = "LINEAR"
             weights = tuple(i.weight for i in keyFrames)
-            shapeKey.slider_min = min(shapeKey.slider_min, floor(min(weights)))
-            shapeKey.slider_max = max(shapeKey.slider_max, ceil(max(weights)))
+            shapeKey.slider_min = min(shapeKey.slider_min, math.floor(min(weights)))
+            shapeKey.slider_max = max(shapeKey.slider_max, math.ceil(max(weights)))
+
+            fcurve.update()
 
         self.__assign_action(meshObj.data.shape_keys, action)
 
@@ -551,23 +645,23 @@ class VMDImporter:
             return
 
         action_name = action_name or rootObj.name
-        action = bpy.data.actions.new(name=action_name)
+        action = self.__get_or_create_action(rootObj, action_name)
 
         logging.debug("(Display) list(frame, show): %s", [(keyFrame.frame_number, bool(keyFrame.visible)) for keyFrame in propertyAnim])
         for keyFrame in propertyAnim:
-            self.__keyframe_insert(action.fcurves, "mmd_root.show_meshes", keyFrame.frame_number + self.__frame_margin, float(keyFrame.visible))
+            self.__keyframe_insert(action.fcurves, "mmd_root.show_meshes", keyFrame.frame_number + self.__frame_start + self.__frame_margin, float(keyFrame.visible))
 
         self.__assign_action(rootObj, action)
 
     @staticmethod
-    def detectCameraChange(fcurve, threshold=10.0):
+    def detectCameraChange(fcurve):
         frames = list(fcurve.keyframe_points)
         frameCount = len(frames)
         frames.sort(key=lambda x: x.co[0])
         for i, f in enumerate(frames):
             if i + 1 < frameCount:
                 n = frames[i + 1]
-                if n.co[0] - f.co[0] <= 1.0 and abs(f.co[1] - n.co[1]) > threshold:
+                if n.co[0] - f.co[0] <= 1.0:
                     f.interpolation = "CONSTANT"
 
     def __assignToCamera(self, cameraObj, action_name=None):
@@ -581,28 +675,33 @@ class VMDImporter:
             return
 
         action_name = action_name or mmdCamera.name
-        parent_action = bpy.data.actions.new(name=action_name)
-        distance_action = bpy.data.actions.new(name=action_name + "_dis")
+        parent_action = self.__get_or_create_action(mmdCamera, action_name)
+        distance_action = self.__get_or_create_action(cameraObj, action_name + "_dis")
 
-        _loc = _rot = lambda i: i
+        def _identity(i):
+            return i
+
+        _loc = _rot = _identity
         if self.__mirror:
             _loc, _rot = _MirrorMapper.get_location, _MirrorMapper.get_rotation3
 
-        fcurves = []
-        for i in range(3):
-            fcurves.append(parent_action.fcurves.new(data_path="location", index=i))  # x, y, z
-        for i in range(3):
-            fcurves.append(parent_action.fcurves.new(data_path="rotation_euler", index=i))  # rx, ry, rz
-        fcurves.append(parent_action.fcurves.new(data_path="mmd_camera.angle"))  # fov
-        fcurves.append(parent_action.fcurves.new(data_path="mmd_camera.is_perspective"))  # persp
-        fcurves.append(distance_action.fcurves.new(data_path="location", index=1))  # dis
+        fcurves = [self.__get_or_create_fcurve(parent_action, "location", i) for i in range(3)]  # x, y, z
+        fcurves.extend(self.__get_or_create_fcurve(parent_action, "rotation_euler", i) for i in range(3))  # rx, ry, rz
+        fcurves.append(self.__get_or_create_fcurve(parent_action, "mmd_camera.angle", 0))  # fov
+        fcurves.append(self.__get_or_create_fcurve(parent_action, "mmd_camera.is_perspective", 0))  # persp
+        fcurves.append(self.__get_or_create_fcurve(distance_action, "location", 1))  # dis
+
+        new_keyframe_iterators = []
         for c in fcurves:
+            original_count = len(c.keyframe_points)
             c.keyframe_points.add(len(cameraAnim))
+            new_keyframes = c.keyframe_points[original_count:]
+            new_keyframe_iterators.append(iter(new_keyframes))
 
         prev_kps, indices = None, (0, 8, 4, 12, 12, 12, 16, 20)  # x, z, y, rx, ry, rz, dis, fov
         cameraAnim.sort(key=lambda x: x.frame_number)
-        for k, x, y, z, rx, ry, rz, fov, persp, dis in zip(cameraAnim, *(c.keyframe_points for c in fcurves)):
-            frame = k.frame_number + self.__frame_margin
+        for k, x, y, z, rx, ry, rz, fov, persp, dis in zip(cameraAnim, *new_keyframe_iterators, strict=False):
+            frame = k.frame_number + self.__frame_start + self.__frame_margin
             x.co, z.co, y.co = ((frame, val * self.__scale) for val in _loc(k.location))
             rx.co, rz.co, ry.co = ((frame, val) for val in _rot(k.rotation))
             fov.co = (frame, math.radians(k.angle))
@@ -613,20 +712,22 @@ class VMDImporter:
             curr_kps = (x, y, z, rx, ry, rz, dis, fov)
             if prev_kps is not None:
                 interp = k.interp
-                for idx, prev_kp, kp in zip(indices, prev_kps, curr_kps):
+                for idx, prev_kp, kp in zip(indices, prev_kps, curr_kps, strict=False):
+                    # TODO: Optimize this bottleneck: __setInterpolation is called per keypoint; should batch set interpolation instead
                     self.__setInterpolation(interp[idx : idx + 4 : 2] + interp[idx + 1 : idx + 4 : 2], prev_kp, kp)
             prev_kps = curr_kps
 
         for fcurve in fcurves:
+            fcurve.update()
             self.__fixFcurveHandles(fcurve)
-            if fcurve.data_path == "rotation_euler":
+            if self.__detect_camera_changes:
                 self.detectCameraChange(fcurve)
 
         self.__assign_action(mmdCamera, parent_action)
         self.__assign_action(cameraObj, distance_action)
 
     @staticmethod
-    def detectLampChange(fcurve, threshold=0.1):
+    def detectLampChange(fcurve):
         frames = list(fcurve.keyframe_points)
         frameCount = len(frames)
         frames.sort(key=lambda x: x.co[0])
@@ -634,7 +735,7 @@ class VMDImporter:
             f.interpolation = "LINEAR"
             if i + 1 < frameCount:
                 n = frames[i + 1]
-                if n.co[0] - f.co[0] <= 1.0 and abs(f.co[1] - n.co[1]) > threshold:
+                if n.co[0] - f.co[0] <= 1.0:
                     f.interpolation = "CONSTANT"
 
     def __assignToLamp(self, lampObj, action_name=None):
@@ -648,17 +749,21 @@ class VMDImporter:
             return
 
         action_name = action_name or mmdLamp.name
-        color_action = bpy.data.actions.new(name=action_name + "_color")
-        location_action = bpy.data.actions.new(name=action_name + "_loc")
+        color_action = self.__get_or_create_action(lampObj.data, action_name + "_color")
+        location_action = self.__get_or_create_action(lampObj, action_name + "_loc")
 
-        _loc = _MirrorMapper.get_location if self.__mirror else lambda i: i
+        def _identity(i):
+            return i
+
+        _loc = _MirrorMapper.get_location if self.__mirror else _identity
         for keyFrame in lampAnim:
-            frame = keyFrame.frame_number + self.__frame_margin
+            frame = keyFrame.frame_number + self.__frame_start + self.__frame_margin
             self.__keyframe_insert(color_action.fcurves, "color", frame, Vector(keyFrame.color))
             self.__keyframe_insert(location_action.fcurves, "location", frame, Vector(_loc(keyFrame.direction)).xzy * -1)
 
-        for fcurve in location_action.fcurves:
-            self.detectLampChange(fcurve)
+        if self.__detect_lamp_changes:
+            for fcurve in location_action.fcurves:
+                self.detectLampChange(fcurve)
 
         self.__assign_action(lampObj.data, color_action)
         self.__assign_action(lampObj, location_action)
@@ -679,7 +784,7 @@ class VMDImporter:
             self.__assignToArmature(obj, action_name + "_bone")
         elif obj.type == "CAMERA" and self.__convert_mmd_camera:
             self.__assignToCamera(obj, action_name + "_camera")
-        elif obj.type == "LAMP" and self.__convert_mmd_lamp:
+        elif obj.type == "LIGHT" and self.__convert_mmd_lamp:
             self.__assignToLamp(obj, action_name + "_lamp")
         elif obj.mmd_type == "ROOT":
             self.__assignToRoot(obj, action_name + "_display")

--- a/extern_tools/mmd_tools_local/core/vpd/__init__.py
+++ b/extern_tools/mmd_tools_local/core/vpd/__init__.py
@@ -13,11 +13,7 @@ class VpdBone:
         self.rotation = rotation if any(rotation) else [0, 0, 0, 1]
 
     def __repr__(self):
-        return "<VpdBone %s, loc %s, rot %s>" % (
-            self.bone_name,
-            str(self.location),
-            str(self.rotation),
-        )
+        return f"<VpdBone {self.bone_name}, loc {str(self.location)}, rot {str(self.rotation)}>"
 
 
 class VpdMorph:
@@ -26,10 +22,7 @@ class VpdMorph:
         self.weight = weight
 
     def __repr__(self):
-        return "<VpdMorph %s, weight %f>" % (
-            self.morph_name,
-            self.weight,
-        )
+        return f"<VpdMorph {self.morph_name}, weight {self.weight:f}>"
 
 
 class File:
@@ -50,8 +43,8 @@ class File:
     def load(self, **args):
         path = args["filepath"]
 
-        encoding = "shift_jis"
-        with open(path, "rt", encoding=encoding, errors="replace") as fin:
+        encoding = "cp932"
+        with open(path, encoding=encoding, errors="replace") as fin:
             self.filepath = path
             if not fin.readline().startswith("Vocaloid Pose Data file"):
                 raise InvalidFileError
@@ -93,8 +86,8 @@ class File:
     def save(self, **args):
         path = args.get("filepath", self.filepath)
 
-        encoding = "shift_jis"
-        with open(path, "wt", encoding=encoding, errors="replace", newline="") as fout:
+        encoding = "cp932"
+        with open(path, "w", encoding=encoding, errors="replace", newline="") as fout:
             self.filepath = path
             fout.write("Vocaloid Pose Data file\r\n")
 

--- a/extern_tools/mmd_tools_local/core/vpd/exporter.py
+++ b/extern_tools/mmd_tools_local/core/vpd/exporter.py
@@ -59,19 +59,19 @@ class VPDExporter:
 
     def __exportPoseLib(self, armObj: bpy.types.Object, pose_type, filepath, use_pose_mode=False):
         if armObj is None:
-            return None
-        
+            return
+
         # Use animation_data and action, checking if they are available
         if armObj.animation_data is None or armObj.animation_data.action is None:
             logging.warning('[WARNING] armature "%s" has no animation data or action', armObj.name)
-            return None
+            return
 
         pose_bones = armObj.pose.bones
         converters = self.__getConverters(pose_bones)
 
-        backup = {b: (b.matrix_basis.copy(), b.bone.select) for b in pose_bones}
+        backup = {b: (b.matrix_basis.copy(), b.select) for b in pose_bones}
         for b in pose_bones:
-            b.bone.select = False
+            b.select = False
 
         matrix_basis_map = {}
         if use_pose_mode:
@@ -99,7 +99,7 @@ class VPDExporter:
                         __export_index(i, os.path.join(folder, m.name + ".vpd"))
         finally:
             for b, bak in backup.items():
-                b.matrix_basis, b.bone.select = bak
+                b.matrix_basis, b.select = bak
 
     def __exportMorphs(self, meshObj):
         if meshObj is None:
@@ -116,11 +116,11 @@ class VPDExporter:
         return vpd_morphs
 
     def export(self, **args):
-        armature = args.get("armature", None)
-        mesh = args.get("mesh", None)
+        armature = args.get("armature")
+        mesh = args.get("mesh")
         filepath = args.get("filepath", "")
         self.__scale = args.get("scale", 1.0)
-        self.__osm_name = "%s.osm" % args.get("model_name", None)
+        self.__osm_name = "%s.osm" % args.get("model_name")
 
         pose_type = args.get("pose_type", "CURRENT")
         if pose_type == "CURRENT":
@@ -133,4 +133,4 @@ class VPDExporter:
                 self.__bone_util_cls = importer.BoneConverterPoseMode
             self.__exportPoseLib(armature, pose_type, filepath, use_pose_mode)
         else:
-            raise ValueError('Unknown pose type "{pose_type}"')
+            raise ValueError(f'Unknown pose type "{pose_type}"')

--- a/extern_tools/mmd_tools_local/core/vpd/importer.py
+++ b/extern_tools/mmd_tools_local/core/vpd/importer.py
@@ -6,7 +6,7 @@ import logging
 import bpy
 from mathutils import Matrix
 
-from ...bpyutils import FnContext
+from ...compat import action_compat
 from .. import vpd
 from ..vmd import importer
 
@@ -47,7 +47,7 @@ class VPDImporter:
         # Check if an action exists
         if armObj.animation_data.action is None:
             action = bpy.data.actions.new(name="PoseLib")
-            armObj.animation_data.action = action
+            action_compat.assign_action_to_datablock(armObj, action)
         else:
             action = armObj.animation_data.action
 
@@ -58,29 +58,29 @@ class VPDImporter:
 
         # Update and keyframe only the bones affected by the current VPD file
         for bone in armObj.pose.bones:
-            vpd_pose = pose_data.get(bone, None)
+            vpd_pose = pose_data.get(bone)
             if vpd_pose:
                 bone.matrix_basis = vpd_pose
-                
+
                 data_path_rot = prop_rot_map.get(bone.rotation_mode, "rotation_euler")
                 bone_rotation = getattr(bone, data_path_rot)
                 fcurves = [None] * (3 + len(bone_rotation))  # x, y, z, r0, r1, r2, (r3)
-                
-                data_path = 'pose.bones["%s"].location' % bone.name
+
+                data_path = f'pose.bones["{bone.name}"].location'
                 for axis_i in range(3):
                     fcurves[axis_i] = action.fcurves.find(data_path, index=axis_i)
                     if fcurves[axis_i] is None:
                         fcurves[axis_i] = action.fcurves.new(data_path=data_path, index=axis_i, action_group=bone.name)
-                
-                data_path = 'pose.bones["%s"].%s' % (bone.name, data_path_rot)
+
+                data_path = f'pose.bones["{bone.name}"].{data_path_rot}'
                 for axis_i in range(len(bone_rotation)):
-                    fcurves[3 + axis_i] = action.fcurves.find(data_path, index=axis_i) 
+                    fcurves[3 + axis_i] = action.fcurves.find(data_path, index=axis_i)
                     if fcurves[3 + axis_i] is None:
                         fcurves[3 + axis_i] = action.fcurves.new(data_path=data_path, index=axis_i, action_group=bone.name)
-                
+
                 for axis_i in range(3):
                     fcurves[axis_i].keyframe_points.insert(current_frame, bone.location[axis_i])
-                
+
                 for axis_i in range(len(bone_rotation)):
                     fcurves[3 + axis_i].keyframe_points.insert(current_frame, bone_rotation[axis_i])
 
@@ -106,8 +106,8 @@ class VPDImporter:
 
         # Check if an action exists or create new one
         if meshObj.data.shape_keys.animation_data.action is None:
-            action = bpy.data.actions.new(name=meshObj.name+"_ShapeKeys")
-            meshObj.data.shape_keys.animation_data.action = action
+            action = bpy.data.actions.new(name=meshObj.name + "_ShapeKeys")
+            action_compat.assign_action_to_datablock(meshObj.data.shape_keys, action)
         else:
             action = meshObj.data.shape_keys.animation_data.action
 
@@ -121,16 +121,16 @@ class VPDImporter:
             if shape_key is None:
                 logging.warning(" * Shape key not found: %s", m.morph_name)
                 continue
-            
+
             # Set the value
             shape_key.value = m.weight
-            
+
             # Create or get FCurve
-            data_path = 'key_blocks["%s"].value' % shape_key.name
+            data_path = f'key_blocks["{shape_key.name}"].value'
             fcurve = action.fcurves.find(data_path)
             if fcurve is None:
                 fcurve = action.fcurves.new(data_path=data_path)
-            
+
             # Add keyframe
             fcurve.keyframe_points.insert(current_frame, m.weight)
 

--- a/extern_tools/mmd_tools_local/externals/opencc/__init__.py
+++ b/extern_tools/mmd_tools_local/externals/opencc/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (C) 2016 Yichen Huang (Eugene)
+# Licensed under the Apache License, Version 2.0
 ##########################################################
 # Author: Yichen Huang (Eugene)
 # GitHub: https://github.com/yichen0831/opencc-python
@@ -5,3 +7,5 @@
 ##########################################################
 
 from .opencc import OpenCC
+
+__all__ = ["OpenCC"]

--- a/extern_tools/mmd_tools_local/externals/opencc/__main__.py
+++ b/extern_tools/mmd_tools_local/externals/opencc/__main__.py
@@ -1,7 +1,7 @@
-from __future__ import print_function
+# Copyright (C) 2016 Yichen Huang (Eugene)
+# Licensed under the Apache License, Version 2.0
 
 import argparse
-import io
 import sys
 
 from opencc import OpenCC
@@ -10,16 +10,16 @@ from opencc import OpenCC
 def main():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('-i', '--input', metavar='<file>',
-                        help='Read original text from <file>.')
-    parser.add_argument('-o', '--output', metavar='<file>',
-                        help='Write converted text to <file>.')
-    parser.add_argument('-c', '--config', metavar='<conversion>',
-                        help='Conversion')
-    parser.add_argument('--in-enc', metavar='<encoding>', default='UTF-8',
-                        help='Encoding for input')
-    parser.add_argument('--out-enc', metavar='<encoding>', default='UTF-8',
-                        help='Encoding for output')
+    parser.add_argument("-i", "--input", metavar="<file>",
+                        help="Read original text from <file>.")
+    parser.add_argument("-o", "--output", metavar="<file>",
+                        help="Write converted text to <file>.")
+    parser.add_argument("-c", "--config", metavar="<conversion>",
+                        help="Conversion")
+    parser.add_argument("--in-enc", metavar="<encoding>", default="UTF-8",
+                        help="Encoding for input")
+    parser.add_argument("--out-enc", metavar="<encoding>", default="UTF-8",
+                        help="Encoding for output")
     args = parser.parse_args()
 
     if args.config is None:
@@ -29,7 +29,7 @@ def main():
     cc = OpenCC(args.config)
 
     if args.input:
-        with io.open(args.input, encoding=args.in_enc) as f:
+        with open(args.input, encoding=args.in_enc) as f:
             input_str = f.read()
     else:
         input_str = sys.stdin.read()
@@ -37,7 +37,7 @@ def main():
     output_str = cc.convert(input_str)
 
     if args.output:
-        with io.open(args.output, "w", encoding=args.out_enc) as f:
+        with open(args.output, "w", encoding=args.out_enc) as f:
             f.write(output_str)
     else:
         sys.stdout.write(output_str)
@@ -45,5 +45,5 @@ def main():
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/extern_tools/mmd_tools_local/externals/opencc/opencc.py
+++ b/extern_tools/mmd_tools_local/externals/opencc/opencc.py
@@ -1,12 +1,12 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
+# Copyright (C) 2016 Yichen Huang (Eugene)
+# Licensed under the Apache License, Version 2.0
 ##########################################################
 # Author: Yichen Huang (Eugene)
 # GitHub: https://github.com/yichen0831/opencc-python
 # January, 2016
 ##########################################################
 ##########################################################
-# Revised by: Hopkins1 
+# Revised by: Hopkins1
 # June, 2016
 # Apache License Version 2.0, January 2004
 # - Use a tree-like structure hold the result during conversion
@@ -20,41 +20,38 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 # - Use "from __future__ import" to allow support for both Python 2.7
 #   and Python >3.2
 ##########################################################
-import io
 import json
 import os
 import re
 
-CONFIG_DIR = 'config'
-DICT_DIR = 'dictionary'
+CONFIG_DIR = "config"
+DICT_DIR = "dictionary"
 
 
 class OpenCC:
     def __init__(self, conversion=None):
         """
-        init OpenCC
+        Init OpenCC
         :param conversion: the conversion of usage, options are
          'hk2s', 's2hk', 's2t', 's2tw', 's2twp', 't2hk', 't2s', 't2tw', 'tw2s', 'tw2sp', etc
          check the json file names in config directory
         :return: None
         """
-        self.conversion_name = ''
+        self.conversion_name = ""
         self.conversion = conversion
         self._dict_init_done = False
-        self._dict_chain = list()
-        self._dict_chain_data = list()
-        self.dict_cache = dict()
+        self._dict_chain = []
+        self._dict_chain_data = []
+        self.dict_cache = {}
         # List of sentence separators from OpenCC PhraseExtract.cpp. None of these separators are allowed as
         # part of a dictionary entry
         self.split_chars_re = re.compile(
-            r'(\s+|-|,|\.|\?|!|\*|　|，|。|、|；|：|？|！|…|“|”|‘|’|『|』|「|」|﹁|﹂|—|－|（|）|《|》|〈|〉|～|．|／|＼|︒|︑|︔|︓|︿|﹀|︹|︺|︙|︐|［|﹇|］|﹈|︕|︖|︰|︳|︴|︽|︾|︵|︶|｛|︷|｝|︸|﹃|﹄|【|︻|】|︼)')
+            r"(\s+|-|,|\.|\?|!|\*|　|，|。|、|；|：|？|！|…|“|”|‘|’|『|』|「|」|﹁|﹂|—|－|（|）|《|》|〈|〉|～|．|／|＼|︒|︑|︔|︓|︿|﹀|︹|︺|︙|︐|［|﹇|］|﹈|︕|︖|︰|︳|︴|︽|︾|︵|︶|｛|︷|｝|︸|﹃|﹄|【|︻|】|︼)")
         if self.conversion is not None:
             self._init_dict()
 
     def convert(self, string):
-        """
-        Convert string from Simplified Chinese to Traditional Chinese or vice versa
-        """
+        """Convert string from Simplified Chinese to Traditional Chinese or vice versa"""
         if not self._dict_init_done:
             self._init_dict()
             self._dict_init_done = True
@@ -62,7 +59,7 @@ class OpenCC:
         result = []
         # Separate string using the list of separators in a regular expression
         split_string_list = self.split_chars_re.split(string)
-        for i in range(0, len(split_string_list)):
+        for i in range(len(split_string_list)):
             if i % 2 == 0:
                 # Work with the text string
                 # Append converted string to result
@@ -74,7 +71,7 @@ class OpenCC:
         # Join it all together to return a result
         return "".join(result)
 
-    def _convert(self, string, dictionary = []):
+    def _convert(self, string, dictionary=None):
         """
         Convert string from Simplified Chinese to Traditional Chinese or vice versa
         If a dictionary is part of a group of dictionaries, stop conversion on a word
@@ -83,6 +80,8 @@ class OpenCC:
         :param dictionary: list of dictionaries to be applied against the string
         :return: converted string
         """
+        if dictionary is None:
+            dictionary = []
         tree = StringTree(string)
         for c_dict in dictionary:
             tree.create_parse_tree(c_dict)
@@ -91,29 +90,29 @@ class OpenCC:
 
     def _init_dict(self):
         """
-        initialize the dict with chosen conversion
+        Initialize the dict with chosen conversion
         :return: None
         """
         if self.conversion is None:
-            raise ValueError('conversion is not set')
+            raise ValueError("conversion is not set")
 
         self._dict_chain = []
-        config = self.conversion + '.json'
+        config = self.conversion + ".json"
         config_file = os.path.join(os.path.dirname(__file__), CONFIG_DIR, config)
-        with open(config_file) as f:
+        with open(config_file, encoding="utf-8") as f:
             setting_json = json.load(f)
 
-        self.conversion_name = setting_json.get('name')
+        self.conversion_name = setting_json.get("name")
 
-        for chain in setting_json.get('conversion_chain'):
-            self._add_dict_chain(self._dict_chain, chain.get('dict'))
+        for chain in setting_json.get("conversion_chain"):
+            self._add_dict_chain(self._dict_chain, chain.get("dict"))
 
         self._dict_chain_data = []
         self._add_dictionaries(self._dict_chain, self._dict_chain_data)
         # Make sure all dictionaries are in a list
         for index, c_dict in enumerate(self._dict_chain_data):
-           if isinstance(c_dict, tuple):
-               self._dict_chain_data[index] = [c_dict]
+            if isinstance(c_dict, tuple):
+                self._dict_chain_data[index] = [c_dict]
         self._dict_init_done = True
 
     def _add_dictionaries(self, chain_list, chain_data):
@@ -122,47 +121,44 @@ class OpenCC:
                 chain = []
                 self._add_dictionaries(item, chain)
                 chain_data.append(chain)
+            elif item not in self.dict_cache:
+                map_dict = {}
+                # Default max key length to smallest possible value
+                max_len = 1
+                # Default min key length to very large value
+                min_len = 1000
+                with open(item, encoding="utf-8") as f:
+                    for line in f:
+                        key, value = line.strip().split("\t")
+                        map_dict[key] = value
+                        max_len = max(max_len, len(key))
+                        min_len = min(min_len, len(key))
+                chain_data.append((max_len, min_len, map_dict))
+                self.dict_cache[item] = (max_len, min_len, map_dict)
             else:
-                if not item in self.dict_cache:
-                    map_dict = {}
-                    # Default max key length to smallest possible value
-                    max_len = 1
-                    # Default min key length to very large value
-                    min_len = 1000
-                    with io.open(item, "r", encoding="utf-8") as f:
-                        for line in f:
-                            key, value = line.strip().split('\t')
-                            map_dict[key] = value
-                            if len(key) > max_len:
-                                max_len = len(key)
-                            if len(key) < min_len:
-                                min_len = len(key)
-                    chain_data.append((max_len, min_len, map_dict))
-                    self.dict_cache[item] = (max_len, min_len, map_dict)
-                else:
-                    chain_data.append(self.dict_cache[item])
+                chain_data.append(self.dict_cache[item])
 
     def _add_dict_chain(self, dict_chain, dict_dict):
         """
-        add dict chain
+        Add dict chain
         :param dict_chain: the dict chain to add to
         :param dict_dict: the dict to be added in
         :return: None
         """
-        if dict_dict.get('type') == 'group':
+        if dict_dict.get("type") == "group":
             # Create a sublist of dictionaries for a group
             chain = []
-            for dict_item in dict_dict.get('dicts'):
+            for dict_item in dict_dict.get("dicts"):
                 self._add_dict_chain(chain, dict_item)
             dict_chain.append(chain)
-        elif dict_dict.get('type') == 'txt':
-            filename = dict_dict.get('file')
+        elif dict_dict.get("type") == "txt":
+            filename = dict_dict.get("file")
             dict_file = os.path.join(os.path.dirname(__file__), DICT_DIR, filename)
             dict_chain.append(dict_file)
 
     def set_conversion(self, conversion):
         """
-        set conversion
+        Set conversion
         :param conversion: the conversion of usage, options are
          'hk2s', 's2hk', 's2t', 's2tw', 's2twp', 't2hk', 't2s', 't2tw', 'tw2s', and 'tw2sp'
          check the json file names in config directory
@@ -170,13 +166,14 @@ class OpenCC:
         """
         if self.conversion == conversion:
             return
-        else:
-            self._dict_init_done = False
-            self.conversion = conversion
+        self._dict_init_done = False
+        self.conversion = conversion
+
 
 #############################################
 
-class TreeNode(object):
+
+class TreeNode:
     LEFT = 0
     RIGHT = 1
 
@@ -198,7 +195,8 @@ class TreeNode(object):
     def set_hint(self, hint):
         self.length_hint = hint
 
-class StringTree(object):
+
+class StringTree:
     def __init__(self, string):
         self.root = TreeNode(string)
 
@@ -214,22 +212,22 @@ class StringTree(object):
         """
         # Stacks to hold nodes with unmatched strings
         working_stack = [self.root]
-        unmatched_stack =[]
+        unmatched_stack = []
 
         # process stack
         for test_dict in test_dict_list:
             while working_stack:
                 curr = working_stack.pop()
                 value, lstring, rstring, test_len = self.__findMatch(curr.value, test_dict, curr.length_hint)
-                if (value):
+                if value:
                     curr.set_value(value)
                     curr.set_hint(None)
                     curr.set_matched(True)
-                    if (lstring):
+                    if lstring:
                         node = TreeNode(lstring, test_len)
                         working_stack.append(node)
                         curr.set_branch(TreeNode.LEFT, node)
-                    if (rstring):
+                    if rstring:
                         node = TreeNode(rstring, test_len)
                         working_stack.append(node)
                         curr.set_branch(TreeNode.RIGHT, node)
@@ -263,7 +261,7 @@ class StringTree(object):
                 break
         return return_val
 
-    def __findMatch(self, string, test_dict, hint = None):
+    def __findMatch(self, string, test_dict, hint=None):
         """
         Compare smaller and smaller sub-strings going from left to
         right against test_dict. If an entry is found, return it as well
@@ -278,29 +276,27 @@ class StringTree(object):
         string_len = len(string)
         lstring = None
         rstring = None
-        test_len = min (string_len, test_dict[0])
+        test_len = min(string_len, test_dict[0])
         if hint:
-            test_len = min (test_len, hint)
+            test_len = min(test_len, hint)
         min_len = test_dict[1]
         while test_len >= min_len:
             # Loop through trying successively smaller substrings in the dictionary
-            for i in range(0, string_len - test_len + 1):
-                if string[i:i+test_len] in test_dict[2]:
+            for i in range(string_len - test_len + 1):
+                if string[i:i + test_len] in test_dict[2]:
                     # Match found.
                     if i > 0:
                         # Put everything to the left of the match into lstring
                         lstring = string[:i]
-                    if (i+test_len) < string_len:
+                    if (i + test_len) < string_len:
                         # Put everything to the right of the match into rstring
-                        rstring = string[i+test_len:]
+                        rstring = string[i + test_len:]
                     # Save the dictionary value
-                    value = test_dict[2][string[i:i+test_len]]
-                    if len(value.split(' ')) > 1:
+                    value = test_dict[2][string[i:i + test_len]]
+                    if len(value.split(" ")) > 1:
                         # multiple mapping, use the first one for now
-                        value = value.split(' ')[0]
+                        value = value.split(" ")[0]
                     return value, lstring, rstring, test_len
             test_len -= 1
         # No match found
         return None, None, None, None
-
-

--- a/extern_tools/mmd_tools_local/m17n.py
+++ b/extern_tools/mmd_tools_local/m17n.py
@@ -13,7 +13,7 @@ translations_tuple = (
         ((), ()),
         (
             "ja_JP",
-            "Project-Id-Version: MMD Tools 4.3.3 (0)\n",
+            "Project-Id-Version: MMD Tools 4.5.1 (0)\n",
             (
                 False,
                 (
@@ -26,7 +26,7 @@ translations_tuple = (
         ),
         (
             "zh_HANS",
-            "Project-Id-Version: MMD Tools 4.3.3 (0)\n",
+            "Project-Id-Version: MMD Tools 4.5.1 (0)\n",
             (
                 False,
                 (
@@ -47,8 +47,80 @@ translations_tuple = (
     (
         ("*", "Path for textures shared between models"),
         (("bpy.types.MMDToolsAddonPreferences.base_texture_folder",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "モデル間で共有するテクスチャのパス", (False, ())),
         ("zh_HANS", "模型间共用纹理的路径", (False, ())),
+    ),
+    (
+        ("*", "Default PMX Export Operator Preset"),
+        (("bpy.types.MMDToolsAddonPreferences.default_pmx_export_preset",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "默认PMX导出操作项预设", (False, ())),
+    ),
+    (
+        ("*", "Default preset to use for PMX export operations"),
+        (("bpy.types.MMDToolsAddonPreferences.default_pmx_export_preset",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "默认PMX导出操作项预设", (False, ())),
+    ),
+    (
+        ("*", "Default PMX Import Operator Preset"),
+        (("bpy.types.MMDToolsAddonPreferences.default_pmx_import_preset",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "默认PMX导入操作项预设", (False, ())),
+    ),
+    (
+        ("*", "Default preset to use for PMX import operations"),
+        (("bpy.types.MMDToolsAddonPreferences.default_pmx_import_preset",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "默认PMX导入操作项预设", (False, ())),
+    ),
+    (
+        ("*", "Default VMD Export Operator Preset"),
+        (("bpy.types.MMDToolsAddonPreferences.default_vmd_export_preset",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "默认VMD导出操作项预设", (False, ())),
+    ),
+    (
+        ("*", "Default preset to use for VMD export operations"),
+        (("bpy.types.MMDToolsAddonPreferences.default_vmd_export_preset",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "默认VMD导出操作项预设", (False, ())),
+    ),
+    (
+        ("*", "Default VMD Import Operator Preset"),
+        (("bpy.types.MMDToolsAddonPreferences.default_vmd_import_preset",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "默认VMD导入操作项预设", (False, ())),
+    ),
+    (
+        ("*", "Default preset to use for VMD import operations"),
+        (("bpy.types.MMDToolsAddonPreferences.default_vmd_import_preset",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "默认VMD导入操作项预设", (False, ())),
+    ),
+    (
+        ("*", "Default VPD Export Operator Preset"),
+        (("bpy.types.MMDToolsAddonPreferences.default_vpd_export_preset",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "默认VPD导出操作项预设", (False, ())),
+    ),
+    (
+        ("*", "Default preset to use for VPD export operations"),
+        (("bpy.types.MMDToolsAddonPreferences.default_vpd_export_preset",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "默认VPD导出操作项预设", (False, ())),
+    ),
+    (
+        ("*", "Default VPD Import Operator Preset"),
+        (("bpy.types.MMDToolsAddonPreferences.default_vpd_import_preset",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "默认VPD导入操作项预设", (False, ())),
+    ),
+    (
+        ("*", "Default preset to use for VPD import operations"),
+        (("bpy.types.MMDToolsAddonPreferences.default_vpd_import_preset",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "默认VPD导入操作项预设", (False, ())),
     ),
     (
         ("*", "Dictionary Folder"),
@@ -59,7 +131,7 @@ translations_tuple = (
     (
         ("*", "Path for searching csv dictionaries"),
         (("bpy.types.MMDToolsAddonPreferences.dictionary_folder",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "CSV辞書を検索するためのパス", (False, ())),
         ("zh_HANS", "搜索 CSV 词典的路径", (False, ())),
     ),
     (
@@ -85,7 +157,11 @@ translations_tuple = (
             'Directory path to toon textures. This is normally the "Data" directory within of your MikuMikuDance directory',
         ),
         (("bpy.types.MMDToolsAddonPreferences.shared_toon_folder",), ()),
-        ("ja_JP", "", (False, ())),
+        (
+            "ja_JP",
+            "トゥーンテクスチャのパス. 通常は MikuMikuDance の Data ディレクトリ内にあります",
+            (False, ()),
+        ),
         (
             "zh_HANS",
             "卡通纹理路径. 通常是 MikuMikuDance 安装路径下的 Data 目录",
@@ -96,7 +172,7 @@ translations_tuple = (
         ("*", "Internal MMD type of this object (DO NOT CHANGE IT DIRECTLY)"),
         (("bpy.types.Object.mmd_type",), ()),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", "该物体的内部 MMD 类型（切勿直接改动）", (False, ())),
+        ("zh_HANS", "该物体的内部 MMD 类型(切勿直接改动)", (False, ())),
     ),
     (
         ("*", "Rigid Body Grp Empty"),
@@ -127,7 +203,7 @@ translations_tuple = (
         (
             (
                 "bpy.types.Object.mmd_type:'JOINT'",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:53",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:52",
             ),
             (),
         ),
@@ -137,13 +213,13 @@ translations_tuple = (
     (
         ("*", "Rigid body"),
         (("bpy.types.Object.mmd_type:'RIGID_BODY'",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "剛体", (False, ())),
         ("zh_HANS", "刚体", (False, ())),
     ),
     (
         ("*", "Track Target"),
         (("bpy.types.Object.mmd_type:'TRACK_TARGET'",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "追跡対象", (False, ())),
         ("zh_HANS", "追踪目标", (False, ())),
     ),
     (
@@ -155,7 +231,7 @@ translations_tuple = (
     (
         ("*", "Spring Constraint"),
         (("bpy.types.Object.mmd_type:'SPRING_CONSTRAINT'",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "ばねコンストレイント", (False, ())),
         ("zh_HANS", "弹簧约束", (False, ())),
     ),
     (
@@ -163,6 +239,12 @@ translations_tuple = (
         (("bpy.types.Object.mmd_type:'SPRING_GOAL'",), ()),
         ("ja_JP", "", (False, ())),
         ("zh_HANS", "弹簧目标", (False, ())),
+    ),
+    (
+        ("*", "Validation Results"),
+        (("bpy.types.Scene.mmd_validation_results",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "检测结果", (False, ())),
     ),
     (
         ("*", "Bone Order Menu"),
@@ -179,32 +261,32 @@ translations_tuple = (
     (
         ("*", "Display Item Menu"),
         (("bpy.types.OBJECT_MT_mmd_tools_local_display_item_menu",), ()),
-        ("ja_JP", "", (False, ())),
-        ("zh_HANS", "表示枠项目", (True, ())),
+        ("ja_JP", "表示枠", (False, ())),
+        ("zh_HANS", "表示枠", (False, ())),
     ),
     (
         ("*", "Joint Menu"),
         (("bpy.types.OBJECT_MT_mmd_tools_local_joint_menu",), ()),
-        ("ja_JP", "", (False, ())),
-        ("zh_HANS", "", (False, ())),
+        ("ja_JP", "関節", (False, ())),
+        ("zh_HANS", "关节", (False, ())),
     ),
     (
         ("*", "Morph Menu"),
         (("bpy.types.OBJECT_MT_mmd_tools_local_morph_menu",), ()),
-        ("ja_JP", "", (False, ())),
-        ("zh_HANS", "", (False, ())),
+        ("ja_JP", "モーフ", (False, ())),
+        ("zh_HANS", "变形", (False, ())),
     ),
     (
         ("*", "Rigidbody Menu"),
         (("bpy.types.OBJECT_MT_mmd_tools_local_rigidbody_menu",), ()),
-        ("ja_JP", "", (False, ())),
-        ("zh_HANS", "刚体", (True, ())),
+        ("ja_JP", "剛体", (False, ())),
+        ("zh_HANS", "刚体", (False, ())),
     ),
     (
         ("*", "Rigidbody Select Menu"),
         (("bpy.types.OBJECT_MT_mmd_tools_local_rigidbody_select_menu",), ()),
-        ("ja_JP", "", (False, ())),
-        ("zh_HANS", "", (False, ())),
+        ("ja_JP", "剛体選択", (False, ())),
+        ("zh_HANS", "刚体选择", (False, ())),
     ),
     (
         ("*", "MMD UuuNyaa"),
@@ -220,42 +302,8 @@ translations_tuple = (
             ),
             (),
         ),
-        ("ja_JP", "", (False, ())),
-        ("zh_HANS", "", (False, ())),
-    ),
-    (
-        ("Operator", "Add Missing Vertex Groups from Bones"),
-        (("bpy.types.mmd_tools_local_OT_add_missing_vertex_groups_from_bones",), ()),
-        ("ja_JP", "ボーンから不足している頂点グループを追加", (False, ())),
-        ("zh_HANS", "从骨骼中添加缺失的顶点组", (False, ())),
-    ),
-    (
-        ("*", "Add the missing vertex groups to the selected mesh"),
-        (("bpy.types.mmd_tools_local_OT_add_missing_vertex_groups_from_bones",), ()),
-        ("ja_JP", "", (False, ())),
-        ("zh_HANS", "将丢失的顶点组添加至选中的网格", (False, ())),
-    ),
-    (
-        ("*", "Search in all meshes"),
-        (
-            (
-                "bpy.types.mmd_tools_local_OT_add_missing_vertex_groups_from_bones.search_in_all_meshes",
-            ),
-            (),
-        ),
-        ("ja_JP", "全てのメッシュで検索", (False, ())),
-        ("zh_HANS", "在所有网格中搜索", (False, ())),
-    ),
-    (
-        ("*", "Search for vertex groups in all meshes"),
-        (
-            (
-                "bpy.types.mmd_tools_local_OT_add_missing_vertex_groups_from_bones.search_in_all_meshes",
-            ),
-            (),
-        ),
-        ("ja_JP", "", (False, ())),
-        ("zh_HANS", "在所有网格中搜索顶点组", (False, ())),
+        ("ja_JP", "MMD UuuNyaa", (False, ())),
+        ("zh_HANS", "MMD UuuNyaa", (False, ())),
     ),
     (
         ("Operator", "Apply Additional Transform"),
@@ -489,10 +537,17 @@ translations_tuple = (
         ("zh_HANS", "建立骨架", (False, ())),
     ),
     (
-        ("*", "Translate physics of selected object into format usable by Blender"),
+        (
+            "*",
+            "Translate physics of selected object into format usable by Blender\n\nWarning: May cause crashes and performance issues. Consider using mmdbridge instead for better stability and accurate physics simulation.",
+        ),
         (("bpy.types.mmd_tools_local_OT_build_rig",), ()),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", "将选中物体的物理转译为 Blender 可用的形式", (False, ())),
+        (
+            "zh_HANS",
+            "将选中物体的物理转译为 Blender 可用的形式\n\n警告:可能导致崩溃和性能问题。建议使用 MMDBridge 以获得更好的稳定性和准确的物理模拟。",
+            (False, ()),
+        ),
     ),
     (
         (
@@ -523,8 +578,8 @@ translations_tuple = (
         (
             (
                 "bpy.types.mmd_tools_local_OT_change_mmd_ik_loop_factor",
-                "extensions/user_default/mmd_tools_local/panels/prop_object.py:34",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:161",
+                "extensions/blender_org/mmd_tools_local/panels/prop_object.py:34",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:163",
             ),
             (),
         ),
@@ -590,6 +645,21 @@ translations_tuple = (
         ("zh_HANS", "清理重复的材质变形", (False, ())),
     ),
     (
+        ("Operator", "Clean Invalid Bone References"),
+        (("bpy.types.mmd_tools_local_OT_clean_invalid_bone_id_references",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "清理无效骨骼引用", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "Scans the active MMD model for any references to bone_ids that no longer exist, then cleans them up. This is useful after deleting bones to maintain data integrity.",
+        ),
+        (("bpy.types.mmd_tools_local_OT_clean_invalid_bone_id_references",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
         ("Operator", "Clean Rig"),
         (("bpy.types.mmd_tools_local_OT_clean_rig",), ()),
         ("ja_JP", "", (False, ())),
@@ -613,7 +683,7 @@ translations_tuple = (
         (
             (
                 "bpy.types.mmd_tools_local_OT_clean_shape_keys",
-                "extensions/user_default/mmd_tools_local/menus.py:87",
+                "extensions/blender_org/mmd_tools_local/menus.py:83",
             ),
             (),
         ),
@@ -663,6 +733,29 @@ translations_tuple = (
         ("zh_HANS", "清除所有 UV 变形的临时数据", (False, ())),
     ),
     (
+        ("Operator", "Convert To Vertex Morph"),
+        (
+            (
+                "bpy.types.mmd_tools_local_OT_convert_bone_morph_to_vertex_morph",
+                "bpy.types.mmd_tools_local_OT_convert_group_morph_to_vertex_morph",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:191",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:234",
+            ),
+            (),
+        ),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "转换到顶点变形", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "Convert a bone morph into a single vertex morph by applying the bone transformations.\nIf a corresponding vertex morph already exists, it will be updated.",
+        ),
+        (("bpy.types.mmd_tools_local_OT_convert_bone_morph_to_vertex_morph",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
         ("Operator", "Convert Blender Materials"),
         (("bpy.types.mmd_tools_local_OT_convert_bsdf_materials",), ()),
         ("ja_JP", "マテリアルノードを変換", (True, ())),
@@ -679,6 +772,15 @@ translations_tuple = (
         ),
         ("ja_JP", "", (False, ())),
         ("zh_HANS", "转换选中物体的材质", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "Convert a group morph into a single vertex morph by merging only the vertex morphs within the group.\nIf a corresponding vertex morph already exists, it will be updated.",
+        ),
+        (("bpy.types.mmd_tools_local_OT_convert_group_morph_to_vertex_morph",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("Operator", "Convert Materials"),
@@ -1132,10 +1234,13 @@ translations_tuple = (
         ("zh_HANS", "移动显示项目", (False, ())),
     ),
     (
-        ("*", "Move active display item up/dowm in the list"),
+        (
+            "*",
+            "Move active display item up/down in the list. This will also affect the morph order in exported PMX files.",
+        ),
         (("bpy.types.mmd_tools_local_OT_display_item_move",), ()),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", "将活动的表示上移或下移", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("Operator", "Display Item Quick Setup"),
@@ -1319,16 +1424,52 @@ translations_tuple = (
         ("zh_HANS", "将选中的 MMD 模型导出至 PMX 文件 (.pmx)", (False, ())),
     ),
     (
-        ("*", "Copy textures"),
-        (
-            (
-                "bpy.types.mmd_tools_local_OT_export_pmx.copy_textures",
-                "bpy.types.mmd_tools_local_OT_export_pmx.copy_textures",
-            ),
-            (),
-        ),
+        ("*", "Copy Textures"),
+        (("bpy.types.mmd_tools_local_OT_export_pmx.copy_textures_mode",), ()),
         ("ja_JP", "テクスチャをコピー", (False, ())),
         ("zh_HANS", "复制纹理", (False, ())),
+    ),
+    (
+        ("*", "Choose how to handle texture files during export"),
+        (("bpy.types.mmd_tools_local_OT_export_pmx.copy_textures_mode",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Don't Copy"),
+        (("bpy.types.mmd_tools_local_OT_export_pmx.copy_textures_mode:'NONE'",), ()),
+        ("ja_JP", "コピーしない", (False, ())),
+        ("zh_HANS", "不复制", (False, ())),
+    ),
+    (
+        ("*", "Don't copy texture files"),
+        (("bpy.types.mmd_tools_local_OT_export_pmx.copy_textures_mode:'NONE'",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Copy (Skip Existing)"),
+        (("bpy.types.mmd_tools_local_OT_export_pmx.copy_textures_mode:'SKIP_EXISTING'",), ()),
+        ("ja_JP", "コピー(既存をスキップ)", (False, ())),
+        ("zh_HANS", "复制(跳过已存在)", (False, ())),
+    ),
+    (
+        ("*", "Copy textures but skip files that already exist"),
+        (("bpy.types.mmd_tools_local_OT_export_pmx.copy_textures_mode:'SKIP_EXISTING'",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Copy (Overwrite)"),
+        (("bpy.types.mmd_tools_local_OT_export_pmx.copy_textures_mode:'OVERWRITE'",), ()),
+        ("ja_JP", "コピー(上書き)", (False, ())),
+        ("zh_HANS", "复制(覆盖)", (False, ())),
+    ),
+    (
+        ("*", "Copy textures and overwrite existing files"),
+        (("bpy.types.mmd_tools_local_OT_export_pmx.copy_textures_mode:'OVERWRITE'",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "Disable SPH/SPA"),
@@ -1346,11 +1487,123 @@ translations_tuple = (
         ("zh_HANS", "禁用所有高光材质 部分 MME 着色器必须禁用高光材质", (False, ())),
     ),
     (
+        (
+            "*",
+            "Export vertex colors as ADD UV2 data. This allows vertex color data to be preserved in the PMX file format. When enabled, existing ADD UV2 data on the model will be skipped during export.",
+        ),
+        (("bpy.types.mmd_tools_local_OT_export_pmx.export_vertex_colors_as_adduv2",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Filepath used for exporting the file"),
+        (
+            (
+                "bpy.types.mmd_tools_local_OT_export_pmx.filepath",
+                "bpy.types.mmd_tools_local_OT_export_vmd.filepath",
+                "bpy.types.mmd_tools_local_OT_export_vpd.filepath",
+            ),
+            (),
+        ),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Fix Bone Order"),
+        (
+            (
+                "bpy.types.mmd_tools_local_OT_export_pmx.fix_bone_order",
+                "bpy.types.mmd_tools_local_OT_import_model.fix_bone_order",
+            ),
+            (),
+        ),
+        ("ja_JP", "ボーン順序を修正", (False, ())),
+        ("zh_HANS", "修复骨骼顺序", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "Automatically fix bone order before export. This ensures bones are ordered correctly for MMD compatibility.",
+        ),
+        (("bpy.types.mmd_tools_local_OT_export_pmx.fix_bone_order",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "IK Angle Limits"),
+        (("bpy.types.mmd_tools_local_OT_export_pmx.ik_angle_limits",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "IK 角度限制", (False, ())),
+    ),
+    (
+        ("*", "Choose how to handle IK angle limits during export"),
+        (("bpy.types.mmd_tools_local_OT_export_pmx.ik_angle_limits",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Export All Limits"),
+        (("bpy.types.mmd_tools_local_OT_export_pmx.ik_angle_limits:'EXPORT_ALL'",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "导出所有限制", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "Export all existing IK angle limits using current priority system: mmd_ik_limit_override -> Blender IK limits -> other sources. If mmd_ik_limit_override disables an axis but Blender IK limits exist for that axis, the Blender limits will still be exported. This maintains backward compatibility with existing workflows",
+        ),
+        (("bpy.types.mmd_tools_local_OT_export_pmx.ik_angle_limits:'EXPORT_ALL'",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Ignore All Limits"),
+        (("bpy.types.mmd_tools_local_OT_export_pmx.ik_angle_limits:'IGNORE_ALL'",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "忽略所有限制", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "Completely ignore all IK angle limits from any source during export. No angle restrictions will be written to the PMX file, regardless of mmd_ik_limit_override, Blender IK limits, or other constraint settings. Useful when you want to rely entirely on MMD v9.19+ fixed axis feature instead",
+        ),
+        (("bpy.types.mmd_tools_local_OT_export_pmx.ik_angle_limits:'IGNORE_ALL'",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Override Controlled"),
+        (
+            (
+                "bpy.types.mmd_tools_local_OT_export_pmx.ik_angle_limits:'OVERRIDE_CONTROLLED'",
+            ),
+            (),
+        ),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "覆盖控制", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "Use mmd_ik_limit_override constraints as the sole authority for IK limits. When mmd_ik_limit_override exists: only its enabled axes export limits, disabled axes export no limits (ignoring Blender IK limits). When mmd_ik_limit_override doesn't exist: fall back to Blender IK limits. This makes mmd_ik_limit_override act as a true 'override' that completely controls whether limits are exported, enabling fine-grained per-bone control",
+        ),
+        (
+            (
+                "bpy.types.mmd_tools_local_OT_export_pmx.ik_angle_limits:'OVERRIDE_CONTROLLED'",
+            ),
+            (),
+        ),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
         ("*", "Log level"),
         (
             (
                 "bpy.types.mmd_tools_local_OT_export_pmx.log_level",
+                "bpy.types.mmd_tools_local_OT_export_vmd.log_level",
                 "bpy.types.mmd_tools_local_OT_import_model.log_level",
+                "bpy.types.mmd_tools_local_OT_import_vmd.log_level",
             ),
             (),
         ),
@@ -1362,7 +1615,9 @@ translations_tuple = (
         (
             (
                 "bpy.types.mmd_tools_local_OT_export_pmx.log_level",
+                "bpy.types.mmd_tools_local_OT_export_vmd.log_level",
                 "bpy.types.mmd_tools_local_OT_import_model.log_level",
+                "bpy.types.mmd_tools_local_OT_import_vmd.log_level",
             ),
             (),
         ),
@@ -1374,7 +1629,9 @@ translations_tuple = (
         (
             (
                 "bpy.types.mmd_tools_local_OT_export_pmx.log_level:'DEBUG'",
+                "bpy.types.mmd_tools_local_OT_export_vmd.log_level:'DEBUG'",
                 "bpy.types.mmd_tools_local_OT_import_model.log_level:'DEBUG'",
+                "bpy.types.mmd_tools_local_OT_import_vmd.log_level:'DEBUG'",
             ),
             (),
         ),
@@ -1386,7 +1643,9 @@ translations_tuple = (
         (
             (
                 "bpy.types.mmd_tools_local_OT_export_pmx.log_level:'INFO'",
+                "bpy.types.mmd_tools_local_OT_export_vmd.log_level:'INFO'",
                 "bpy.types.mmd_tools_local_OT_import_model.log_level:'INFO'",
+                "bpy.types.mmd_tools_local_OT_import_vmd.log_level:'INFO'",
             ),
             (),
         ),
@@ -1398,7 +1657,9 @@ translations_tuple = (
         (
             (
                 "bpy.types.mmd_tools_local_OT_export_pmx.log_level:'WARNING'",
+                "bpy.types.mmd_tools_local_OT_export_vmd.log_level:'WARNING'",
                 "bpy.types.mmd_tools_local_OT_import_model.log_level:'WARNING'",
+                "bpy.types.mmd_tools_local_OT_import_vmd.log_level:'WARNING'",
             ),
             (),
         ),
@@ -1410,12 +1671,100 @@ translations_tuple = (
         (
             (
                 "bpy.types.mmd_tools_local_OT_export_pmx.log_level:'ERROR'",
+                "bpy.types.mmd_tools_local_OT_export_vmd.log_level:'ERROR'",
                 "bpy.types.mmd_tools_local_OT_import_model.log_level:'ERROR'",
+                "bpy.types.mmd_tools_local_OT_import_vmd.log_level:'ERROR'",
             ),
             (),
         ),
         ("ja_JP", "", (False, ())),
         ("zh_HANS", "1. ERROR", (False, ())),
+    ),
+    (
+        ("*", "Normal Handling"),
+        (("bpy.types.mmd_tools_local_OT_export_pmx.normal_handling",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "法线处理", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "Choose how to handle normals during export. This affects vertex count, edge count, and mesh topology by splitting vertices and edges to preserve split normals.",
+        ),
+        (("bpy.types.mmd_tools_local_OT_export_pmx.normal_handling",), ()),
+        ("ja_JP", "", (False, ())),
+        (
+            "zh_HANS",
+            "选择导出时如何处理法线。这会影响顶点数量、边数量以及网格拓扑，通过拆分顶点和边来保留拆边法线。",
+            (False, ()),
+        ),
+    ),
+    (
+        ("*", "Preserve All Normals"),
+        (
+            (
+                "bpy.types.mmd_tools_local_OT_export_pmx.normal_handling:'PRESERVE_ALL_NORMALS'",
+            ),
+            (),
+        ),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "保留所有法线", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "Export existing normals without any changes. This option performs NO automatic smoothing; only use it if you have already manually smoothed and perfected your normals. When using this option, please verify if the vertex count of the exported model has significantly increased or is within a reasonable range to prevent excessive geometry destruction and an overly fragmented model.",
+        ),
+        (
+            (
+                "bpy.types.mmd_tools_local_OT_export_pmx.normal_handling:'PRESERVE_ALL_NORMALS'",
+            ),
+            (),
+        ),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Smooth (Keep Sharp)"),
+        (
+            ("bpy.types.mmd_tools_local_OT_export_pmx.normal_handling:'SMOOTH_KEEP_SHARP'",),
+            (),
+        ),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "平滑(保留锐边)", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "Shade smooth, keep sharp edges. Balances vertex count and normal preservation.",
+        ),
+        (
+            ("bpy.types.mmd_tools_local_OT_export_pmx.normal_handling:'SMOOTH_KEEP_SHARP'",),
+            (),
+        ),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Smooth All Normals"),
+        (
+            ("bpy.types.mmd_tools_local_OT_export_pmx.normal_handling:'SMOOTH_ALL_NORMALS'",),
+            (),
+        ),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "平滑所有法线", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "Force smooths all normals, ignoring any sharp edges. This will result in a completely smooth-shaded model and minimum vertex count.",
+        ),
+        (
+            ("bpy.types.mmd_tools_local_OT_export_pmx.normal_handling:'SMOOTH_ALL_NORMALS'",),
+            (),
+        ),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "Overwrite Bone Morphs"),
@@ -1449,8 +1798,12 @@ translations_tuple = (
             (
                 "bpy.types.mmd_tools_local_OT_export_pmx.save_log",
                 "bpy.types.mmd_tools_local_OT_export_pmx.save_log",
+                "bpy.types.mmd_tools_local_OT_export_vmd.save_log",
+                "bpy.types.mmd_tools_local_OT_export_vmd.save_log",
                 "bpy.types.mmd_tools_local_OT_import_model.save_log",
                 "bpy.types.mmd_tools_local_OT_import_model.save_log",
+                "bpy.types.mmd_tools_local_OT_import_vmd.save_log",
+                "bpy.types.mmd_tools_local_OT_import_vmd.save_log",
             ),
             (),
         ),
@@ -1537,16 +1890,52 @@ translations_tuple = (
         ("zh_HANS", "仅导出可见的网格", (False, ())),
     ),
     (
+        ("Operator", "Export Translation CSV"),
+        (("bpy.types.mmd_tools_local_OT_export_translation_csv",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Export CSV for external translation."),
+        (("bpy.types.mmd_tools_local_OT_export_translation_csv",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Path to save the translation CSV"),
+        (("bpy.types.mmd_tools_local_OT_export_translation_csv.filepath",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
         ("Operator", "Export VMD File (.vmd)"),
         (("bpy.types.mmd_tools_local_OT_export_vmd",), ()),
         ("ja_JP", "", (False, ())),
         ("zh_HANS", "导出 VMD 文件 (.vmd)", (False, ())),
     ),
     (
-        ("*", "Export motion data of active object to a VMD file (.vmd)"),
+        (
+            "*",
+            "Export motion data of active object to a VMD file (.vmd)\nBehavior varies depending on the active object:\n- Active object is the root (cross under the model): exports both armature and morph animations\n- Active object is the model: exports only morph animation\n- Active object is the armature: exports only armature animation",
+        ),
         (("bpy.types.mmd_tools_local_OT_export_vmd",), ()),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", "将活动物体的运动数据导出至 VMD 文件 (.vmd)", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Preserve Animation Curves"),
+        (("bpy.types.mmd_tools_local_OT_export_vmd.preserve_curves",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "保持动画曲线", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "Add additional keyframes to accurately preserve animation curves. Blender's bezier handles are more flexible than the VMD format. Complex handle settings will be lost during export unless additional keyframes are added to approximate the original curves.",
+        ),
+        (("bpy.types.mmd_tools_local_OT_export_vmd.preserve_curves",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "Scaling factor for exporting the motion"),
@@ -1600,10 +1989,13 @@ translations_tuple = (
         ("zh_HANS", "导出 VPD 文件 (.vpd)", (False, ())),
     ),
     (
-        ("*", "Export active rig's Action Pose to VPD file(s) (.vpd)"),
+        (
+            "*",
+            "Export active rig's Action Pose to VPD file(s) (.vpd)\nBehavior varies depending on the active object:\n- Active object is the root (cross under the model): exports both armature pose and morphs\n- Active object is the model: exports only morphs\n- Active object is the armature: exports only armature pose",
+        ),
         (("bpy.types.mmd_tools_local_OT_export_vpd",), ()),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", "导出活动骨架的动作姿态至 VPD 文件 (.vpd)", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "Pose Type"),
@@ -1676,6 +2068,18 @@ translations_tuple = (
         ),
     ),
     (
+        ("Operator", "Fix Bone Issues"),
+        (("bpy.types.mmd_tools_local_OT_fix_bone_issues",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "修复骨骼问题", (False, ())),
+    ),
+    (
+        ("*", "Fix bone name encoding issues automatically"),
+        (("bpy.types.mmd_tools_local_OT_fix_bone_issues",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
         ("Operator", "Realign Bone IDs"),
         (("bpy.types.mmd_tools_local_OT_fix_bone_order",), ()),
         ("ja_JP", "", (False, ())),
@@ -1684,11 +2088,35 @@ translations_tuple = (
     (
         (
             "*",
-            "Realign bone IDs to be sequential without gaps and apply additional transforms",
+            "Realign bone IDs to be sequential without gaps. Sorted primarily by hierarchy depth (ensuring parents have lower IDs than children), then by bone_id (valid ones prioritized), then by bone name. Apply additional transforms afterward (Assembly -> Bone button).",
         ),
         (("bpy.types.mmd_tools_local_OT_fix_bone_order",), ()),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", "将骨骼 ID 重新对其为连续的序列并应用额外的变换", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("Operator", "Fix Morph Issues"),
+        (("bpy.types.mmd_tools_local_OT_fix_morph_issues",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "修复变形问题", (False, ())),
+    ),
+    (
+        ("*", "Fix morph name issues automatically"),
+        (("bpy.types.mmd_tools_local_OT_fix_morph_issues",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("Operator", "Fix Texture Issues"),
+        (("bpy.types.mmd_tools_local_OT_fix_texture_issues",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "修复贴图问题", (False, ())),
+    ),
+    (
+        ("*", "Fix texture name and path issues automatically"),
+        (("bpy.types.mmd_tools_local_OT_fix_texture_issues",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("Operator", "Flip Pose"),
@@ -1724,6 +2152,21 @@ translations_tuple = (
         ("zh_HANS", "导入模型文件 (.pmd, .pmx)", (False, ())),
     ),
     (
+        ("*", "Add Rigid Body World"),
+        (("bpy.types.mmd_tools_local_OT_import_model.add_rigid_body_world",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "更新刚体世界", (True, ())),
+    ),
+    (
+        (
+            "*",
+            "Automatically add Rigid Body World to the scene when importing physics.",
+        ),
+        (("bpy.types.mmd_tools_local_OT_import_model.add_rigid_body_world",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
         ("*", "Apply Bone Fixed Axis"),
         (("bpy.types.mmd_tools_local_OT_import_model.apply_bone_fixed_axis",), ()),
         ("ja_JP", "ボーン修正回転軸を適用", (False, ())),
@@ -1734,6 +2177,18 @@ translations_tuple = (
         (("bpy.types.mmd_tools_local_OT_import_model.apply_bone_fixed_axis",), ()),
         ("ja_JP", "", (False, ())),
         ("zh_HANS", "应用骨骼的固定坐标轴，使其适合被 Blender 处理", (False, ())),
+    ),
+    (
+        ("*", "Bone Display Mode"),
+        (("bpy.types.mmd_tools_local_OT_import_model.bone_disp_mode",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "骨骼显示样式", (False, ())),
+    ),
+    (
+        ("*", "Change how bones look in viewport."),
+        (("bpy.types.mmd_tools_local_OT_import_model.bone_disp_mode",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "Clean Model"),
@@ -1777,14 +2232,23 @@ translations_tuple = (
         ("zh_HANS", "使用选中的词典将骨骼名从日语翻译为英语", (False, ())),
     ),
     (
+        (
+            "*",
+            "Automatically fix bone order after import. This ensures bones are ordered correctly for MMD compatibility.",
+        ),
+        (("bpy.types.mmd_tools_local_OT_import_model.fix_bone_order",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
         ("*", "Fix IK Links"),
-        (("bpy.types.mmd_tools_local_OT_import_model.fix_IK_links",), ()),
+        (("bpy.types.mmd_tools_local_OT_import_model.fix_ik_links",), ()),
         ("ja_JP", "IKリンクを修正", (False, ())),
         ("zh_HANS", "修复IK关联", (False, ())),
     ),
     (
         ("*", "Fix IK links to be blender suitable"),
-        (("bpy.types.mmd_tools_local_OT_import_model.fix_IK_links",), ()),
+        (("bpy.types.mmd_tools_local_OT_import_model.fix_ik_links",), ()),
         ("ja_JP", "", (False, ())),
         ("zh_HANS", "修复逆向运动学关联，使其适合被 Blender 处理", (False, ())),
     ),
@@ -1795,16 +2259,34 @@ translations_tuple = (
         ("zh_HANS", "逆向运动学循环系数", (False, ())),
     ),
     (
+        ("*", "Import Vertex Colors"),
+        (("bpy.types.mmd_tools_local_OT_import_model.import_adduv2_as_vertex_colors",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "导入顶点色", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "Import ADD UV2 data as vertex colors. When enabled, the UV2 layer will still be created.",
+        ),
+        (("bpy.types.mmd_tools_local_OT_import_model.import_adduv2_as_vertex_colors",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
         ("*", "Remove Doubles"),
         (("bpy.types.mmd_tools_local_OT_import_model.remove_doubles",), ()),
         ("ja_JP", "", (False, ())),
         ("zh_HANS", "去重", (False, ())),
     ),
     (
-        ("*", "Merge duplicated vertices and faces"),
+        (
+            "*",
+            "Merge duplicated vertices and faces.\nWarning: This will perform global vertex merging instead of per-material vertex merging which may break mesh geometry, material boundaries, and distort the UV map. Use with caution.",
+        ),
         (("bpy.types.mmd_tools_local_OT_import_model.remove_doubles",), ()),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", "合并重复的顶点和面", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "Rename Bones - L / R Suffix"),
@@ -1820,7 +2302,10 @@ translations_tuple = (
         ("zh_HANS", "将骨骼重命名 - L / R后缀", (False, ())),
     ),
     (
-        ("*", "Use Blender naming conventions for Left / Right paired bones"),
+        (
+            "*",
+            "Use Blender naming conventions for Left / Right paired bones. Required for features like mirror editing and pose mirroring to function properly.",
+        ),
         (
             (
                 "bpy.types.mmd_tools_local_OT_import_model.rename_bones",
@@ -1830,7 +2315,7 @@ translations_tuple = (
             (),
         ),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", "为左右成对的骨骼应用 Blender 命名约定", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "Scaling factor for importing the model"),
@@ -1954,16 +2439,58 @@ translations_tuple = (
         ("zh_HANS", "不使用点. 例如，重命名骨骼时使用 _R 而非 .R", (False, ())),
     ),
     (
+        ("Operator", "Import Translation CSV"),
+        (("bpy.types.mmd_tools_local_OT_import_translation_csv",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Import translated CSV."),
+        (("bpy.types.mmd_tools_local_OT_import_translation_csv",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Path to import the translation CSV"),
+        (("bpy.types.mmd_tools_local_OT_import_translation_csv.filepath",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Only Update English Name"),
+        (
+            ("bpy.types.mmd_tools_local_OT_import_translation_csv.only_update_english_name",),
+            (),
+        ),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "(Enabled by default) Only update English name (name_e). otherwise, update all names when different",
+        ),
+        (
+            ("bpy.types.mmd_tools_local_OT_import_translation_csv.only_update_english_name",),
+            (),
+        ),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
         ("Operator", "Import VMD File (.vmd)"),
         (("bpy.types.mmd_tools_local_OT_import_vmd",), ()),
         ("ja_JP", "", (False, ())),
         ("zh_HANS", "导入 VMD 文件 (.vmd)", (False, ())),
     ),
     (
-        ("*", "Import a VMD file to selected objects (.vmd)"),
+        (
+            "*",
+            "Import a VMD file to selected objects (.vmd)\nBehavior varies depending on the selected object:\n- Select the root (cross under the model): imports both armature and morph animations\n- Select the model: imports only morph animation\n- Select the armature: imports only armature animation",
+        ),
         (("bpy.types.mmd_tools_local_OT_import_vmd",), ()),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", "向选中物体导入 VMD 文件 (.vmd)", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "Bone Mapper"),
@@ -2032,10 +2559,52 @@ translations_tuple = (
         ("zh_HANS", "重命名动作数据中的骨骼，使其适于被 Blender 处理", (False, ())),
     ),
     (
-        ("*", "How many frames added before motion starting"),
+        (
+            "*",
+            "Create a new action when importing VMD, otherwise add keyframes to existing actions if available. Note: This option is ignored when 'Use NLA' is enabled.",
+        ),
+        (("bpy.types.mmd_tools_local_OT_import_vmd.create_new_action",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Detect Camera Cut"),
+        (("bpy.types.mmd_tools_local_OT_import_vmd.detect_camera_changes",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "检测镜头切换", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "When the interval between camera keyframes is 1 frame, change the interpolation to CONSTANT. This is useful when making a 60fps video, as it helps prevent unwanted smoothing between rapid camera cuts.",
+        ),
+        (("bpy.types.mmd_tools_local_OT_import_vmd.detect_camera_changes",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Detect Light Cut"),
+        (("bpy.types.mmd_tools_local_OT_import_vmd.detect_lamp_changes",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "检测灯光切换", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "When the interval between light keyframes is 1 frame, change the interpolation to CONSTANT. This is useful when making a 60fps video, as it helps prevent unwanted smoothing during sudden lighting changes.",
+        ),
+        (("bpy.types.mmd_tools_local_OT_import_vmd.detect_lamp_changes",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "Number of frames to add before the motion starts (only applies if current frame is 0 or 1)",
+        ),
         (("bpy.types.mmd_tools_local_OT_import_vmd.margin",), ()),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", "动作开始前的帧数", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "Scaling factor for importing the motion"),
@@ -2056,18 +2625,6 @@ translations_tuple = (
         ("zh_HANS", "更新帧范围与帧率 (30 FPS)", (False, ())),
     ),
     (
-        ("*", "Use NLA"),
-        (("bpy.types.mmd_tools_local_OT_import_vmd.use_NLA",), ()),
-        ("ja_JP", "NLAを使用", (False, ())),
-        ("zh_HANS", "使用NLA", (False, ())),
-    ),
-    (
-        ("*", "Import the motion as NLA strips"),
-        (("bpy.types.mmd_tools_local_OT_import_vmd.use_NLA",), ()),
-        ("ja_JP", "", (False, ())),
-        ("zh_HANS", "将动作导入为非线性动作片段", (False, ())),
-    ),
-    (
         ("*", "Mirror Motion"),
         (("bpy.types.mmd_tools_local_OT_import_vmd.use_mirror",), ()),
         ("ja_JP", "モーションをミラー", (False, ())),
@@ -2078,6 +2635,18 @@ translations_tuple = (
         (("bpy.types.mmd_tools_local_OT_import_vmd.use_mirror",), ()),
         ("ja_JP", "", (False, ())),
         ("zh_HANS", "导入动作时使用X轴镜像", (False, ())),
+    ),
+    (
+        ("*", "Use NLA"),
+        (("bpy.types.mmd_tools_local_OT_import_vmd.use_nla",), ()),
+        ("ja_JP", "NLAを使用", (False, ())),
+        ("zh_HANS", "使用NLA", (False, ())),
+    ),
+    (
+        ("*", "Import the motion as NLA strips"),
+        (("bpy.types.mmd_tools_local_OT_import_vmd.use_nla",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "将动作导入为非线性动作片段", (False, ())),
     ),
     (
         (
@@ -2099,10 +2668,13 @@ translations_tuple = (
         ("zh_HANS", "导入 VPD 文件 (.vpd)", (False, ())),
     ),
     (
-        ("*", "Import VPD file(s) to selected rig's Action Pose (.vpd)"),
+        (
+            "*",
+            "Import VPD file(s) to selected rig's Action Pose (.vpd)\nBehavior varies depending on the selected object:\n- Select the root (cross under the model): applies both armature pose and morphs\n- Select the model: applies only morphs\n- Select the armature: applies only armature pose",
+        ),
         (("bpy.types.mmd_tools_local_OT_import_vpd",), ()),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", "向选中骨架的动作姿态导入 VPD 文件 (.vpd)", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "Rename the bone of pose data to be blender suitable"),
@@ -2300,13 +2872,13 @@ translations_tuple = (
     (
         ("*", "Target Value"),
         (("bpy.types.mmd_tools_local_OT_material_morph_offset_init.target_value",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "ターゲット値", (False, ())),
         ("zh_HANS", "目标值", (False, ())),
     ),
     (
         ("*", "Target value"),
         (("bpy.types.mmd_tools_local_OT_material_morph_offset_init.target_value",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "ターゲット値", (False, ())),
         ("zh_HANS", "目标值", (False, ())),
     ),
     (
@@ -2358,10 +2930,34 @@ translations_tuple = (
         ("zh_HANS", "移除活动材质的主纹理", (False, ())),
     ),
     (
+        ("Operator", "Merge Materials"),
+        (("bpy.types.mmd_tools_local_OT_merge_materials",), ()),
+        ("ja_JP", "マテリアルを統合", (False, ())),
+        ("zh_HANS", "合併材质", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "Merge materials with the same texture in selected objects. Only merges materials with exactly one texture node. Materials with no texture or with multiple textures are not merged. Please convert to Blender materials first.",
+        ),
+        (("bpy.types.mmd_tools_local_OT_merge_materials",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
         ("Operator", "Model Join by Bones"),
         (("bpy.types.mmd_tools_local_OT_model_join_by_bones",), ()),
         ("ja_JP", "モデルをボーンで統合", (False, ())),
         ("zh_HANS", "用骨骼合并模型", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "Join multiple MMD models into one.\n\nWARNING: To align models before joining, only adjust the root (cross under the model) transformation. Do not move armatures, meshes, rigid bodies, or joints directly as they will not move together.\n\nIMPORTANT: Don't use any of the 'Assembly' functions before using this function. This function requires the models to be in a clean state.",
+        ),
+        (("bpy.types.mmd_tools_local_OT_model_join_by_bones",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "Join Type"),
@@ -2374,6 +2970,15 @@ translations_tuple = (
         (("bpy.types.mmd_tools_local_OT_model_separate_by_bones",), ()),
         ("ja_JP", "モデルをボーンで分離", (False, ())),
         ("zh_HANS", "用骨骼分离模型", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "Separate MMD model into multiple models based on selected bones.\n\nWARNING: This operation will split meshes, armatures, rigid bodies and joints. To move models before separating, only adjust the root (cross under the model) transformation. Do not move armatures, meshes, rigid bodies, or joints directly before separating as they will not move together.\n\nIMPORTANT: Don't use any of the 'Assembly' functions before using this function. This function requires the model to be in a clean state.",
+        ),
+        (("bpy.types.mmd_tools_local_OT_model_separate_by_bones",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "Boundary Joint Owner"),
@@ -2457,10 +3062,13 @@ translations_tuple = (
         ("zh_HANS", "移动变形", (False, ())),
     ),
     (
-        ("*", "Move active morph item up/down in the list"),
+        (
+            "*",
+            "Move active morph item up/down in the list. This will not affect the morph order in exported PMX files (use Display Panel order instead).",
+        ),
         (("bpy.types.mmd_tools_local_OT_morph_move",), ()),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", "在列表中上移或下移活动的变形", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("Operator", "Add Morph Offset"),
@@ -2617,7 +3225,7 @@ translations_tuple = (
         (
             (
                 "bpy.types.mmd_tools_local_OT_ptcache_rigid_body_delete_bake",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/scene_setup.py:76",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/scene_setup.py:75",
             ),
             (),
         ),
@@ -2629,7 +3237,7 @@ translations_tuple = (
         (
             (
                 "bpy.types.mmd_tools_local_OT_recalculate_bone_roll",
-                "extensions/user_default/mmd_tools_local/panels/prop_object.py:35",
+                "extensions/blender_org/mmd_tools_local/panels/prop_object.py:35",
             ),
             (),
         ),
@@ -2840,7 +3448,7 @@ translations_tuple = (
     (
         ("Operator", "Select Rigid Body"),
         (("bpy.types.mmd_tools_local_OT_rigid_body_select",), ()),
-        ("ja_JP", "MMDリジッドボディ選択", (True, ())),
+        ("ja_JP", "MMD剛体選択", (True, ())),
         ("zh_HANS", "选择刚体", (False, ())),
     ),
     (
@@ -3036,10 +3644,25 @@ translations_tuple = (
         ("zh_HANS", "在骨架中选中与此偏移相关的骨骼", (False, ())),
     ),
     (
-        ("Operator", "Separate By Materials"),
+        ("Operator", "Sep by Mat(High Risk)"),
+        (
+            (
+                "bpy.types.mmd_tools_local_OT_separate_by_materials",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:139",
+            ),
+            (),
+        ),
+        ("ja_JP", "マテリアルで分離(高リスク)", (False, ())),
+        ("zh_HANS", "按材质分开(高风险)", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "Separate by Materials (High Risk)\nSeparate the mesh into multiple objects based on materials.\nHIGH RISK & BUGGY: This operation is not reversible and may cause various issues. It splits adjacent geometry by material, and merging later will not reconnect shared edges.\nKnown issues include potential mesh corruption, UV mapping problems, and other unpredictable behaviors. Use with extreme caution and backup your work first.",
+        ),
         (("bpy.types.mmd_tools_local_OT_separate_by_materials",), ()),
-        ("ja_JP", "マテリアルで分解", (True, ())),
-        ("zh_HANS", "按材质分离", (False, ())),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "Clean Shape Keys"),
@@ -3226,6 +3849,42 @@ translations_tuple = (
         ("zh_HANS", "添加或删除变形英文名的前缀", (False, ())),
     ),
     (
+        ("Operator", "Validate Bone Limits"),
+        (("bpy.types.mmd_tools_local_OT_validate_bone_limits",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Check for bone name encoding issues"),
+        (("bpy.types.mmd_tools_local_OT_validate_bone_limits",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("Operator", "Validate Morphs"),
+        (("bpy.types.mmd_tools_local_OT_validate_morphs",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Check for morph name issues and duplicates"),
+        (("bpy.types.mmd_tools_local_OT_validate_morphs",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("Operator", "Validate Textures"),
+        (("bpy.types.mmd_tools_local_OT_validate_textures",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Check for texture path and name issues"),
+        (("bpy.types.mmd_tools_local_OT_validate_textures",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
         ("Operator", "View Bone Morph"),
         (("bpy.types.mmd_tools_local_OT_view_bone_morph",), ()),
         ("ja_JP", "", (False, ())),
@@ -3252,26 +3911,26 @@ translations_tuple = (
     (
         ("*", "MMD Bone Tools"),
         (("bpy.types.BONE_PT_mmd_tools_local_bone",), ()),
-        ("ja_JP", "MMDボーンツール", (True, ())),
-        ("zh_HANS", "MMD Tools", (True, ())),
+        ("ja_JP", "MMDボーンツール", (False, ())),
+        ("zh_HANS", "MMD 骨骼工具", (False, ())),
     ),
     (
         ("*", "MMD Joint"),
         (("bpy.types.JOINT_PT_mmd_tools_local_bone",), ()),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", "", (False, ())),
+        ("zh_HANS", "MMD 关节", (False, ())),
     ),
     (
         ("*", "MMD Material"),
         (("bpy.types.MATERIAL_PT_mmd_tools_local_material",), ()),
-        ("ja_JP", "マテリアル:", (True, ())),
-        ("zh_HANS", "材质:", (True, ())),
+        ("ja_JP", "MMD マテリアル", (False, ())),
+        ("zh_HANS", "MMD 材质", (False, ())),
     ),
     (
         ("*", "MMD Texture"),
         (("bpy.types.MATERIAL_PT_mmd_tools_local_texture",), ()),
-        ("ja_JP", "", (False, ())),
-        ("zh_HANS", "", (False, ())),
+        ("ja_JP", "MMD テクスチャ", (False, ())),
+        ("zh_HANS", "MMD 纹理", (False, ())),
     ),
     (
         ("*", "MMD"),
@@ -3282,6 +3941,7 @@ translations_tuple = (
                 "bpy.types.OBJECT_PT_mmd_tools_local_joint_list",
                 "bpy.types.OBJECT_PT_mmd_tools_local_material_sorter",
                 "bpy.types.OBJECT_PT_mmd_tools_local_meshes_sorter",
+                "bpy.types.OBJECT_PT_mmd_tools_local_model_debug",
                 "bpy.types.OBJECT_PT_mmd_tools_local_model_production",
                 "bpy.types.OBJECT_PT_mmd_tools_local_model_setup",
                 "bpy.types.OBJECT_PT_mmd_tools_local_morph_tools",
@@ -3303,7 +3963,7 @@ translations_tuple = (
         ("*", "MMD Camera Tools"),
         (("bpy.types.OBJECT_PT_mmd_tools_local_camera",), ()),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", "", (False, ())),
+        ("zh_HANS", "MMD 相机工具", (False, ())),
     ),
     (
         ("*", "Display Panel"),
@@ -3320,8 +3980,8 @@ translations_tuple = (
     (
         ("*", "MMD Light Tools"),
         (("bpy.types.OBJECT_PT_mmd_tools_local_light",), ()),
-        ("ja_JP", "MMDボーンツール", (True, ())),
-        ("zh_HANS", "MMD Tools", (True, ())),
+        ("ja_JP", "MMDライトツール", (False, ())),
+        ("zh_HANS", "MMD灯光工具", (False, ())),
     ),
     (
         ("*", "Material Sorter"),
@@ -3334,6 +3994,12 @@ translations_tuple = (
         (("bpy.types.OBJECT_PT_mmd_tools_local_meshes_sorter",), ()),
         ("ja_JP", "メッシュ順序", (False, ())),
         ("zh_HANS", "网格顺序", (False, ())),
+    ),
+    (
+        ("*", "Model Debug"),
+        (("bpy.types.OBJECT_PT_mmd_tools_local_model_debug",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "模型调试", (False, ())),
     ),
     (
         ("*", "Model Production"),
@@ -3356,7 +4022,7 @@ translations_tuple = (
     (
         ("*", "Rigid Bodies"),
         (("bpy.types.OBJECT_PT_mmd_tools_local_rigidbody_list",), ()),
-        ("ja_JP", "リジッドボディ", (False, ())),
+        ("ja_JP", "剛体", (False, ())),
         ("zh_HANS", "刚体", (False, ())),
     ),
     (
@@ -3368,8 +4034,8 @@ translations_tuple = (
     (
         ("*", "MMD Rigid Body"),
         (("bpy.types.RIGID_PT_mmd_tools_local_bone",), ()),
-        ("ja_JP", "MMDリジッドボディ選択", (True, ())),
-        ("zh_HANS", "刚体", (True, ())),
+        ("ja_JP", "MMD剛体", (False, ())),
+        ("zh_HANS", "MMD刚体", (False, ())),
     ),
     (
         ("*", "MMD IK Toggle"),
@@ -3382,6 +4048,15 @@ translations_tuple = (
         (("bpy.types.PoseBone.mmd_ik_toggle",), ()),
         ("ja_JP", "", (False, ())),
         ("zh_HANS", "在启用或关闭逆向运动学的情况下导入或导出动画", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "Pose bone selection state (compatibility layer for Blender 4.x, forwards to bone.select)",
+        ),
+        (("bpy.types.PoseBone.select",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "Bone Morph"),
@@ -3696,18 +4371,6 @@ translations_tuple = (
         ("zh_HANS", "显示连接 (PMX displayConnection) 使用的骨骼 ID", (False, ())),
     ),
     (
-        ("*", "Display Connection Offset"),
-        (("bpy.types.MMDBone.display_connection_offset",), ()),
-        ("ja_JP", "", (False, ())),
-        ("zh_HANS", "显示联系偏移", (False, ())),
-    ),
-    (
-        ("*", "Offset vector for display connection"),
-        (("bpy.types.MMDBone.display_connection_offset",), ()),
-        ("ja_JP", "", (False, ())),
-        ("zh_HANS", "显示连接使用的偏移向量", (False, ())),
-    ),
-    (
         ("*", "Display Connection Type"),
         (("bpy.types.MMDBone.display_connection_type",), ()),
         ("ja_JP", "", (False, ())),
@@ -3730,12 +4393,6 @@ translations_tuple = (
         (("bpy.types.MMDBone.display_connection_type:'OFFSET'",), ()),
         ("ja_JP", "", (False, ())),
         ("zh_HANS", "连接至加偏移的位置", (False, ())),
-    ),
-    (
-        ("*", "No connection"),
-        (("bpy.types.MMDBone.display_connection_type:'NONE'",), ()),
-        ("ja_JP", "", (False, ())),
-        ("zh_HANS", "没有连接", (False, ())),
     ),
     (
         ("*", "Fixed Axis"),
@@ -3885,7 +4542,7 @@ translations_tuple = (
         ("*", "PMX 表示項目(表示枠内の1項目)"),
         (("bpy.types.MMDDisplayItem",), ()),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", "PMX 表示（表示枠中的一项）", (False, ())),
+        ("zh_HANS", "PMX 表示(表示枠中的一项)", (False, ())),
     ),
     (
         ("*", "Select item type"),
@@ -4152,7 +4809,7 @@ translations_tuple = (
         (
             (
                 "bpy.types.MMDMaterial.toon_texture",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:147",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:148",
             ),
             (),
         ),
@@ -4287,6 +4944,30 @@ translations_tuple = (
         (("bpy.types.MMDRoot.show_armature",), ()),
         ("ja_JP", "", (False, ())),
         ("zh_HANS", "显示MMD模型的骨架物体", (False, ())),
+    ),
+    (
+        ("*", "English name"),
+        (("bpy.types.MMDRoot.show_english_name",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "英文名", (False, ())),
+    ),
+    (
+        ("*", "Toggle English name display"),
+        (("bpy.types.MMDRoot.show_english_name",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Japanese name"),
+        (("bpy.types.MMDRoot.show_japanese_name",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "日文名", (False, ())),
+    ),
+    (
+        ("*", "Toggle Japanese name display"),
+        (("bpy.types.MMDRoot.show_japanese_name",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "Show Joints"),
@@ -4563,7 +5244,7 @@ translations_tuple = (
     (
         ("*", "Operation Target"),
         (("bpy.types.MMDTranslation.batch_operation_target",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "操作対象", (False, ())),
         ("zh_HANS", "操作目标", (False, ())),
     ),
     (
@@ -4587,13 +5268,13 @@ translations_tuple = (
     (
         ("*", "English Blank"),
         (("bpy.types.MMDTranslation.filter_english_blank",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "英語空白", (False, ())),
         ("zh_HANS", "英语为空", (False, ())),
     ),
     (
         ("*", "Japanese Blank"),
         (("bpy.types.MMDTranslation.filter_japanese_blank",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "日本語空白", (False, ())),
         ("zh_HANS", "日语为空", (False, ())),
     ),
     (
@@ -4665,7 +5346,7 @@ translations_tuple = (
     (
         ("*", "Related Mesh Data"),
         (("bpy.types.MaterialMorphData.related_mesh_data",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "関連メッシュデータ", (False, ())),
         ("zh_HANS", "相关网格数据", (False, ())),
     ),
     (
@@ -4677,7 +5358,7 @@ translations_tuple = (
     (
         ("*", "Sphere texture factor"),
         (("bpy.types.MaterialMorphData.sphere_texture_factor",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "スフィアテクスチャ係数", (False, ())),
         ("zh_HANS", "球体纹理的系数", (False, ())),
     ),
     (
@@ -4701,13 +5382,13 @@ translations_tuple = (
     (
         ("*", "Toon texture factor"),
         (("bpy.types.MaterialMorphData.toon_texture_factor",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "トゥーンテクスチャ係数", (False, ())),
         ("zh_HANS", "卡通纹理的系数", (False, ())),
     ),
     (
         ("*", "UV Morph"),
         (("bpy.types.UVMorph",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "UVモーフ", (False, ())),
         ("zh_HANS", "UV形变", (False, ())),
     ),
     (
@@ -4737,19 +5418,19 @@ translations_tuple = (
     (
         ("*", "UV Index"),
         (("bpy.types.UVMorph.uv_index",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "UVインデックス", (False, ())),
         ("zh_HANS", "UV索引", (False, ())),
     ),
     (
         ("*", "UV index (UV, UV1 ~ UV4)"),
         (("bpy.types.UVMorph.uv_index",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "UV インデックス (UV, UV1 ~ UV4)", (False, ())),
         ("zh_HANS", "UV索引 (UV, UV1 ~ UV4)", (False, ())),
     ),
     (
         ("*", "Vertex Group Scale"),
         (("bpy.types.UVMorph.vertex_group_scale",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "頂点グループスケール", (False, ())),
         ("zh_HANS", "顶点组比例", (False, ())),
     ),
     (
@@ -4761,31 +5442,31 @@ translations_tuple = (
     (
         ("*", "UV Morph Offset"),
         (("bpy.types.UVMorphOffset",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "UVモーフオフセット", (False, ())),
         ("zh_HANS", "UV 形变偏移", (False, ())),
     ),
     (
         ("*", "Vertex Index"),
         (("bpy.types.UVMorphOffset.index",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "頂点インデックス", (False, ())),
         ("zh_HANS", "顶点索引", (False, ())),
     ),
     (
         ("*", "UV offset"),
         (("bpy.types.UVMorphOffset.offset",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "UVオフセット", (False, ())),
         ("zh_HANS", "UV偏移", (False, ())),
     ),
     (
         ("*", "Vertex Morph"),
         (("bpy.types.VertexMorph",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "頂点モーフ", (False, ())),
         ("zh_HANS", "顶点形变", (False, ())),
     ),
     (
         ("*", "MMD Name"),
         (("bpy.types.MMD_ROOT_UL_display_items.mmd_name",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "MMD名称", (False, ())),
         ("zh_HANS", "MMD名称", (False, ())),
     ),
     (
@@ -4797,19 +5478,19 @@ translations_tuple = (
     (
         ("*", "JP"),
         (("bpy.types.MMD_ROOT_UL_display_items.mmd_name:'name_j'",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "日本語", (False, ())),
         ("zh_HANS", "日文", (False, ())),
     ),
     (
         ("*", "EN"),
         (("bpy.types.MMD_ROOT_UL_display_items.mmd_name:'name_e'",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "英語", (False, ())),
         ("zh_HANS", "英文", (False, ())),
     ),
     (
         ("*", "Morph Filter"),
         (("bpy.types.MMD_ROOT_UL_display_items.morph_filter",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "モーフフィルタ", (False, ())),
         ("zh_HANS", "形变筛选", (False, ())),
     ),
     (
@@ -4827,7 +5508,7 @@ translations_tuple = (
             ),
             (),
         ),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "モデルフィルタ", (False, ())),
         ("zh_HANS", "模型筛选", (False, ())),
     ),
     (
@@ -4875,346 +5556,522 @@ translations_tuple = (
             ),
             (),
         ),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "可視のみ", (False, ())),
         ("zh_HANS", "仅显示可见项目", (False, ())),
     ),
     (
         ("Operator", "MikuMikuDance Model (.pmd, .pmx)"),
-        (("extensions/user_default/mmd_tools_local/menus.py:22",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/menus.py:18",), ()),
+        ("ja_JP", "MikuMikuDance モデル (.pmd, .pmx)", (False, ())),
         ("zh_HANS", "MikuMikuDance 模型 (.pmd, .pmx)", (False, ())),
     ),
     (
         ("Operator", "MikuMikuDance Motion (.vmd)"),
         (
             (
-                "extensions/user_default/mmd_tools_local/menus.py:23",
-                "extensions/user_default/mmd_tools_local/menus.py:45",
+                "extensions/blender_org/mmd_tools_local/menus.py:19",
+                "extensions/blender_org/mmd_tools_local/menus.py:41",
             ),
             (),
         ),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "MikuMikuDance モーション (.vmd)", (False, ())),
         ("zh_HANS", "MikuMikuDance 动作 (.vmd)", (False, ())),
     ),
     (
         ("Operator", "Vocaloid Pose Data (.vpd)"),
         (
             (
-                "extensions/user_default/mmd_tools_local/menus.py:24",
-                "extensions/user_default/mmd_tools_local/menus.py:46",
+                "extensions/blender_org/mmd_tools_local/menus.py:20",
+                "extensions/blender_org/mmd_tools_local/menus.py:42",
             ),
             (),
         ),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "Vocaloid ポーズデータ (.vpd)", (False, ())),
         ("zh_HANS", "Vocaloid 姿态数据 (.vpd)", (False, ())),
     ),
     (
         ("Operator", "MikuMikuDance Model (.pmx)"),
-        (("extensions/user_default/mmd_tools_local/menus.py:44",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/menus.py:40",), ()),
+        ("ja_JP", "MikuMikuDance モデル (.pmx)", (False, ())),
         ("zh_HANS", "MikuMikuDance 模型 (.pmx)", (False, ())),
     ),
     (
         ("Operator", "Create MMD Model"),
-        (("extensions/user_default/mmd_tools_local/menus.py:66",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/menus.py:62",), ()),
+        ("ja_JP", "MMDモデルを作成", (False, ())),
         ("zh_HANS", "创建 MMD 模型", (False, ())),
     ),
     (
         ("Operator", "MMD Flip Pose"),
-        (("extensions/user_default/mmd_tools_local/menus.py:129",), ()),
+        (("extensions/blender_org/mmd_tools_local/menus.py:125",), ()),
         ("ja_JP", "MMDポーズを反転", (False, ())),
         ("zh_HANS", "MMD翻转姿态", (False, ())),
     ),
     (
         ("Operator", "Select MMD Rigid Body"),
-        (("extensions/user_default/mmd_tools_local/menus.py:109",), ()),
-        ("ja_JP", "MMDリジッドボディ選択", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/menus.py:105",), ()),
+        ("ja_JP", "MMD剛体選択", (False, ())),
         ("zh_HANS", "选择MMD刚体", (False, ())),
     ),
     (
-        ("*", 'Imported MMD model from "%s"'),
-        (("extensions/user_default/mmd_tools_local/operators/fileio.py:210",), ()),
-        ("ja_JP", "", (False, ())),
-        ("zh_HANS", '已从"%s"导入 MMD 模型', (False, ())),
+        ("*", 'Imported MMD model from ""'),
+        (("extensions/blender_org/mmd_tools_local/operators/fileio.py:396",), ()),
+        ("ja_JP", 'MMDモデルを "%s" からインポートしました', (True, ())),
+        ("zh_HANS", '已从"%s"导入 MMD 模型', (True, ())),
     ),
     (
-        ("*", '[Skipped] The armature object of MMD model "%s" can\'t be found'),
-        (("extensions/user_default/mmd_tools_local/operators/fileio.py:552",), ()),
+        ("*", '[Skipped] The armature object of MMD model "" can\'t be found'),
+        (("extensions/blender_org/mmd_tools_local/operators/fileio.py:963",), ()),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", '[跳过] 找不到 MMD 模型"%s"的骨架数据', (False, ())),
+        ("zh_HANS", '[跳过] 找不到 MMD 模型"%s"的骨架数据', (True, ())),
     ),
     (
-        ("*", 'Exported MMD model "%s" to "%s"'),
-        (("extensions/user_default/mmd_tools_local/operators/fileio.py:580",), ()),
+        ("*", 'Exported MMD model "" to ""'),
+        (("extensions/blender_org/mmd_tools_local/operators/fileio.py:995",), ()),
+        ("ja_JP", 'MMDモデル "%s" を "%s" にエクスポートしました', (True, ())),
+        ("zh_HANS", '已导出 MMD 模型"%s"至"%s"', (True, ())),
+    ),
+    (
+        ("*", "Object '': Merged  materials"),
+        (("extensions/blender_org/mmd_tools_local/operators/material.py:180",), ()),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", '已导出 MMD 模型"%s"至"%s"', (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Object '' has no materials"),
+        (("extensions/blender_org/mmd_tools_local/operators/material.py:120",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "No materials to merge in object ''"),
+        (("extensions/blender_org/mmd_tools_local/operators/material.py:146",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Same Texture '': Merged materials [] into ''"),
+        (("extensions/blender_org/mmd_tools_local/operators/material.py:184",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "Select a MMD model"),
         (
             (
-                "extensions/user_default/mmd_tools_local/operators/material.py:262",
-                "extensions/user_default/mmd_tools_local/operators/misc.py:195",
-                "extensions/user_default/mmd_tools_local/operators/misc.py:241",
+                "extensions/blender_org/mmd_tools_local/operators/material.py:353",
+                "extensions/blender_org/mmd_tools_local/operators/misc.py:205",
+                "extensions/blender_org/mmd_tools_local/operators/misc.py:251",
             ),
             (),
         ),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "MMDモデルを選択する", (False, ())),
         ("zh_HANS", "选择 MMD 模型", (False, ())),
     ),
     (
         ("*", "Created %d toon edge(s)"),
-        (("extensions/user_default/mmd_tools_local/operators/material.py:273",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/operators/material.py:364",), ()),
+        ("ja_JP", "トゥーンエッジを %d 作成しました ", (False, ())),
         ("zh_HANS", "已创建 %d 条卡通边缘", (False, ())),
     ),
     (
         ("*", " * Failed to change to Cycles render engine."),
-        (("extensions/user_default/mmd_tools_local/operators/material.py:48",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/operators/material.py:49",), ()),
+        ("ja_JP", "Cycles に変更できませんでした", (False, ())),
         ("zh_HANS", " * 未能改变至 Cycles 渲染引擎", (False, ())),
     ),
     (
         ("*", "Materials not found"),
         (
             (
-                "extensions/user_default/mmd_tools_local/operators/material.py:209",
-                "extensions/user_default/mmd_tools_local/operators/material.py:235",
+                "extensions/blender_org/mmd_tools_local/operators/material.py:301",
+                "extensions/blender_org/mmd_tools_local/operators/material.py:326",
             ),
             (),
         ),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "マテリアルが見つかりません", (False, ())),
         ("zh_HANS", "找不到材质", (False, ())),
     ),
     (
         ("*", "This operation will break existing f-curve/action."),
-        (("extensions/user_default/mmd_tools_local/operators/misc.py:301",), ()),
+        (("extensions/blender_org/mmd_tools_local/operators/misc.py:312",), ()),
         ("ja_JP", "この操作は既存のFカーブ/アクションを破壊します", (False, ())),
         ("zh_HANS", "这一操作将破坏现有的函数曲线/动作", (False, ())),
     ),
     (
         ("*", "Click [OK] to run the operation."),
-        (("extensions/user_default/mmd_tools_local/operators/misc.py:302",), ()),
+        (("extensions/blender_org/mmd_tools_local/operators/misc.py:313",), ()),
         ("ja_JP", "[OK]をクリックして操作を実行してください", (False, ())),
         ("zh_HANS", "点击[确定]来运行操作", (False, ())),
     ),
     (
-        ("*", 'Can not move object "%s"'),
-        (("extensions/user_default/mmd_tools_local/operators/misc.py:67",), ()),
-        ("ja_JP", "", (False, ())),
-        ("zh_HANS", '无法移动物体"%s"', (False, ())),
+        ("*", 'Can not move object ""'),
+        (("extensions/blender_org/mmd_tools_local/operators/misc.py:66",), ()),
+        ("ja_JP", 'オブジェクト "%s" を移動できません', (True, ())),
+        ("zh_HANS", '无法移动物体"%s"', (True, ())),
     ),
     (
         ("*", "The model does not have any meshes"),
-        (("extensions/user_default/mmd_tools_local/operators/misc.py:205",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/operators/misc.py:215",), ()),
+        ("ja_JP", "このモデルにはメッシュがありません", (False, ())),
         ("zh_HANS", "该模型不具有任何网格", (False, ())),
     ),
     (
         ("*", "Model Armature not found"),
-        (("extensions/user_default/mmd_tools_local/operators/misc.py:246",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/operators/misc.py:256",), ()),
+        ("ja_JP", "モデルのアーマチュアが見つかりません", (False, ())),
         ("zh_HANS", "找不到模型的骨架", (False, ())),
     ),
     (
         ("*", "Active object is not an armature object"),
         (
             (
-                "extensions/user_default/mmd_tools_local/operators/model.py:152",
-                "extensions/user_default/mmd_tools_local/operators/model.py:183",
+                "extensions/blender_org/mmd_tools_local/operators/model.py:151",
+                "extensions/blender_org/mmd_tools_local/operators/model.py:182",
+            ),
+            (),
+        ),
+        ("ja_JP", "選択中のオブジェクトはアーマチュアではありません", (False, ())),
+        ("zh_HANS", "选中的物体不是骨架物体", (False, ())),
+    ),
+    (
+        ("*", "No MMD model selected"),
+        (
+            (
+                "extensions/blender_org/mmd_tools_local/operators/model_validation.py:70",
+                "extensions/blender_org/mmd_tools_local/operators/model_validation.py:125",
+                "extensions/blender_org/mmd_tools_local/operators/model_validation.py:170",
+                "extensions/blender_org/mmd_tools_local/operators/model_validation.py:258",
+                "extensions/blender_org/mmd_tools_local/operators/model_validation.py:367",
+                "extensions/blender_org/mmd_tools_local/operators/model_validation.py:462",
             ),
             (),
         ),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", "选中的物体不是骨架物体", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "No armature found in model"),
+        (
+            (
+                "extensions/blender_org/mmd_tools_local/operators/model_validation.py:76",
+                "extensions/blender_org/mmd_tools_local/operators/model_validation.py:264",
+            ),
+            (),
+        ),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "Successfully converted vertex morphs in group to vertex morph '' and added to facial display frame",
+        ),
+        (("extensions/blender_org/mmd_tools_local/operators/morph.py:1095",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "You need to choose a Related Mesh first"),
         (
             (
-                "extensions/user_default/mmd_tools_local/operators/morph.py:298",
-                "extensions/user_default/mmd_tools_local/operators/morph.py:362",
+                "extensions/blender_org/mmd_tools_local/operators/morph.py:295",
+                "extensions/blender_org/mmd_tools_local/operators/morph.py:359",
             ),
             (),
         ),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "まず関連するメッシュを選んでください", (False, ())),
         ("zh_HANS", "请首先选择关联的网格", (False, ())),
     ),
     (
         ("*", "The model mesh can't be found"),
         (
             (
-                "extensions/user_default/mmd_tools_local/operators/morph.py:302",
-                "extensions/user_default/mmd_tools_local/operators/morph.py:366",
+                "extensions/blender_org/mmd_tools_local/operators/morph.py:299",
+                "extensions/blender_org/mmd_tools_local/operators/morph.py:363",
             ),
             (),
         ),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "モデルのメッシュが見つかりません", (False, ())),
         ("zh_HANS", "找不到模型的网格", (False, ())),
     ),
     (
-        ("*", 'Material "%s" not found'),
-        (("extensions/user_default/mmd_tools_local/operators/morph.py:371",), ()),
-        ("ja_JP", "", (False, ())),
-        ("zh_HANS", '找不到材质"%s"', (False, ())),
+        ("*", 'Material "" not found'),
+        (("extensions/blender_org/mmd_tools_local/operators/morph.py:368",), ()),
+        ("ja_JP", 'マテリアル "%s" が見つかりません', (True, ())),
+        ("zh_HANS", '找不到材质"%s"', (True, ())),
     ),
     (
-        ("*", 'Temporary material "%s" is in use'),
-        (("extensions/user_default/mmd_tools_local/operators/morph.py:376",), ()),
+        ("*", 'Temporary material "" is in use'),
+        (("extensions/blender_org/mmd_tools_local/operators/morph.py:373",), ()),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", '临时材质"%s"已占用', (False, ())),
+        ("zh_HANS", '临时材质"%s"已占用', (True, ())),
+    ),
+    (
+        ("*", "No active bone morph"),
+        (("extensions/blender_org/mmd_tools_local/operators/morph.py:797",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "Successfully converted bone morph '' to vertex morph ''. Created shape keys: ",
+        ),
+        (("extensions/blender_org/mmd_tools_local/operators/morph.py:940",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "No active group morph"),
+        (("extensions/blender_org/mmd_tools_local/operators/morph.py:976",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "The group morph does not contain any vertex morphs to convert"),
+        (("extensions/blender_org/mmd_tools_local/operators/morph.py:987",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "Material not found"),
-        (("extensions/user_default/mmd_tools_local/operators/morph.py:308",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/operators/morph.py:305",), ()),
+        ("ja_JP", "マテリアルが見つかりません", (False, ())),
         ("zh_HANS", "找不到材质", (False, ())),
     ),
     (
         ("*", "Please select a mesh object"),
-        (("extensions/user_default/mmd_tools_local/operators/morph.py:586",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/operators/morph.py:583",), ()),
+        ("ja_JP", "メッシュオブジェクトを選択してください", (False, ())),
         ("zh_HANS", "选择网格物体", (False, ())),
     ),
     (
         ("*", "Invalid uv index: %d"),
-        (("extensions/user_default/mmd_tools_local/operators/morph.py:600",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/operators/morph.py:597",), ()),
+        ("ja_JP", "無効なUVインデックス: %d", (False, ())),
         ("zh_HANS", "无效 UV 索引: %d", (False, ())),
     ),
     (
         ("*", "Failed to create a temporary uv layer"),
-        (("extensions/user_default/mmd_tools_local/operators/morph.py:610",), ()),
+        (("extensions/blender_org/mmd_tools_local/operators/morph.py:607",), ()),
         ("ja_JP", "", (False, ())),
         ("zh_HANS", "无法创建临时 UV 层", (False, ())),
     ),
     (
-        ("*", ' * UV map "%s" not found'),
-        (("extensions/user_default/mmd_tools_local/operators/morph.py:734",), ()),
+        ("*", ' * UV map "" not found'),
+        (("extensions/blender_org/mmd_tools_local/operators/morph.py:731",), ()),
+        ("ja_JP", ' * UVマップ "%s" が見つかりません', (True, ())),
+        ("zh_HANS", ' * 找不到 UV 贴图 "%s"', (True, ())),
+    ),
+    (
+        ("*", "Failed to create morph slider system"),
+        (("extensions/blender_org/mmd_tools_local/operators/morph.py:823",), ()),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", ' * 找不到 UV 贴图 "%s"', (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Bone morph '' not found in morph sliders"),
+        (("extensions/blender_org/mmd_tools_local/operators/morph.py:832",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Created shape key '' on mesh ''"),
+        (("extensions/blender_org/mmd_tools_local/operators/morph.py:887",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Error during conversion: "),
+        (("extensions/blender_org/mmd_tools_local/operators/morph.py:943",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "An unexpected error happened"),
-        (("extensions/user_default/mmd_tools_local/operators/morph.py:329",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/operators/morph.py:326",), ()),
+        ("ja_JP", "予期しないエラーが発生しました", (False, ())),
         ("zh_HANS", "发生了非预期的错误", (False, ())),
     ),
     (
-        ("*", "Base material for %s was not found"),
-        (("extensions/user_default/mmd_tools_local/operators/morph.py:435",), ()),
+        ("*", "No armature modifier found on mesh ''"),
+        (("extensions/blender_org/mmd_tools_local/operators/morph.py:874",), ()),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", "找不到 %s 的基础材质", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Base material for  was not found"),
+        (("extensions/blender_org/mmd_tools_local/operators/morph.py:432",), ()),
+        ("ja_JP", "%s のベースマテリアルが見つかりませんでした", (True, ())),
+        ("zh_HANS", "找不到 %s 的基础材质", (True, ())),
     ),
     (
         ("*", "The model root can't be found"),
-        (("extensions/user_default/mmd_tools_local/operators/rigid_body.py:55",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/operators/rigid_body.py:54",), ()),
+        ("ja_JP", "モデルのルートが見つかりません", (False, ())),
         ("zh_HANS", "找不到模型的根部", (False, ())),
     ),
     (
         ("*", "Please select two or more mmd rigid objects"),
-        (("extensions/user_default/mmd_tools_local/operators/rigid_body.py:451",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/operators/rigid_body.py:450",), ()),
+        ("ja_JP", "2つ以上のMMD剛体を選択してください", (False, ())),
         ("zh_HANS", "选择两个或更多 MMD 刚体", (False, ())),
     ),
     (
         ("*", "Binded  of  selected mesh(es)"),
-        (("extensions/user_default/mmd_tools_local/operators/sdef.py:88",), ()),
+        (("extensions/blender_org/mmd_tools_local/operators/sdef.py:87",), ()),
         ("ja_JP", "", (False, ())),
         ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "Filter"),
-        (("extensions/user_default/mmd_tools_local/operators/translations.py:238",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/operators/translations.py:273",), ()),
+        ("ja_JP", "フィルタ", (False, ())),
         ("zh_HANS", "筛选", (False, ())),
     ),
     (
         ("*", "is Blank:"),
-        (("extensions/user_default/mmd_tools_local/operators/translations.py:242",), ()),
+        (("extensions/blender_org/mmd_tools_local/operators/translations.py:277",), ()),
         ("ja_JP", "空白のみ:", (False, ())),
         ("zh_HANS", "是空白:", (False, ())),
     ),
     (
         ("*", "Japanese"),
-        (("extensions/user_default/mmd_tools_local/operators/translations.py:244",), ()),
+        (("extensions/blender_org/mmd_tools_local/operators/translations.py:280",), ()),
         ("ja_JP", "日本語", (False, ())),
         ("zh_HANS", "日文", (False, ())),
     ),
     (
         ("*", "English"),
-        (("extensions/user_default/mmd_tools_local/operators/translations.py:245",), ()),
+        (("extensions/blender_org/mmd_tools_local/operators/translations.py:282",), ()),
         ("ja_JP", "英語", (False, ())),
         ("zh_HANS", "英文", (False, ())),
     ),
     (
         ("*", "Select the target column for Batch Operations:"),
-        (("extensions/user_default/mmd_tools_local/operators/translations.py:255",), ()),
+        (("extensions/blender_org/mmd_tools_local/operators/translations.py:310",), ()),
         ("ja_JP", "一括操作の対象列を選択:", (False, ())),
         ("zh_HANS", "选择批量操作的目标列:", (False, ())),
     ),
     (
         ("*", "Batch Operation:"),
-        (("extensions/user_default/mmd_tools_local/operators/translations.py:276",), ()),
+        (("extensions/blender_org/mmd_tools_local/operators/translations.py:334",), ()),
         ("ja_JP", "一括操作:", (False, ())),
         ("zh_HANS", "批量操作:", (False, ())),
     ),
     (
         ("*", "Preset"),
-        (("extensions/user_default/mmd_tools_local/operators/translations.py:281",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/operators/translations.py:342",), ()),
+        ("ja_JP", "プリセット", (False, ())),
         ("zh_HANS", "预设", (False, ())),
     ),
     (
         ("Operator", "Execute"),
-        (("extensions/user_default/mmd_tools_local/operators/translations.py:282",), ()),
+        (("extensions/blender_org/mmd_tools_local/operators/translations.py:345",), ()),
         ("ja_JP", "実行", (False, ())),
         ("zh_HANS", "执行", (False, ())),
     ),
     (
         ("*", "Dictionaries:"),
-        (("extensions/user_default/mmd_tools_local/operators/translations.py:286",), ()),
+        (("extensions/blender_org/mmd_tools_local/operators/translations.py:349",), ()),
         ("ja_JP", "辞書:", (False, ())),
         ("zh_HANS", "词典:", (False, ())),
     ),
     (
         ("*", "to_english"),
-        (("extensions/user_default/mmd_tools_local/operators/translations.py:288",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/operators/translations.py:351",), ()),
+        ("ja_JP", "to_english", (False, ())),
         ("zh_HANS", "to_english", (False, ())),
     ),
     (
         ("*", "replace"),
-        (("extensions/user_default/mmd_tools_local/operators/translations.py:293",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/operators/translations.py:355",), ()),
+        ("ja_JP", "置換", (False, ())),
         ("zh_HANS", "替换", (False, ())),
+    ),
+    (
+        ("*", "CSV:"),
+        (("extensions/blender_org/mmd_tools_local/operators/translations.py:360",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("Operator", "Import CSV"),
+        (("extensions/blender_org/mmd_tools_local/operators/translations.py:362",), ()),
+        ("ja_JP", "インポート CSV", (False, ())),
+        ("zh_HANS", "导入 CSV", (False, ())),
+    ),
+    (
+        ("Operator", "Export CSV"),
+        (("extensions/blender_org/mmd_tools_local/operators/translations.py:363",), ()),
+        ("ja_JP", "エクスポート CSV", (False, ())),
+        ("zh_HANS", "导出 CSV", (False, ())),
+    ),
+    (
+        ("*", "Exported to "),
+        (("extensions/blender_org/mmd_tools_local/operators/translations.py:456",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "Failed to translate %d names, see '%s' in text editor"),
         (
             (
-                "extensions/user_default/mmd_tools_local/operators/translations.py:104",
-                "extensions/user_default/mmd_tools_local/operators/translations.py:331",
+                "extensions/blender_org/mmd_tools_local/operators/translations.py:112",
+                "extensions/blender_org/mmd_tools_local/operators/translations.py:403",
+            ),
+            (),
+        ),
+        (
+            "ja_JP",
+            "名称 %d の翻訳に失敗しました, テキストエディタで '%s' を確認してください",
+            (False, ()),
+        ),
+        ("zh_HANS", "未能翻译 %d 个名称，参见文本编辑器中的 '%s'", (False, ())),
+    ),
+    (
+        ("*", "Root object not found"),
+        (
+            (
+                "extensions/blender_org/mmd_tools_local/operators/translations.py:438",
+                "extensions/blender_org/mmd_tools_local/operators/translations.py:486",
             ),
             (),
         ),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", "未能翻译 %d 个名称，参见文本编辑器中的 '%s'", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
-        ("*", "Failed to load dictionary: %s"),
-        (("extensions/user_default/mmd_tools_local/operators/translations.py:87",), ()),
+        ("*", "Failed to load dictionary: "),
+        (("extensions/blender_org/mmd_tools_local/operators/translations.py:93",), ()),
+        ("ja_JP", "辞書の読み込みに失敗しました: %s", (True, ())),
+        ("zh_HANS", "未能加载词典: %s", (True, ())),
+    ),
+    (
+        ("*", "Failed to write CSV: "),
+        (("extensions/blender_org/mmd_tools_local/operators/translations.py:453",), ()),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", "未能加载词典: %s", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Failed to read CSV: "),
+        (("extensions/blender_org/mmd_tools_local/operators/translations.py:554",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Missing required headers in CSV: , "),
+        (("extensions/blender_org/mmd_tools_local/operators/translations.py:501",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "Information:"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/prop_bone.py:46",
-                "extensions/user_default/mmd_tools_local/panels/prop_material.py:31",
+                "extensions/blender_org/mmd_tools_local/panels/prop_bone.py:45",
+                "extensions/blender_org/mmd_tools_local/panels/prop_material.py:30",
             ),
             (),
         ),
@@ -5225,8 +6082,8 @@ translations_tuple = (
         ("*", "ID"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/prop_bone.py:49",
-                "extensions/user_default/mmd_tools_local/panels/prop_material.py:34",
+                "extensions/blender_org/mmd_tools_local/panels/prop_bone.py:48",
+                "extensions/blender_org/mmd_tools_local/panels/prop_material.py:33",
             ),
             (),
         ),
@@ -5235,37 +6092,37 @@ translations_tuple = (
     ),
     (
         ("*", "Rotate +"),
-        (("extensions/user_default/mmd_tools_local/panels/prop_bone.py:87",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/prop_bone.py:86",), ()),
         ("ja_JP", "回転 +", (False, ())),
         ("zh_HANS", "旋转 +", (False, ())),
     ),
     (
         ("*", "Move +"),
-        (("extensions/user_default/mmd_tools_local/panels/prop_bone.py:88",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/prop_bone.py:87",), ()),
         ("ja_JP", "移動 +", (False, ())),
         ("zh_HANS", "移动 +", (False, ())),
     ),
     (
         ("*", "Influence"),
-        (("extensions/user_default/mmd_tools_local/panels/prop_bone.py:92",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/panels/prop_bone.py:91",), ()),
+        ("ja_JP", "影響", (False, ())),
         ("zh_HANS", "影响", (False, ())),
     ),
     (
-        ("*", "Display Connection (Bone Target):"),
-        (("extensions/user_default/mmd_tools_local/panels/prop_bone.py:95",), ()),
+        ("*", "Display Connection (Bone Tail Location):"),
+        (("extensions/blender_org/mmd_tools_local/panels/prop_bone.py:94",), ()),
         ("ja_JP", "", (False, ())),
         ("zh_HANS", "骨骼末端指向:", (False, ())),
     ),
     (
         ("*", "Type"),
-        (("extensions/user_default/mmd_tools_local/panels/prop_bone.py:96",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/prop_bone.py:95",), ()),
         ("ja_JP", "タイプ", (True, ())),
         ("zh_HANS", "类型", (False, ())),
     ),
     (
         ("*", "MMD Shadow Bone!"),
-        (("extensions/user_default/mmd_tools_local/panels/prop_bone.py:38",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/prop_bone.py:37",), ()),
         ("ja_JP", "", (False, ())),
         ("zh_HANS", "MMD Shadow Bone!", (False, ())),
     ),
@@ -5273,92 +6130,98 @@ translations_tuple = (
         ("Operator", "Load"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/prop_bone.py:68",
-                "extensions/user_default/mmd_tools_local/panels/prop_bone.py:78",
+                "extensions/blender_org/mmd_tools_local/panels/prop_bone.py:67",
+                "extensions/blender_org/mmd_tools_local/panels/prop_bone.py:77",
             ),
             (),
         ),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "読み込む", (False, ())),
         ("zh_HANS", "加载", (False, ())),
     ),
     (
         ("Operator", "Apply"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/prop_bone.py:69",
-                "extensions/user_default/mmd_tools_local/panels/prop_bone.py:79",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:183",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:210",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:153",
+                "extensions/blender_org/mmd_tools_local/panels/prop_bone.py:68",
+                "extensions/blender_org/mmd_tools_local/panels/prop_bone.py:78",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:187",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:217",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:157",
             ),
             (),
         ),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "適用", (False, ())),
         ("zh_HANS", "应用", (False, ())),
     ),
     (
         ("*", "Target Bone"),
-        (("extensions/user_default/mmd_tools_local/panels/prop_bone.py:99",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/panels/prop_bone.py:98",), ()),
+        ("ja_JP", "対象ボーン", (False, ())),
         ("zh_HANS", "目标骨骼", (False, ())),
     ),
     (
-        ("*", "IK Angle {%s}"),
-        (("extensions/user_default/mmd_tools_local/panels/prop_bone.py:27",), ()),
+        ("*", "Offset is auto-calculated during export."),
+        (("extensions/blender_org/mmd_tools_local/panels/prop_bone.py:100",), ()),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", "IK角度 {%s}", (False, ())),
+        ("zh_HANS", "偏移量会在导出模型时自动计算。", (False, ())),
     ),
     (
-        ("*", "IK Angle (%s)"),
-        (("extensions/user_default/mmd_tools_local/panels/prop_bone.py:29",), ()),
-        ("ja_JP", "", (False, ())),
-        ("zh_HANS", "IK角度 (%s)", (False, ())),
+        ("*", "IK Angle {}"),
+        (("extensions/blender_org/mmd_tools_local/panels/prop_bone.py:26",), ()),
+        ("ja_JP", "IK角度 {%s}", (True, ())),
+        ("zh_HANS", "IK角度 {%s}", (True, ())),
+    ),
+    (
+        ("*", "IK Angle ()"),
+        (("extensions/blender_org/mmd_tools_local/panels/prop_bone.py:28",), ()),
+        ("ja_JP", "IK角度 (%s)", (True, ())),
+        ("zh_HANS", "IK角度 (%s)", (True, ())),
     ),
     (
         ("*", "Distance"),
-        (("extensions/user_default/mmd_tools_local/panels/prop_camera.py:36",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/panels/prop_camera.py:35",), ()),
+        ("ja_JP", "距離", (False, ())),
         ("zh_HANS", "距离", (False, ())),
     ),
     (
         ("Operator", "Convert"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/prop_camera.py:44",
-                "extensions/user_default/mmd_tools_local/panels/prop_lamp.py:36",
+                "extensions/blender_org/mmd_tools_local/panels/prop_camera.py:43",
+                "extensions/blender_org/mmd_tools_local/panels/prop_lamp.py:35",
             ),
             (),
         ),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "変換", (False, ())),
         ("zh_HANS", "转换", (False, ())),
     ),
     (
         ("*", "Light Source"),
-        (("extensions/user_default/mmd_tools_local/panels/prop_lamp.py:34",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/prop_lamp.py:33",), ()),
         ("ja_JP", "光源", (False, ())),
         ("zh_HANS", "光源", (False, ())),
     ),
     (
         ("*", "Color:"),
-        (("extensions/user_default/mmd_tools_local/panels/prop_material.py:41",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/prop_material.py:40",), ()),
         ("ja_JP", "カラー:", (False, ())),
         ("zh_HANS", "颜色:", (False, ())),
     ),
     (
         ("*", "Shadow:"),
-        (("extensions/user_default/mmd_tools_local/panels/prop_material.py:53",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/prop_material.py:52",), ()),
         ("ja_JP", "シャドウ:", (False, ())),
         ("zh_HANS", "阴影:", (False, ())),
     ),
     (
         ("*", "Texture:"),
-        (("extensions/user_default/mmd_tools_local/panels/prop_material.py:91",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/prop_material.py:90",), ()),
         ("ja_JP", "テクスチャ:", (False, ())),
         ("zh_HANS", "纹理:", (False, ())),
     ),
     (
         ("*", "Sphere Texture:"),
-        (("extensions/user_default/mmd_tools_local/panels/prop_material.py:105",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/prop_material.py:104",), ()),
         ("ja_JP", "スフィアテクスチャ:", (False, ())),
         ("zh_HANS", "球体纹理:", (False, ())),
     ),
@@ -5366,44 +6229,44 @@ translations_tuple = (
         ("Operator", "Add"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/prop_material.py:102",
-                "extensions/user_default/mmd_tools_local/panels/prop_material.py:116",
+                "extensions/blender_org/mmd_tools_local/panels/prop_material.py:101",
+                "extensions/blender_org/mmd_tools_local/panels/prop_material.py:115",
             ),
             (),
         ),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "追加", (False, ())),
         ("zh_HANS", "添加", (False, ())),
     ),
     (
         ("Operator", "Remove"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/prop_material.py:99",
-                "extensions/user_default/mmd_tools_local/panels/prop_material.py:113",
+                "extensions/blender_org/mmd_tools_local/panels/prop_material.py:98",
+                "extensions/blender_org/mmd_tools_local/panels/prop_material.py:112",
             ),
             (),
         ),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "削除", (False, ())),
         ("zh_HANS", "移除", (False, ())),
     ),
     (
         ("*", "Collision Group Mask:"),
-        (("extensions/user_default/mmd_tools_local/panels/prop_physics.py:73",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/prop_physics.py:72",), ()),
         ("ja_JP", "コリジョングループマスク:", (False, ())),
         ("zh_HANS", "碰撞组遮罩:", (False, ())),
     ),
     (
         ("*", "Damping"),
-        (("extensions/user_default/mmd_tools_local/panels/prop_physics.py:82",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/panels/prop_physics.py:81",), ()),
+        ("ja_JP", "減衰", (False, ())),
         ("zh_HANS", "阻尼", (False, ())),
     ),
     (
         ("*", "X-Axis:"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/prop_physics.py:118",
-                "extensions/user_default/mmd_tools_local/panels/prop_physics.py:134",
+                "extensions/blender_org/mmd_tools_local/panels/prop_physics.py:117",
+                "extensions/blender_org/mmd_tools_local/panels/prop_physics.py:133",
             ),
             (),
         ),
@@ -5414,8 +6277,8 @@ translations_tuple = (
         ("*", "Y-Axis:"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/prop_physics.py:119",
-                "extensions/user_default/mmd_tools_local/panels/prop_physics.py:135",
+                "extensions/blender_org/mmd_tools_local/panels/prop_physics.py:118",
+                "extensions/blender_org/mmd_tools_local/panels/prop_physics.py:134",
             ),
             (),
         ),
@@ -5426,8 +6289,8 @@ translations_tuple = (
         ("*", "Z-Axis:"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/prop_physics.py:120",
-                "extensions/user_default/mmd_tools_local/panels/prop_physics.py:136",
+                "extensions/blender_org/mmd_tools_local/panels/prop_physics.py:119",
+                "extensions/blender_org/mmd_tools_local/panels/prop_physics.py:135",
             ),
             (),
         ),
@@ -5436,19 +6299,19 @@ translations_tuple = (
     ),
     (
         ("*", "MMD Shading Presets"),
-        (("extensions/user_default/mmd_tools_local/panels/shading.py:23",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/shading.py:22",), ()),
         ("ja_JP", "MMDシェーディングプリセット", (False, ())),
         ("zh_HANS", "MMD着色预设", (False, ())),
     ),
     (
         ("Operator", "GLSL"),
-        (("extensions/user_default/mmd_tools_local/panels/shading.py:25",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/shading.py:24",), ()),
         ("ja_JP", "", (False, ())),
         ("zh_HANS", "GLSL", (False, ())),
     ),
     (
         ("Operator", "Shadeless"),
-        (("extensions/user_default/mmd_tools_local/panels/shading.py:26",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/shading.py:25",), ()),
         ("ja_JP", "影なし", (False, ())),
         ("zh_HANS", "无明暗", (False, ())),
     ),
@@ -5456,67 +6319,118 @@ translations_tuple = (
         ("Operator", "Reset"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/shading.py:28",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:41",
+                "extensions/blender_org/mmd_tools_local/panels/shading.py:27",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:40",
             ),
             (),
         ),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "リセット", (False, ())),
         ("zh_HANS", "重设", (False, ())),
     ),
     (
         ("*", "Migrating from old vertex group ordering to bone_id system"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/bone_order.py:254",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/bone_order.py:276",), ()),
         ("ja_JP", "", (False, ())),
         ("zh_HANS", "从旧的顶点组排序迁移至新的骨骼 ID 系统", (False, ())),
     ),
     (
         ("*", "Successfully migrated  bones from vertex groups to bone_id system"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/bone_order.py:279",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/bone_order.py:301",), ()),
         ("ja_JP", "", (False, ())),
         ("zh_HANS", "成功从旧的顶点组排序迁移至新的骨骼 ID 系统", (False, ())),
+    ),
+    (
+        ("*", "Cleaning invalid bone references..."),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/bone_order.py:315",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("Operator", "Fix Bone Order"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/bone_order.py:518",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/bone_order.py:565",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/bone_order.py:600",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/bone_order.py:647",
             ),
             (),
         ),
-        ("ja_JP", "ボーン順序", (True, ())),
+        ("ja_JP", "ボーン順序を修正", (False, ())),
         ("zh_HANS", "修复骨骼顺序", (False, ())),
     ),
     (
         ("*", "Total Bones: %d"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/bone_order.py:564",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/bone_order.py:564",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/bone_order.py:646",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/bone_order.py:646",
+            ),
+            (),
+        ),
+        ("ja_JP", "ボーン合計", (False, ())),
+        ("zh_HANS", "骨骼数量: %d", (False, ())),
+    ),
+    (
+        (
+            "*",
+            "Bone ID is invalid (-1). Please click 'Fix Bone Order' button first to assign proper bone IDs.",
+        ),
+        (
+            (
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/bone_order.py:33",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/bone_order.py:75",
             ),
             (),
         ),
         ("ja_JP", "", (False, ())),
-        ("zh_HANS", "骨骼数量: %d", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Cleaned  invalid bone reference(s)."),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/bone_order.py:163",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Bone order did not converge after 10 iterations"),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/bone_order.py:199",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "Converting layer collections to MMD collections"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/bone_order.py:229",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/bone_order.py:251",), ()),
         ("ja_JP", "", (False, ())),
         ("zh_HANS", "将分层集合转换为 MMD 集合", (False, ())),
+    ),
+    (
+        ("*", "Operation cancelled: No active MMD model found."),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/bone_order.py:319",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "Successfully cleaned or removed  invalid bone reference(s)."),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/bone_order.py:325",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
+    ),
+    (
+        ("*", "No invalid bone references were found."),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/bone_order.py:327",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "", (False, ())),
     ),
     (
         ("*", "Select a MMD Model"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/bone_order.py:532",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/display_panel.py:23",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/joints.py:21",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/meshes_sorter.py:22",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:24",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:24",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/rigid_bodies.py:21",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/bone_order.py:614",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/display_panel.py:22",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/joints.py:20",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/meshes_sorter.py:21",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:23",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:23",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/rigid_bodies.py:20",
             ),
             (),
         ),
@@ -5525,28 +6439,28 @@ translations_tuple = (
     ),
     (
         ("*", "The armature object of active MMD model can't be found"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/bone_order.py:537",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/bone_order.py:619",), ()),
+        ("ja_JP", "選択中のMMDモデルのアーマチュアが見つかりません", (False, ())),
         ("zh_HANS", "找不到选中MMD模型的骨架", (False, ())),
     ),
     (
         ("Operator", "Select"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/display_panel.py:75",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:195",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/display_panel.py:74",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:202",
             ),
             (),
         ),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "選択", (False, ())),
         ("zh_HANS", "选择", (False, ())),
     ),
     (
         ("Operator", "Bone"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/display_panel.py:73",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:74",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/display_panel.py:72",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:73",
             ),
             (),
         ),
@@ -5557,8 +6471,8 @@ translations_tuple = (
         ("Operator", "Morph"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/display_panel.py:74",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:78",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/display_panel.py:73",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:77",
             ),
             (),
         ),
@@ -5569,11 +6483,11 @@ translations_tuple = (
         ("Operator", "Move To Top"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/display_panel.py:176",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/display_panel.py:188",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/joints.py:70",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:333",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/rigid_bodies.py:82",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/display_panel.py:175",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/display_panel.py:187",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/joints.py:69",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:363",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/rigid_bodies.py:81",
             ),
             (),
         ),
@@ -5584,11 +6498,11 @@ translations_tuple = (
         ("Operator", "Move To Bottom"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/display_panel.py:177",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/display_panel.py:189",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/joints.py:71",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:334",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/rigid_bodies.py:83",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/display_panel.py:176",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/display_panel.py:188",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/joints.py:70",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:364",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/rigid_bodies.py:82",
             ),
             (),
         ),
@@ -5599,8 +6513,8 @@ translations_tuple = (
         ("Operator", "Delete All"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/display_panel.py:186",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:324",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/display_panel.py:185",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:354",
             ),
             (),
         ),
@@ -5611,8 +6525,8 @@ translations_tuple = (
         ("*", "Use the arrows to sort"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/material_sorter.py:49",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/meshes_sorter.py:48",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/material_sorter.py:48",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/meshes_sorter.py:47",
             ),
             (),
         ),
@@ -5622,18 +6536,76 @@ translations_tuple = (
     (
         ("*", "Select a mesh object"),
         (
-            ("extensions/user_default/mmd_tools_local/panels/sidebar/material_sorter.py:20",),
+            ("extensions/blender_org/mmd_tools_local/panels/sidebar/material_sorter.py:19",),
             (),
         ),
         ("ja_JP", "メッシュを選択してください", (False, ())),
         ("zh_HANS", "选择一个网格物体", (False, ())),
     ),
     (
+        ("*", "Model Validation:"),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_debug.py:20",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "模型检测:", (False, ())),
+    ),
+    (
+        ("Operator", "Check Bones"),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_debug.py:29",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "检测骨骼", (False, ())),
+    ),
+    (
+        ("Operator", "Check Morphs"),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_debug.py:30",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "检测变形", (False, ())),
+    ),
+    (
+        ("Operator", "Check Textures"),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_debug.py:31",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "检测贴图", (False, ())),
+    ),
+    (
+        ("*", "Validation Results:"),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_debug.py:35",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "检测结果:", (False, ())),
+    ),
+    (
+        ("*", "Quick Fixes:"),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_debug.py:48",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "快速修复:", (False, ())),
+    ),
+    (
+        ("Operator", "Fix Bones"),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_debug.py:53",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "修复骨骼", (False, ())),
+    ),
+    (
+        ("Operator", "Fix Morphs"),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_debug.py:56",), ()),
+        ("ja_JP", "モーフ", (True, ())),
+        ("zh_HANS", "修复变形", (False, ())),
+    ),
+    (
+        ("Operator", "Fix Textures"),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_debug.py:59",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "修复贴图", (False, ())),
+    ),
+    (
+        ("*", "Run validation to see results"),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_debug.py:44",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "运行测试以查看结果", (False, ())),
+    ),
+    (
         ("Operator", "Create Model"),
         (
-            (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/model_production.py:23",
-            ),
+            ("extensions/blender_org/mmd_tools_local/panels/sidebar/model_production.py:22",),
             (),
         ),
         ("ja_JP", "モデルを作成", (False, ())),
@@ -5642,9 +6614,7 @@ translations_tuple = (
     (
         ("Operator", "Convert Model"),
         (
-            (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/model_production.py:24",
-            ),
+            ("extensions/blender_org/mmd_tools_local/panels/sidebar/model_production.py:23",),
             (),
         ),
         ("ja_JP", "モデルを変換", (False, ())),
@@ -5653,9 +6623,7 @@ translations_tuple = (
     (
         ("Operator", "Attach Meshes"),
         (
-            (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/model_production.py:29",
-            ),
+            ("extensions/blender_org/mmd_tools_local/panels/sidebar/model_production.py:28",),
             (),
         ),
         ("ja_JP", "メッシュを取付", (False, ())),
@@ -5664,31 +6632,25 @@ translations_tuple = (
     (
         ("Operator", "Translate"),
         (
-            (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/model_production.py:32",
-            ),
+            ("extensions/blender_org/mmd_tools_local/panels/sidebar/model_production.py:31",),
             (),
         ),
         ("ja_JP", "翻訳", (False, ())),
         ("zh_HANS", "翻译", (False, ())),
     ),
     (
-        ("*", "Model Surgery:"),
+        ("*", "Model Surgery (Experimental):"),
         (
-            (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/model_production.py:39",
-            ),
+            ("extensions/blender_org/mmd_tools_local/panels/sidebar/model_production.py:38",),
             (),
         ),
-        ("ja_JP", "モデル手術", (False, ())),
-        ("zh_HANS", "模型手术", (False, ())),
+        ("ja_JP", "モデル手術(実験的):", (False, ())),
+        ("zh_HANS", "模型手术(实验性):", (False, ())),
     ),
     (
         ("Operator", "Chop"),
         (
-            (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/model_production.py:45",
-            ),
+            ("extensions/blender_org/mmd_tools_local/panels/sidebar/model_production.py:44",),
             (),
         ),
         ("ja_JP", "切断", (False, ())),
@@ -5697,9 +6659,7 @@ translations_tuple = (
     (
         ("Operator", "Peel"),
         (
-            (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/model_production.py:56",
-            ),
+            ("extensions/blender_org/mmd_tools_local/panels/sidebar/model_production.py:55",),
             (),
         ),
         ("ja_JP", "はがす", (False, ())),
@@ -5709,8 +6669,8 @@ translations_tuple = (
         ("Operator", "Join"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/model_production.py:63",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:139",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/model_production.py:62",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:140",
             ),
             (),
         ),
@@ -5719,109 +6679,103 @@ translations_tuple = (
     ),
     (
         ("*", "Visibility:"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:40",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:39",), ()),
         ("ja_JP", "可視性:", (False, ())),
         ("zh_HANS", "可见性:", (False, ())),
     ),
     (
         ("*", "Mesh"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:46",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:45",), ()),
+        ("ja_JP", "メッシュ", (False, ())),
         ("zh_HANS", "网格", (False, ())),
     ),
     (
         ("*", "Armature"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:47",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:46",), ()),
+        ("ja_JP", "アーマチュア", (False, ())),
         ("zh_HANS", "骨架", (False, ())),
     ),
     (
         ("*", "Temporary Object"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:48",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:47",), ()),
         ("ja_JP", "テンポラリオブジェクト", (False, ())),
         ("zh_HANS", "临时物体", (False, ())),
     ),
     (
         ("*", "Rigid Body"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:50",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:49",), ()),
+        ("ja_JP", "剛体", (False, ())),
         ("zh_HANS", "刚体", (False, ())),
     ),
     (
         ("*", "Assembly:"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:59",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:58",), ()),
         ("ja_JP", "組み立て:", (False, ())),
         ("zh_HANS", "装配:", (False, ())),
     ),
     (
         ("Operator", "All"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:64",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:63",), ()),
+        ("ja_JP", "すべて", (False, ())),
         ("zh_HANS", "全部", (False, ())),
     ),
     (
         ("Operator", "SDEF"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:68",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:67",), ()),
         ("ja_JP", "SDEF", (False, ())),
         ("zh_HANS", "SDEF", (False, ())),
     ),
     (
         ("*", "Property"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:91",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:90",), ()),
+        ("ja_JP", "プロパティ", (False, ())),
         ("zh_HANS", "属性", (False, ())),
     ),
     (
         ("*", "IK Toggle:"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:128",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:129",), ()),
         ("ja_JP", "IK切替え:", (False, ())),
         ("zh_HANS", "IK切换:", (False, ())),
     ),
     (
         ("*", "Mesh:"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:136",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:137",), ()),
         ("ja_JP", "メッシュ:", (False, ())),
         ("zh_HANS", "网格:", (False, ())),
     ),
     (
-        ("Operator", "Separate by Materials"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:138",), ()),
-        ("ja_JP", "マテリアルで分解", (False, ())),
-        ("zh_HANS", "按材质分开", (False, ())),
-    ),
-    (
         ("*", "Material:"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:143",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:144",), ()),
         ("ja_JP", "マテリアル:", (False, ())),
         ("zh_HANS", "材质:", (False, ())),
     ),
     (
         ("*", "Sphere Texture"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:148",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:149",), ()),
         ("ja_JP", "スフィアテクスチャ", (False, ())),
         ("zh_HANS", "球体纹理", (False, ())),
     ),
     (
         ("Operator", "Convert to Blender"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:153",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:154",), ()),
         ("ja_JP", "Blender用に変換", (False, ())),
         ("zh_HANS", "转换给Blender", (False, ())),
     ),
     (
         ("Operator", "Convert to MMD"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:154",), ()),
-        ("ja_JP", "", (False, ())),
-        ("zh_HANS", "转换至 MMD", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:156",), ()),
+        ("ja_JP", "MMD用に変換", (False, ())),
+        ("zh_HANS", "转换给MMD", (False, ())),
     ),
     (
         ("*", "Misc:"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:158",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:160",), ()),
         ("ja_JP", "その他:", (False, ())),
         ("zh_HANS", "杂项:", (False, ())),
     ),
     (
         ("Operator", "(Experimental) Global Translation"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:160",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:162",), ()),
         ("ja_JP", "(実験的) 全体翻訳", (False, ())),
         ("zh_HANS", "(实验性) 全局翻译", (False, ())),
     ),
@@ -5829,8 +6783,8 @@ translations_tuple = (
         ("Operator", "Physics"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:86",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:88",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:85",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:87",
             ),
             (),
         ),
@@ -5839,7 +6793,7 @@ translations_tuple = (
     ),
     (
         ("Operator", "Edge Preview"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/model_setup.py:150",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/model_setup.py:151",), ()),
         ("ja_JP", "輪郭プレビュー", (False, ())),
         ("zh_HANS", "边缘预览", (False, ())),
     ),
@@ -5847,8 +6801,8 @@ translations_tuple = (
         ("*", "Material Offsets (%d)"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:103",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:103",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:107",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:107",
             ),
             (),
         ),
@@ -5859,34 +6813,34 @@ translations_tuple = (
         ("Operator", "View"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:182",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:206",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:186",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:213",
             ),
             (),
         ),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "表示", (False, ())),
         ("zh_HANS", "显示", (False, ())),
     ),
     (
         ("Operator", "Clear"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:184",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:207",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:154",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:128",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:188",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:214",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:158",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:132",
             ),
             (),
         ),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "クリア", (False, ())),
         ("zh_HANS", "清除", (False, ())),
     ),
     (
         ("*", "Bone Offsets (%d)"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:186",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:186",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:193",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:193",
             ),
             (),
         ),
@@ -5897,20 +6851,20 @@ translations_tuple = (
         ("Operator", "Edit"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:209",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:196",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:216",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:203",
             ),
             (),
         ),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "編集", (False, ())),
         ("zh_HANS", "编辑", (False, ())),
     ),
     (
         ("*", "Group Offsets (%d)"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:226",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:226",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:236",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:236",
             ),
             (),
         ),
@@ -5919,46 +6873,46 @@ translations_tuple = (
     ),
     (
         ("*", "Morph Settings"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:61",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:65",), ()),
         ("ja_JP", "モーフ設定", (False, ())),
         ("zh_HANS", "变形设置", (False, ())),
     ),
     (
         ("*", "Not found"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:98",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:102",), ()),
+        ("ja_JP", "見つかりませんでした", (False, ())),
         ("zh_HANS", "未找到", (False, ())),
     ),
     (
         ("*", "This is not a valid base material"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:116",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:120",), ()),
+        ("ja_JP", "これは有効なベースマテリアルではありません", (False, ())),
         ("zh_HANS", "不是有效的基础材质", (False, ())),
     ),
     (
         ("*", "Armature not found"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:178",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:182",), ()),
+        ("ja_JP", "アーマチュアが見つかりません", (False, ())),
         ("zh_HANS", "找不到骨架", (False, ())),
     ),
     (
         ("Operator", "Update"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:197",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:204",), ()),
         ("ja_JP", "更新", (False, ())),
         ("zh_HANS", "更新", (False, ())),
     ),
     (
         ("*", "Scale"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:218",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:225",), ()),
+        ("ja_JP", "スケール", (False, ())),
         ("zh_HANS", "缩放", (False, ())),
     ),
     (
         ("*", "UV Offsets (%d)"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:220",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:220",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:227",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:227",
             ),
             (),
         ),
@@ -5967,37 +6921,37 @@ translations_tuple = (
     ),
     (
         ("Operator", "Bind morphs to .placeholder"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:326",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:356",), ()),
         ("ja_JP", "モーフを.placeholderへバインド", (False, ())),
         ("zh_HANS", "将变形绑定到.placeholder", (False, ())),
     ),
     (
         ("Operator", "Unbind morphs from .placeholder"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:327",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:357",), ()),
         ("ja_JP", "モーフを.placeholderからバインド解除", (False, ())),
         ("zh_HANS", "解绑变形与.placeholder", (False, ())),
     ),
     (
         ("*", "This offset affects all materials"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/morph_tools.py:125",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/morph_tools.py:129",), ()),
+        ("ja_JP", "このオフセットは全てのマテリアルに影響します", (False, ())),
         ("zh_HANS", "该偏移影响所有材质", (False, ())),
     ),
     (
         ("Operator", "Select Similar..."),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/rigid_bodies.py:67",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/rigid_bodies.py:66",), ()),
         ("ja_JP", "類似を選択...", (False, ())),
         ("zh_HANS", "选择类似...", (False, ())),
     ),
     (
         ("*", "Select Similar"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/rigid_bodies.py:80",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/rigid_bodies.py:79",), ()),
+        ("ja_JP", "類似選択", (False, ())),
         ("zh_HANS", "选择类似的刚体", (False, ())),
     ),
     (
         ("*", "Model:"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/scene_setup.py:29",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/scene_setup.py:28",), ()),
         ("ja_JP", "モデル:", (False, ())),
         ("zh_HANS", "模型:", (False, ())),
     ),
@@ -6005,9 +6959,9 @@ translations_tuple = (
         ("Operator", "Import"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/scene_setup.py:30",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/scene_setup.py:35",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/scene_setup.py:40",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/scene_setup.py:29",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/scene_setup.py:34",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/scene_setup.py:39",
             ),
             (),
         ),
@@ -6018,9 +6972,9 @@ translations_tuple = (
         ("Operator", "Export"),
         (
             (
-                "extensions/user_default/mmd_tools_local/panels/sidebar/scene_setup.py:31",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/scene_setup.py:36",
-                "extensions/user_default/mmd_tools_local/panels/sidebar/scene_setup.py:41",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/scene_setup.py:30",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/scene_setup.py:35",
+                "extensions/blender_org/mmd_tools_local/panels/sidebar/scene_setup.py:40",
             ),
             (),
         ),
@@ -6029,80 +6983,122 @@ translations_tuple = (
     ),
     (
         ("*", "Motion:"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/scene_setup.py:34",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/scene_setup.py:33",), ()),
         ("ja_JP", "モーション:", (False, ())),
         ("zh_HANS", "运动:", (False, ())),
     ),
     (
         ("*", "Pose:"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/scene_setup.py:39",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/scene_setup.py:38",), ()),
         ("ja_JP", "ポーズ:", (False, ())),
         ("zh_HANS", "姿态:", (False, ())),
     ),
     (
         ("*", "Timeline:"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/scene_setup.py:46",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/scene_setup.py:45",), ()),
         ("ja_JP", "タイムライン:", (False, ())),
         ("zh_HANS", "时间线:", (False, ())),
     ),
     (
         ("*", "Start"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/scene_setup.py:49",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/scene_setup.py:48",), ()),
+        ("ja_JP", "開始", (False, ())),
         ("zh_HANS", "开始", (False, ())),
     ),
     (
         ("*", "End"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/scene_setup.py:50",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/scene_setup.py:49",), ()),
+        ("ja_JP", "終了", (False, ())),
         ("zh_HANS", "结束", (False, ())),
     ),
     (
         ("*", "Rigid Body Physics:"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/scene_setup.py:58",), ()),
-        ("ja_JP", "リジッドボディ物理演算:", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/scene_setup.py:57",), ()),
+        ("ja_JP", "剛体物理演算:", (False, ())),
         ("zh_HANS", "刚体物理:", (False, ())),
     ),
     (
         ("Operator", "Update World"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/scene_setup.py:59",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/scene_setup.py:58",), ()),
         ("ja_JP", "ワールドを更新", (False, ())),
         ("zh_HANS", "更新世界", (False, ())),
     ),
     (
         ("Operator", "MMD Tools/Manual"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/scene_setup.py:20",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/scene_setup.py:19",), ()),
         ("ja_JP", "MMD Tools/マニュアル", (False, ())),
         ("zh_HANS", "MMD Tools/使用手册", (False, ())),
     ),
     (
         ("*", "Substeps"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/scene_setup.py:63",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/scene_setup.py:62",), ()),
         ("ja_JP", "サブステップ", (False, ())),
         ("zh_HANS", "子步数", (False, ())),
     ),
     (
         ("*", "Iterations"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/scene_setup.py:64",), ()),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/scene_setup.py:63",), ()),
         ("ja_JP", "反復数", (False, ())),
         ("zh_HANS", "迭代", (False, ())),
     ),
     (
         ("Operator", "Bake"),
-        (("extensions/user_default/mmd_tools_local/panels/sidebar/scene_setup.py:78",), ()),
-        ("ja_JP", "", (False, ())),
+        (("extensions/blender_org/mmd_tools_local/panels/sidebar/scene_setup.py:77",), ()),
+        ("ja_JP", "ベイク", (False, ())),
         ("zh_HANS", "烘焙", (False, ())),
+    ),
+    (
+        ("*", "Default Operator Presets:"),
+        (("extensions/blender_org/mmd_tools_local/preferences.py:136",), ()),
+        ("ja_JP", "", (False, ())),
+        ("zh_HANS", "默认操作项预设:", (False, ())),
+    ),
+    (
+        ("*", "PMX Import"),
+        (("extensions/blender_org/mmd_tools_local/preferences.py:137",), ()),
+        ("ja_JP", "PMX インポート", (False, ())),
+        ("zh_HANS", "PMX 导入", (False, ())),
+    ),
+    (
+        ("*", "PMX Export"),
+        (("extensions/blender_org/mmd_tools_local/preferences.py:138",), ()),
+        ("ja_JP", "PMX エクスポート", (False, ())),
+        ("zh_HANS", "PMX 导出", (False, ())),
+    ),
+    (
+        ("*", "VMD Import"),
+        (("extensions/blender_org/mmd_tools_local/preferences.py:139",), ()),
+        ("ja_JP", "VMD インポート", (False, ())),
+        ("zh_HANS", "VMD 导入", (False, ())),
+    ),
+    (
+        ("*", "VMD Export"),
+        (("extensions/blender_org/mmd_tools_local/preferences.py:140",), ()),
+        ("ja_JP", "VMD エクスポート", (False, ())),
+        ("zh_HANS", "VMD 导出", (False, ())),
+    ),
+    (
+        ("*", "VPD Import"),
+        (("extensions/blender_org/mmd_tools_local/preferences.py:141",), ()),
+        ("ja_JP", "VPD インポート", (False, ())),
+        ("zh_HANS", "VPD 导入", (False, ())),
+    ),
+    (
+        ("*", "VPD Export"),
+        (("extensions/blender_org/mmd_tools_local/preferences.py:142",), ()),
+        ("ja_JP", "VPD エクスポート", (False, ())),
+        ("zh_HANS", "VPD 导出", (False, ())),
     ),
     (
         ("*", "MMD Tools"),
         (("Add-on MMD Tools info: name",), ()),
-        ("ja_JP", "MMDボーンツール", (True, ())),
+        ("ja_JP", "MMD Tools", (False, ())),
         ("zh_HANS", "MMD Tools", (False, ())),
     ),
     (
         ("*", "Utility tools for MMD model editing"),
         (("Add-on MMD Tools info: description",), ()),
-        ("ja_JP", "", (False, ())),
+        ("ja_JP", "MMDモデル編集用のツール", (False, ())),
         ("zh_HANS", "MMD 模型编辑实用工具", (False, ())),
     ),
 )
@@ -6133,5 +7129,5 @@ if __name__ == "__main__":
 
     for lang, cnt in untranslated_count.items():
         print(
-            f"Of {total_count} entries, {cnt} have not been translated for language {lang}"
+            f"Of {total_count} entries, {cnt} have not been translated for language {lang}",
         )

--- a/extern_tools/mmd_tools_local/operators/camera.py
+++ b/extern_tools/mmd_tools_local/operators/camera.py
@@ -46,7 +46,7 @@ class ConvertToMMDCamera(Operator):
     @classmethod
     def poll(cls, context):
         obj = context.active_object
-        return obj and obj.type == "CAMERA"
+        return obj is not None and obj.type == "CAMERA"
 
     def invoke(self, context, event):
         vm = context.window_manager

--- a/extern_tools/mmd_tools_local/operators/display_item.py
+++ b/extern_tools/mmd_tools_local/operators/display_item.py
@@ -89,20 +89,19 @@ class AddDisplayItem(Operator):
             morph = ItemOp.get_by_index(getattr(mmd_root, mmd_root.active_morph_type), mmd_root.active_morph)
             morph_name = morph.name if morph else "Morph Item"
             self._add_item(frame, "MORPH", morph_name, mmd_root.active_morph_type)
+        elif context.active_bone:
+            bone_names = [context.active_bone.name]
+            if context.selected_bones:
+                bone_names += [b.name for b in context.selected_bones]
+            if context.selected_editable_bones:
+                bone_names += [b.name for b in context.selected_editable_bones]
+            if context.selected_pose_bones:
+                bone_names += [b.name for b in context.selected_pose_bones]
+            bone_names = sorted(set(bone_names))
+            for bone_name in bone_names:
+                self._add_item(frame, "BONE", bone_name)
         else:
-            if context.active_bone:
-                bone_names = [context.active_bone.name]
-                if context.selected_bones:
-                    bone_names += [b.name for b in context.selected_bones]
-                if context.selected_editable_bones:
-                    bone_names += [b.name for b in context.selected_editable_bones]
-                if context.selected_pose_bones:
-                    bone_names += [b.name for b in context.selected_pose_bones]
-                bone_names = sorted(list(set(bone_names)))
-                for bone_name in bone_names:
-                    self._add_item(frame, "BONE", bone_name)
-            else:
-                self._add_item(frame, "BONE", "Bone Item")
+            self._add_item(frame, "BONE", "Bone Item")
         return {"FINISHED"}
 
     def _add_item(self, frame, item_type, item_name, morph_type=None):
@@ -147,7 +146,7 @@ class RemoveDisplayItem(Operator):
 class MoveDisplayItem(Operator, ItemMoveOp):
     bl_idname = "mmd_tools_local.display_item_move"
     bl_label = "Move Display Item"
-    bl_description = "Move active display item up/dowm in the list"
+    bl_description = "Move active display item up/down in the list. This will also affect the morph order in exported PMX files."
     bl_options = {"REGISTER", "UNDO", "INTERNAL"}
 
     def execute(self, context):
@@ -295,7 +294,7 @@ class DisplayItemQuickSetup(Operator):
         item_list.sort(key=lambda x: old.index(x) if x in old else len(old))
 
         ItemOp.resize(facial_items, len(item_list))
-        for item, data in zip(facial_items, item_list):
+        for item, data in zip(facial_items, item_list, strict=False):
             item.type = "MORPH"
             item.morph_type, item.name = data
         frame.active_item = 0

--- a/extern_tools/mmd_tools_local/operators/fileio.py
+++ b/extern_tools/mmd_tools_local/operators/fileio.py
@@ -58,14 +58,166 @@ def _update_types(cls, prop):
         cls.types = types  # trigger update
 
 
-class ImportPmx(Operator, ImportHelper):
+def get_addon_package_name():
+    """Get the root package name for addon preferences"""
+    current_package = __package__
+    parts = current_package.split(".")
+    try:
+        index = parts.index("mmd_tools_local")
+        return ".".join(parts[: index + 1])
+    except ValueError:
+        pass
+    return current_package
+
+
+def get_preset_directories(operator_bl_idname):
+    """Get preset directories for an operator"""
+    preset_dirs = []
+
+    try:
+        # Try the official API first
+        official_dirs = bpy.utils.preset_paths(operator_bl_idname)
+        preset_dirs.extend(official_dirs)
+
+        # Add manual preset paths as fallback
+        scripts_dir = bpy.utils.user_resource("SCRIPTS")
+        config_dir = bpy.utils.user_resource("CONFIG")
+
+        manual_preset_paths = [
+            os.path.join(scripts_dir, "presets", "operator", operator_bl_idname),
+            os.path.join(config_dir, "presets", "operator", operator_bl_idname),
+        ]
+
+        for path in manual_preset_paths:
+            if os.path.exists(path) and path not in preset_dirs:
+                preset_dirs.append(path)
+
+    except Exception:
+        pass
+
+    return preset_dirs
+
+
+def apply_operator_preset(operator, preset_name):
+    """Apply a saved preset to an operator instance"""
+    if not preset_name:
+        return False
+
+    try:
+        preset_dirs = get_preset_directories(operator.__class__.bl_idname)
+
+        if not preset_dirs:
+            return False
+
+        # Look for the preset file
+        preset_file = None
+        for path in preset_dirs:
+            potential_file = os.path.join(path, preset_name + ".py")
+            if os.path.exists(potential_file):
+                preset_file = potential_file
+                break
+
+        if not preset_file:
+            return False
+
+        # Execute preset with proper context
+        with bpy.context.temp_override(active_operator=operator):
+            try:
+                with open(preset_file, encoding="utf-8") as f:
+                    preset_code = f.read()
+
+                namespace = {"bpy": bpy}
+                exec(preset_code, namespace)
+                return True
+
+            except Exception:
+                return False
+
+    except Exception:
+        return False
+
+
+def get_available_presets(operator_bl_idname):
+    """Get list of available presets for an operator"""
+    presets = []
+
+    try:
+        preset_dirs = get_preset_directories(operator_bl_idname)
+
+        for preset_dir in preset_dirs:
+            try:
+                for filename in os.listdir(preset_dir):
+                    if filename.endswith(".py"):
+                        preset_name = filename[:-3]  # Remove .py extension
+                        if preset_name not in presets:
+                            presets.append(preset_name)
+            except Exception:
+                continue
+
+        return sorted(presets)
+
+    except Exception:
+        return []
+
+
+def load_default_settings_from_preferences(operator, context, preset_property_name):
+    """Load default settings from preferences using preset"""
+    try:
+        addon_package = get_addon_package_name()
+        addon_prefs = context.preferences.addons.get(addon_package)
+
+        if not addon_prefs:
+            return False
+
+        prefs = addon_prefs.preferences
+
+        # Check if the preset property exists
+        if not hasattr(prefs, preset_property_name):
+            return False
+
+        # Apply preset if specified
+        preset_name = getattr(prefs, preset_property_name, "")
+        if preset_name and apply_operator_preset(operator, preset_name):
+            return True
+
+        return False
+
+    except Exception:
+        return False
+
+
+def get_armature_display_items(self, context):
+    # https://docs.blender.org/api/current/bpy.props.html#bpy.props.EnumProperty
+    # self & context are required, even though they are not used in function
+    enum_items = bpy.types.Armature.bl_rna.properties["display_type"].enum_items
+    return [(item.identifier, item.name, "") for item in enum_items]
+
+
+class PreferencesMixin:
+    """Mixin for operators that load default settings from preferences"""
+
+    _preferences_applied = False
+
+    def load_preferences_on_invoke(self, context, preset_property_name):
+        """Load preferences on first invoke"""
+        self._preferences_were_applied = getattr(self.__class__, "_preferences_applied", False)
+        if not self._preferences_were_applied:
+            if load_default_settings_from_preferences(self, context, preset_property_name):
+                self.__class__._preferences_applied = True
+
+    def restore_preferences_on_cancel(self):
+        """Restore preferences state on cancel"""
+        self.__class__._preferences_applied = self._preferences_were_applied
+
+
+class ImportPmx(Operator, ImportHelper, PreferencesMixin):
     bl_idname = "mmd_tools_local.import_model"
     bl_label = "Import Model File (.pmd, .pmx)"
     bl_description = "Import model file(s) (.pmd, .pmx)"
     bl_options = {"REGISTER", "UNDO", "PRESET"}
 
     files: bpy.props.CollectionProperty(type=OperatorFileListElement, options={"HIDDEN", "SKIP_SAVE"})
-    directory: bpy.props.StringProperty(maxlen=1024, subtype="FILE_PATH", options={"HIDDEN", "SKIP_SAVE"})
+    directory: bpy.props.StringProperty(maxlen=1024, subtype="DIR_PATH", options={"HIDDEN", "SKIP_SAVE"})
 
     filename_ext = ".pmx"
     filter_glob: bpy.props.StringProperty(default="*.pmx;*.pmd", options={"HIDDEN"})
@@ -102,10 +254,20 @@ class ImportPmx(Operator, ImportHelper):
     )
     remove_doubles: bpy.props.BoolProperty(
         name="Remove Doubles",
-        description="Merge duplicated vertices and faces",
+        description="Merge duplicated vertices and faces.\nWarning: This will perform global vertex merging instead of per-material vertex merging which may break mesh geometry, material boundaries, and distort the UV map. Use with caution.",
         default=False,
     )
-    fix_IK_links: bpy.props.BoolProperty(
+    import_adduv2_as_vertex_colors: bpy.props.BoolProperty(
+        name="Import Vertex Colors",
+        description="Import ADD UV2 data as vertex colors. When enabled, the UV2 layer will still be created.",
+        default=False,
+    )
+    fix_bone_order: bpy.props.BoolProperty(
+        name="Fix Bone Order",
+        description="Automatically fix bone order after import. This ensures bones are ordered correctly for MMD compatibility.",
+        default=True,
+    )
+    fix_ik_links: bpy.props.BoolProperty(
         name="Fix IK Links",
         description="Fix IK links to be blender suitable",
         default=False,
@@ -125,7 +287,7 @@ class ImportPmx(Operator, ImportHelper):
     )
     rename_bones: bpy.props.BoolProperty(
         name="Rename Bones - L / R Suffix",
-        description="Use Blender naming conventions for Left / Right paired bones",
+        description="Use Blender naming conventions for Left / Right paired bones. Required for features like mirror editing and pose mirroring to function properly.",
         default=True,
     )
     use_underscore: bpy.props.BoolProperty(
@@ -137,6 +299,11 @@ class ImportPmx(Operator, ImportHelper):
         name="Rename Bones To English",
         items=DictionaryEnum.get_dictionary_items,
         description="Translate bone names from Japanese to English using selected dictionary",
+    )
+    bone_disp_mode: bpy.props.EnumProperty(
+        name="Bone Display Mode",
+        items=get_armature_display_items,
+        description="Change how bones look in viewport.",
     )
     use_mipmap: bpy.props.BoolProperty(
         name="use MIP maps for UV textures",
@@ -153,6 +320,11 @@ class ImportPmx(Operator, ImportHelper):
         description="The diffuse color factor of texture slot for .spa textures",
         default=1.0,
     )
+    add_rigid_body_world: bpy.props.BoolProperty(
+        name="Add Rigid Body World",
+        description="Automatically add Rigid Body World to the scene when importing physics.",
+        default=True,
+    )
     log_level: bpy.props.EnumProperty(
         name="Log level",
         description="Select log level",
@@ -165,6 +337,14 @@ class ImportPmx(Operator, ImportHelper):
         default=False,
     )
 
+    def invoke(self, context, event):
+        self.load_preferences_on_invoke(context, "default_pmx_import_preset")
+        return super().invoke(context, event)
+
+    def cancel(self, context):
+        self.restore_preferences_on_cancel()
+        return super().cancel(context) if hasattr(super(), "cancel") else None
+
     def execute(self, context):
         try:
             self.__translator = DictionaryEnum.get_translator(self.dictionary)
@@ -174,7 +354,8 @@ class ImportPmx(Operator, ImportHelper):
                     self._do_execute(context)
             elif self.filepath:
                 self._do_execute(context)
-        except Exception as e:
+        except Exception:
+            logging.exception("Error occurred")
             err_msg = traceback.format_exc()
             self.report({"ERROR"}, err_msg)
         return {"FINISHED"}
@@ -182,12 +363,14 @@ class ImportPmx(Operator, ImportHelper):
     def _do_execute(self, context):
         logger = logging.getLogger()
         logger.setLevel(self.log_level)
+        handler = None
         if self.save_log:
             handler = log_handler(self.log_level, filepath=self.filepath + ".mmd_tools_local.import.log")
             logger.addHandler(handler)
+
         try:
             importer_cls = pmx_importer.PMXImporter
-            if re.search("\.pmd$", self.filepath, flags=re.I):
+            if re.search(r"\.pmd$", self.filepath, flags=re.IGNORECASE):
                 importer_cls = pmd_importer.PMDImporter
 
             importer_cls().execute(
@@ -196,33 +379,39 @@ class ImportPmx(Operator, ImportHelper):
                 scale=self.scale,
                 clean_model=self.clean_model,
                 remove_doubles=self.remove_doubles,
-                fix_IK_links=self.fix_IK_links,
+                import_adduv2_as_vertex_colors=self.import_adduv2_as_vertex_colors,
+                fix_bone_order=self.fix_bone_order,
+                fix_ik_links=self.fix_ik_links,
                 ik_loop_factor=self.ik_loop_factor,
                 apply_bone_fixed_axis=self.apply_bone_fixed_axis,
                 rename_LR_bones=self.rename_bones,
                 use_underscore=self.use_underscore,
+                bone_disp_mode=self.bone_disp_mode,
                 translator=self.__translator,
                 use_mipmap=self.use_mipmap,
                 sph_blend_factor=self.sph_blend_factor,
                 spa_blend_factor=self.spa_blend_factor,
+                add_rigid_body_world=self.add_rigid_body_world,
             )
-            self.report({"INFO"}, 'Imported MMD model from "%s"' % self.filepath)
-        except Exception as e:
-            err_msg = traceback.format_exc()
-            logging.error(err_msg)
+            self.report({"INFO"}, f'Imported MMD model from "{self.filepath}"')
+        except Exception:
+            logging.exception("Error occurred")
             raise
         finally:
-            if self.save_log:
+            if handler:
                 logger.removeHandler(handler)
 
         return {"FINISHED"}
 
 
-class ImportVmd(Operator, ImportHelper):
+class ImportVmd(Operator, ImportHelper, PreferencesMixin):
     bl_idname = "mmd_tools_local.import_vmd"
     bl_label = "Import VMD File (.vmd)"
-    bl_description = "Import a VMD file to selected objects (.vmd)"
+    bl_description = "Import a VMD file to selected objects (.vmd)\nBehavior varies depending on the selected object:\n- Select the root (cross under the model): imports both armature and morph animations\n- Select the model: imports only morph animation\n- Select the armature: imports only armature animation"
     bl_options = {"REGISTER", "UNDO", "PRESET"}
+
+    files: bpy.props.CollectionProperty(type=OperatorFileListElement, options={"HIDDEN", "SKIP_SAVE"})
+    directory: bpy.props.StringProperty(maxlen=1024, subtype="DIR_PATH", options={"HIDDEN", "SKIP_SAVE"})
 
     filename_ext = ".vmd"
     filter_glob: bpy.props.StringProperty(default="*.vmd", options={"HIDDEN"})
@@ -234,9 +423,9 @@ class ImportVmd(Operator, ImportHelper):
     )
     margin: bpy.props.IntProperty(
         name="Margin",
-        description="How many frames added before motion starting",
+        description="Number of frames to add before the motion starts (only applies if current frame is 0 or 1)",
         min=0,
-        default=5,
+        default=0,
     )
     bone_mapper: bpy.props.EnumProperty(
         name="Bone Mapper",
@@ -250,7 +439,7 @@ class ImportVmd(Operator, ImportHelper):
     )
     rename_bones: bpy.props.BoolProperty(
         name="Rename Bones - L / R Suffix",
-        description="Use Blender naming conventions for Left / Right paired bones",
+        description="Use Blender naming conventions for Left / Right paired bones. Required for features like mirror editing and pose mirroring to function properly.",
         default=True,
     )
     use_underscore: bpy.props.BoolProperty(
@@ -279,25 +468,63 @@ class ImportVmd(Operator, ImportHelper):
         description="Update frame range and frame rate (30 fps)",
         default=True,
     )
-    use_NLA: bpy.props.BoolProperty(
+    create_new_action: bpy.props.BoolProperty(
+        name="Create New Action",
+        description="Create a new action when importing VMD, otherwise add keyframes to existing actions if available. Note: This option is ignored when 'Use NLA' is enabled.",
+        default=False,
+    )
+    use_nla: bpy.props.BoolProperty(
         name="Use NLA",
         description="Import the motion as NLA strips",
         default=False,
     )
-    files: bpy.props.CollectionProperty(
-        type=OperatorFileListElement,
+    detect_camera_changes: bpy.props.BoolProperty(
+        name="Detect Camera Cut",
+        description="When the interval between camera keyframes is 1 frame, change the interpolation to CONSTANT. This is useful when making a 60fps video, as it helps prevent unwanted smoothing between rapid camera cuts.",
+        default=True,
     )
-    directory: bpy.props.StringProperty(subtype="DIR_PATH")
+    detect_lamp_changes: bpy.props.BoolProperty(
+        # TODO: Update all instances of "lamp" to "light" throughout the repository to align with Blender 2.80+ API changes.
+        # This includes:
+        #   - Variable names and references
+        #   - Class/type checks (LAMP -> LIGHT)
+        #   - Documentation and comments
+        #   - Function parameters and return values
+        # This change is necessary since Blender 2.80 renamed the "Lamp" type to "Light".
+        name="Detect Light Cut",
+        description="When the interval between light keyframes is 1 frame, change the interpolation to CONSTANT. This is useful when making a 60fps video, as it helps prevent unwanted smoothing during sudden lighting changes.",
+        default=True,
+    )
+    log_level: bpy.props.EnumProperty(
+        name="Log level",
+        description="Select log level",
+        items=LOG_LEVEL_ITEMS,
+        default="INFO",
+    )
+    save_log: bpy.props.BoolProperty(
+        name="Create a log file",
+        description="Create a log file",
+        default=False,
+    )
 
     @classmethod
     def poll(cls, context):
         return len(context.selected_objects) > 0
 
+    def invoke(self, context, event):
+        self.load_preferences_on_invoke(context, "default_vmd_import_preset")
+        return super().invoke(context, event)
+
+    def cancel(self, context):
+        self.restore_preferences_on_cancel()
+        return super().cancel(context) if hasattr(super(), "cancel") else None
+
     def draw(self, context):
         layout = self.layout
         layout.prop(self, "scale")
         layout.prop(self, "margin")
-        layout.prop(self, "use_NLA")
+        layout.prop(self, "create_new_action")
+        layout.prop(self, "use_nla")
 
         layout.prop(self, "bone_mapper")
         if self.bone_mapper == "RENAMED_BONES":
@@ -306,60 +533,161 @@ class ImportVmd(Operator, ImportHelper):
             layout.prop(self, "dictionary")
         layout.prop(self, "use_pose_mode")
         layout.prop(self, "use_mirror")
+        layout.prop(self, "detect_camera_changes")
+        layout.prop(self, "detect_lamp_changes")
 
         layout.prop(self, "update_scene_settings")
 
+        layout.prop(self, "log_level")
+        layout.prop(self, "save_log")
+
     def execute(self, context):
-        selected_objects = set(context.selected_objects)
-        for i in frozenset(selected_objects):
-            root = FnModel.find_root_object(i)
-            if root == i:
-                rig = Model(root)
-                selected_objects.add(rig.armature())
-                selected_objects.add(rig.morph_slider.placeholder())
-                selected_objects |= set(rig.meshes())
+        logger = logging.getLogger()
+        logger.setLevel(self.log_level)
+        handler = None
+        if self.save_log:
+            handler = log_handler(self.log_level, filepath=self.filepath + ".mmd_tools_local.import.log")
+            logger.addHandler(handler)
 
-        bone_mapper = None
-        if self.bone_mapper == "PMX":
-            bone_mapper = makePmxBoneMap
-        elif self.bone_mapper == "RENAMED_BONES":
-            bone_mapper = vmd_importer.RenamedBoneMapper(
-                rename_LR_bones=self.rename_bones,
-                use_underscore=self.use_underscore,
-                translator=DictionaryEnum.get_translator(self.dictionary),
-            ).init
+        try:
+            selected_objects = set(context.selected_objects)
+            for i in frozenset(selected_objects):
+                root = FnModel.find_root_object(i)
+                if root == i:
+                    rig = Model(root)
+                    armature = rig.armature()
+                    if armature is not None:
+                        selected_objects.add(armature)
+                    placeholder = rig.morph_slider.placeholder()
+                    if placeholder is not None:
+                        selected_objects.add(placeholder)
+                    selected_objects |= set(rig.meshes())
 
-        for file in self.files:
-            start_time = time.time()
-            importer = vmd_importer.VMDImporter(
-                filepath=os.path.join(self.directory, file.name),
-                scale=self.scale,
-                bone_mapper=bone_mapper,
-                use_pose_mode=self.use_pose_mode,
-                frame_margin=self.margin,
-                use_mirror=self.use_mirror,
-                use_NLA=self.use_NLA,
-            )
+            bone_mapper = None
+            if self.bone_mapper == "PMX":
+                bone_mapper = makePmxBoneMap
+            elif self.bone_mapper == "RENAMED_BONES":
+                bone_mapper = vmd_importer.RenamedBoneMapper(
+                    rename_LR_bones=self.rename_bones,
+                    use_underscore=self.use_underscore,
+                    translator=DictionaryEnum.get_translator(self.dictionary),
+                ).init
 
-            for i in selected_objects:
-                importer.assign(i)
-            logging.info(" Finished importing motion in %f seconds.", time.time() - start_time)
+            if self.files:
+                if self.create_new_action:
+                    for obj in selected_objects:
+                        self.__reset_all_animations(obj)
 
-        if self.update_scene_settings:
-            auto_scene_setup.setupFrameRanges()
-            auto_scene_setup.setupFps()
-        context.scene.frame_set(context.scene.frame_current)
+            for file in self.files:
+                start_time = time.time()
+                importer = vmd_importer.VMDImporter(
+                    filepath=os.path.join(self.directory, file.name),
+                    scale=self.scale,
+                    bone_mapper=bone_mapper,
+                    use_pose_mode=self.use_pose_mode,
+                    frame_margin=self.margin,
+                    use_mirror=self.use_mirror,
+                    use_nla=self.use_nla,
+                    detect_camera_changes=self.detect_camera_changes,
+                    detect_lamp_changes=self.detect_lamp_changes,
+                )
+
+                for i in selected_objects:
+                    importer.assign(i)
+                logging.info(" Finished importing motion in %f seconds.", time.time() - start_time)
+
+            if self.update_scene_settings:
+                auto_scene_setup.setupFrameRanges()
+                auto_scene_setup.setupFps()
+            context.scene.frame_set(context.scene.frame_current)
+
+        except Exception:
+            logging.exception("Error occurred")
+            err_msg = traceback.format_exc()
+            self.report({"ERROR"}, err_msg)
+        finally:
+            if handler:
+                logger.removeHandler(handler)
+
         return {"FINISHED"}
 
+    def __reset_all_animations(self, target_obj):
+        """Reset all animation states for the target object and related MMD model objects"""
+        root_object = FnModel.find_root_object(target_obj)
+        objects_to_process = set()
 
-class ImportVpd(Operator, ImportHelper):
+        if root_object:
+            objects_to_process.add(root_object)
+            objects_to_process.add(target_obj)
+            # Add armature object
+            armature_object = FnModel.find_armature_object(root_object)
+            if armature_object:
+                objects_to_process.add(armature_object)
+            # Add all mesh objects
+            objects_to_process.update(FnModel.iterate_mesh_objects(root_object))
+            # Add other group objects if they exist
+            rigid_group = FnModel.find_rigid_group_object(root_object)
+            if rigid_group:
+                objects_to_process.add(rigid_group)
+            joint_group = FnModel.find_joint_group_object(root_object)
+            if joint_group:
+                objects_to_process.add(joint_group)
+            temporary_group = FnModel.find_temporary_group_object(root_object)
+            if temporary_group:
+                objects_to_process.add(temporary_group)
+        else:
+            objects_to_process.add(target_obj)
+
+        # STEP 1: Clear all existing actions first
+        for obj in objects_to_process:
+            # Clear object's own actions
+            if obj.animation_data:
+                obj.animation_data.action = None
+
+            # Clear Shape Keys actions
+            if hasattr(obj, "data") and hasattr(obj.data, "shape_keys") and obj.data.shape_keys:
+                if obj.data.shape_keys.animation_data:
+                    obj.data.shape_keys.animation_data.action = None
+
+            # Clear light data actions
+            if obj.type == "LIGHT" and obj.data.animation_data:
+                obj.data.animation_data.action = None
+
+        # STEP 2: Reset all properties to default states
+        for obj in objects_to_process:
+            if obj.type == "ARMATURE":
+                # Reset armature pose
+                for bone in obj.pose.bones:
+                    bone.location = (0.0, 0.0, 0.0)
+                    bone.rotation_quaternion = (1.0, 0.0, 0.0, 0.0)
+                    bone.rotation_euler = (0.0, 0.0, 0.0)
+                    bone.rotation_axis_angle = (0.0, 0.0, 1.0, 0.0)
+                    bone.scale = (1.0, 1.0, 1.0)
+
+                    # Reset IK settings to default
+                    if hasattr(bone, "mmd_ik_toggle"):
+                        bone.mmd_ik_toggle = True
+
+            elif obj.type == "MESH" and getattr(obj.data, "shape_keys", None):
+                # Reset mesh morphs
+                for shape_key in obj.data.shape_keys.key_blocks:
+                    if shape_key.name != "Basis":  # Don't reset basis shape key
+                        shape_key.value = 0.0
+
+            elif hasattr(obj, "mmd_type") and obj.mmd_type == "ROOT":
+                # Reset root display state
+                if hasattr(obj, "mmd_root") and hasattr(obj.mmd_root, "show_meshes"):
+                    obj.mmd_root.show_meshes = True  # Default to show meshes
+
+
+class ImportVpd(Operator, ImportHelper, PreferencesMixin):
     bl_idname = "mmd_tools_local.import_vpd"
     bl_label = "Import VPD File (.vpd)"
-    bl_description = "Import VPD file(s) to selected rig's Action Pose (.vpd)"
+    bl_description = "Import VPD file(s) to selected rig's Action Pose (.vpd)\nBehavior varies depending on the selected object:\n- Select the root (cross under the model): applies both armature pose and morphs\n- Select the model: applies only morphs\n- Select the armature: applies only armature pose"
     bl_options = {"REGISTER", "UNDO", "PRESET"}
 
     files: bpy.props.CollectionProperty(type=OperatorFileListElement, options={"HIDDEN", "SKIP_SAVE"})
-    directory: bpy.props.StringProperty(maxlen=1024, subtype="FILE_PATH", options={"HIDDEN", "SKIP_SAVE"})
+    directory: bpy.props.StringProperty(maxlen=1024, subtype="DIR_PATH", options={"HIDDEN", "SKIP_SAVE"})
 
     filename_ext = ".vpd"
     filter_glob: bpy.props.StringProperty(default="*.vpd", options={"HIDDEN"})
@@ -381,7 +709,7 @@ class ImportVpd(Operator, ImportHelper):
     )
     rename_bones: bpy.props.BoolProperty(
         name="Rename Bones - L / R Suffix",
-        description="Use Blender naming conventions for Left / Right paired bones",
+        description="Use Blender naming conventions for Left / Right paired bones. Required for features like mirror editing and pose mirroring to function properly.",
         default=True,
     )
     use_underscore: bpy.props.BoolProperty(
@@ -405,6 +733,14 @@ class ImportVpd(Operator, ImportHelper):
     def poll(cls, context):
         return len(context.selected_objects) > 0
 
+    def invoke(self, context, event):
+        self.load_preferences_on_invoke(context, "default_vpd_import_preset")
+        return super().invoke(context, event)
+
+    def cancel(self, context):
+        self.restore_preferences_on_cancel()
+        return super().cancel(context) if hasattr(super(), "cancel") else None
+
     def draw(self, context):
         layout = self.layout
         layout.prop(self, "scale")
@@ -422,8 +758,12 @@ class ImportVpd(Operator, ImportHelper):
             root = FnModel.find_root_object(i)
             if root == i:
                 rig = Model(root)
-                selected_objects.add(rig.armature())
-                selected_objects.add(rig.morph_slider.placeholder())
+                armature = rig.armature()
+                if armature is not None:
+                    selected_objects.add(armature)
+                placeholder = rig.morph_slider.placeholder()
+                if placeholder is not None:
+                    selected_objects.add(placeholder)
                 selected_objects |= set(rig.meshes())
 
         bone_mapper = None
@@ -448,7 +788,7 @@ class ImportVpd(Operator, ImportHelper):
         return {"FINISHED"}
 
 
-class ExportPmx(Operator, ExportHelper):
+class ExportPmx(Operator, ExportHelper, PreferencesMixin):
     bl_idname = "mmd_tools_local.export_pmx"
     bl_label = "Export PMX File (.pmx)"
     bl_description = "Export selected MMD model(s) to PMX file(s) (.pmx)"
@@ -462,14 +802,19 @@ class ExportPmx(Operator, ExportHelper):
         description="Scaling factor for exporting the model",
         default=12.5,
     )
-    copy_textures: bpy.props.BoolProperty(
-        name="Copy textures",
-        description="Copy textures",
-        default=True,
+    copy_textures_mode: bpy.props.EnumProperty(
+        name="Copy Textures",
+        description="Choose how to handle texture files during export",
+        items=[
+            ("NONE", "Don't Copy", "Don't copy texture files", 0),
+            ("SKIP_EXISTING", "Copy (Skip Existing)", "Copy textures but skip files that already exist", 1),
+            ("OVERWRITE", "Copy (Overwrite)", "Copy textures and overwrite existing files", 2),
+        ],
+        default="SKIP_EXISTING",
     )
     sort_materials: bpy.props.BoolProperty(
         name="Sort Materials",
-        description=("Sort materials for alpha blending. " "WARNING: Will not work if you have " + "transparent meshes inside the model. " + "E.g. blush meshes"),
+        description="Sort materials for alpha blending. WARNING: Will not work if you have transparent meshes inside the model. E.g. blush meshes",
         default=False,
     )
     disable_specular: bpy.props.BoolProperty(
@@ -482,6 +827,16 @@ class ExportPmx(Operator, ExportHelper):
         description="Export visible meshes only",
         default=False,
     )
+    export_vertex_colors_as_adduv2: bpy.props.BoolProperty(
+        name="Export Vertex Colors",
+        description="Export vertex colors as ADD UV2 data. This allows vertex color data to be preserved in the PMX file format. When enabled, existing ADD UV2 data on the model will be skipped during export.",
+        default=False,
+    )
+    fix_bone_order: bpy.props.BoolProperty(
+        name="Fix Bone Order",
+        description="Automatically fix bone order before export. This ensures bones are ordered correctly for MMD compatibility.",
+        default=True,
+    )
     overwrite_bone_morphs_from_action_pose: bpy.props.BoolProperty(
         name="Overwrite Bone Morphs",
         description="Overwrite the bone morphs from active Action Pose before exporting.",
@@ -492,6 +847,16 @@ class ExportPmx(Operator, ExportHelper):
         description="Translate in presets before exporting.",
         default=False,
     )
+    normal_handling: bpy.props.EnumProperty(
+        name="Normal Handling",
+        description="Choose how to handle normals during export. This affects vertex count, edge count, and mesh topology by splitting vertices and edges to preserve split normals.",
+        items=[
+            ("PRESERVE_ALL_NORMALS", "Preserve All Normals", "Export existing normals without any changes. This option performs NO automatic smoothing; only use it if you have already manually smoothed and perfected your normals. When using this option, please verify if the vertex count of the exported model has significantly increased or is within a reasonable range to prevent excessive geometry destruction and an overly fragmented model.", 0),
+            ("SMOOTH_KEEP_SHARP", "Smooth (Keep Sharp)", "Shade smooth, keep sharp edges. Balances vertex count and normal preservation.", 1),
+            ("SMOOTH_ALL_NORMALS", "Smooth All Normals", "Force smooths all normals, ignoring any sharp edges. This will result in a completely smooth-shaded model and minimum vertex count.", 2),
+        ],
+        default="SMOOTH_KEEP_SHARP",
+    )
     sort_vertices: bpy.props.EnumProperty(
         name="Sort Vertices",
         description="Choose the method to sort vertices",
@@ -501,6 +866,43 @@ class ExportPmx(Operator, ExportHelper):
             ("CUSTOM", "Custom", 'Use custom vertex weight of vertex group "mmd_vertex_order"', 2),
         ],
         default="NONE",
+    )
+    ik_angle_limits: bpy.props.EnumProperty(
+        name="IK Angle Limits",
+        description="Choose how to handle IK angle limits during export",
+        items=[
+            (
+                "EXPORT_ALL",
+                "Export All Limits",
+                "Export all existing IK angle limits using current priority system: "
+                "mmd_ik_limit_override -> Blender IK limits -> other sources. "
+                "If mmd_ik_limit_override disables an axis but Blender IK limits exist for that axis, "
+                "the Blender limits will still be exported. This maintains backward compatibility "
+                "with existing workflows",
+                0,
+            ),
+            (
+                "IGNORE_ALL",
+                "Ignore All Limits",
+                "Completely ignore all IK angle limits from any source during export. "
+                "No angle restrictions will be written to the PMX file, regardless of "
+                "mmd_ik_limit_override, Blender IK limits, or other constraint settings. "
+                "Useful when you want to rely entirely on MMD v9.19+ fixed axis feature instead",
+                1,
+            ),
+            (
+                "OVERRIDE_CONTROLLED",
+                "Override Controlled",
+                "Use mmd_ik_limit_override constraints as the sole authority for IK limits. "
+                "When mmd_ik_limit_override exists: only its enabled axes export limits, "
+                "disabled axes export no limits (ignoring Blender IK limits). "
+                "When mmd_ik_limit_override doesn't exist: fall back to Blender IK limits. "
+                "This makes mmd_ik_limit_override act as a true 'override' that completely "
+                "controls whether limits are exported, enabling fine-grained per-bone control",
+                2,
+            ),
+        ],
+        default="EXPORT_ALL",
     )
     log_level: bpy.props.EnumProperty(
         name="Log level",
@@ -517,7 +919,15 @@ class ExportPmx(Operator, ExportHelper):
     @classmethod
     def poll(cls, context):
         obj = context.active_object
-        return obj in context.selected_objects and FnModel.find_root_object(obj)
+        return obj is not None and obj in context.selected_objects and FnModel.find_root_object(obj)
+
+    def invoke(self, context, event):
+        self.load_preferences_on_invoke(context, "default_pmx_export_preset")
+        return super().invoke(context, event)
+
+    def cancel(self, context):
+        self.restore_preferences_on_cancel()
+        return super().cancel(context) if hasattr(super(), "cancel") else None
 
     def execute(self, context):
         try:
@@ -534,7 +944,8 @@ class ExportPmx(Operator, ExportHelper):
                     os.makedirs(model_folder, exist_ok=True)
                     self.filepath = os.path.join(model_folder, model_name + ".pmx")
                 self._do_execute(context, root)
-        except Exception as e:
+        except Exception:
+            logging.exception("Error occurred")
             err_msg = traceback.format_exc()
             self.report({"ERROR"}, err_msg)
         return {"FINISHED"}
@@ -542,13 +953,14 @@ class ExportPmx(Operator, ExportHelper):
     def _do_execute(self, context, root):
         logger = logging.getLogger()
         logger.setLevel(self.log_level)
+        handler = None
         if self.save_log:
             handler = log_handler(self.log_level, filepath=self.filepath + ".mmd_tools_local.export.log")
             logger.addHandler(handler)
 
         arm = FnModel.find_armature_object(root)
         if arm is None:
-            self.report({"ERROR"}, '[Skipped] The armature object of MMD model "%s" can\'t be found' % root.name)
+            self.report({"ERROR"}, f'[Skipped] The armature object of MMD model "{root.name}" can\'t be found')
             return {"CANCELLED"}
         orig_pose_position = None
         if not root.mmd_root.is_built:  # use 'REST' pose when the model is not built
@@ -569,31 +981,34 @@ class ExportPmx(Operator, ExportHelper):
                 meshes=meshes,
                 rigid_bodies=FnModel.iterate_rigid_body_objects(root),
                 joints=FnModel.iterate_joint_objects(root),
-                copy_textures=self.copy_textures,
+                copy_textures_mode=self.copy_textures_mode,
+                fix_bone_order=self.fix_bone_order,
                 overwrite_bone_morphs_from_action_pose=self.overwrite_bone_morphs_from_action_pose,
                 translate_in_presets=self.translate_in_presets,
                 sort_materials=self.sort_materials,
                 sort_vertices=self.sort_vertices,
                 disable_specular=self.disable_specular,
+                export_vertex_colors_as_adduv2=self.export_vertex_colors_as_adduv2,
+                normal_handling=self.normal_handling,
+                ik_angle_limits=self.ik_angle_limits,
             )
-            self.report({"INFO"}, 'Exported MMD model "%s" to "%s"' % (root.name, self.filepath))
-        except:
-            err_msg = traceback.format_exc()
-            logging.error(err_msg)
+            self.report({"INFO"}, f'Exported MMD model "{root.name}" to "{self.filepath}"')
+        except Exception:
+            logging.exception("Error occurred")
             raise
         finally:
             if orig_pose_position:
                 arm.data.pose_position = orig_pose_position
-            if self.save_log:
+            if handler:
                 logger.removeHandler(handler)
 
         return {"FINISHED"}
 
 
-class ExportVmd(Operator, ExportHelper):
+class ExportVmd(Operator, ExportHelper, PreferencesMixin):
     bl_idname = "mmd_tools_local.export_vmd"
     bl_label = "Export VMD File (.vmd)"
-    bl_description = "Export motion data of active object to a VMD file (.vmd)"
+    bl_description = "Export motion data of active object to a VMD file (.vmd)\nBehavior varies depending on the active object:\n- Active object is the root (cross under the model): exports both armature and morph animations\n- Active object is the model: exports only morph animation\n- Active object is the armature: exports only armature animation"
     bl_options = {"PRESET"}
 
     filename_ext = ".vmd"
@@ -615,6 +1030,22 @@ class ExportVmd(Operator, ExportHelper):
         description="Export frames only in the frame range of context scene",
         default=False,
     )
+    preserve_curves: bpy.props.BoolProperty(
+        name="Preserve Animation Curves",
+        description="Add additional keyframes to accurately preserve animation curves. Blender's bezier handles are more flexible than the VMD format. Complex handle settings will be lost during export unless additional keyframes are added to approximate the original curves.",
+        default=False,
+    )
+    log_level: bpy.props.EnumProperty(
+        name="Log level",
+        description="Select log level",
+        items=LOG_LEVEL_ITEMS,
+        default="INFO",
+    )
+    save_log: bpy.props.BoolProperty(
+        name="Create a log file",
+        description="Create a log file",
+        default=False,
+    )
 
     @classmethod
     def poll(cls, context):
@@ -631,50 +1062,67 @@ class ExportVmd(Operator, ExportHelper):
 
         return False
 
-    def execute(self, context):
-        params = {
-            "filepath": self.filepath,
-            "scale": self.scale,
-            "use_pose_mode": self.use_pose_mode,
-            "use_frame_range": self.use_frame_range,
-        }
+    def invoke(self, context, event):
+        self.load_preferences_on_invoke(context, "default_vmd_export_preset")
+        return super().invoke(context, event)
 
-        obj = context.active_object
-        if obj.mmd_type == "ROOT":
-            rig = Model(obj)
-            params["mesh"] = rig.morph_slider.placeholder(binded=True) or rig.firstMesh()
-            params["armature"] = rig.armature()
-            params["model_name"] = obj.mmd_root.name or obj.name
-        elif getattr(obj.data, "shape_keys", None):
-            params["mesh"] = obj
-            params["model_name"] = obj.name
-        elif obj.type == "ARMATURE":
-            params["armature"] = obj
-            params["model_name"] = obj.name
-        else:
-            for i in context.selected_objects:
-                if MMDCamera.isMMDCamera(i):
-                    params["camera"] = i
-                elif MMDLamp.isMMDLamp(i):
-                    params["lamp"] = i
+    def cancel(self, context):
+        self.restore_preferences_on_cancel()
+        return super().cancel(context) if hasattr(super(), "cancel") else None
+
+    def execute(self, context):
+        logger = logging.getLogger()
+        logger.setLevel(self.log_level)
+        handler = None
+        if self.save_log:
+            handler = log_handler(self.log_level, filepath=self.filepath + ".mmd_tools_local.export.log")
+            logger.addHandler(handler)
 
         try:
+            params = {
+                "filepath": self.filepath,
+                "scale": self.scale,
+                "use_pose_mode": self.use_pose_mode,
+                "use_frame_range": self.use_frame_range,
+                "preserve_curves": self.preserve_curves,
+            }
+
+            obj = context.active_object
+            if obj.mmd_type == "ROOT":
+                rig = Model(obj)
+                params["mesh"] = rig.morph_slider.placeholder(binded=True) or rig.firstMesh()
+                params["armature"] = rig.armature()
+                params["model_name"] = obj.mmd_root.name or obj.name
+            elif getattr(obj.data, "shape_keys", None):
+                params["mesh"] = obj
+                params["model_name"] = obj.name
+            elif obj.type == "ARMATURE":
+                params["armature"] = obj
+                params["model_name"] = obj.name
+            else:
+                for i in context.selected_objects:
+                    if MMDCamera.isMMDCamera(i):
+                        params["camera"] = i
+                    elif MMDLamp.isMMDLamp(i):
+                        params["lamp"] = i
+
             start_time = time.time()
             vmd_exporter.VMDExporter().export(**params)
             logging.info(" Finished exporting motion in %f seconds.", time.time() - start_time)
-        except Exception as e:
+        except Exception:
+            logging.exception("Error occurred")
             err_msg = traceback.format_exc()
-            logging.error(err_msg)
             self.report({"ERROR"}, err_msg)
-
+        finally:
+            if handler:
+                logger.removeHandler(handler)
         return {"FINISHED"}
 
 
-class ExportVpd(Operator, ExportHelper):
+class ExportVpd(Operator, ExportHelper, PreferencesMixin):
     bl_idname = "mmd_tools_local.export_vpd"
     bl_label = "Export VPD File (.vpd)"
-    bl_description = "Export to VPD file(s) (.vpd)"
-    bl_description = "Export active rig's Action Pose to VPD file(s) (.vpd)"
+    bl_description = "Export active rig's Action Pose to VPD file(s) (.vpd)\nBehavior varies depending on the active object:\n- Active object is the root (cross under the model): exports both armature pose and morphs\n- Active object is the model: exports only morphs\n- Active object is the armature: exports only armature pose"
     bl_options = {"PRESET"}
 
     filename_ext = ".vpd"
@@ -715,6 +1163,14 @@ class ExportVpd(Operator, ExportHelper):
 
         return False
 
+    def invoke(self, context, event):
+        self.load_preferences_on_invoke(context, "default_vpd_export_preset")
+        return super().invoke(context, event)
+
+    def cancel(self, context):
+        self.restore_preferences_on_cancel()
+        return super().cancel(context) if hasattr(super(), "cancel") else None
+
     def draw(self, context):
         layout = self.layout
         layout.prop(self, "scale")
@@ -745,8 +1201,8 @@ class ExportVpd(Operator, ExportHelper):
 
         try:
             vpd_exporter.VPDExporter().export(**params)
-        except Exception as e:
+        except Exception:
+            logging.exception("Error occurred")
             err_msg = traceback.format_exc()
-            logging.error(err_msg)
             self.report({"ERROR"}, err_msg)
         return {"FINISHED"}

--- a/extern_tools/mmd_tools_local/operators/material.py
+++ b/extern_tools/mmd_tools_local/operators/material.py
@@ -1,6 +1,8 @@
 # Copyright 2014 MMD Tools authors
 # This file is part of MMD Tools.
 
+from collections import defaultdict
+
 import bpy
 from bpy.props import BoolProperty, StringProperty
 from bpy.types import Operator
@@ -33,7 +35,7 @@ class ConvertMaterialsForCycles(Operator):
 
     @classmethod
     def poll(cls, context):
-        return next((x for x in context.selected_objects if x.type == "MESH"), None)
+        return any(x.type == "MESH" for x in context.selected_objects)
 
     def draw(self, context):
         layout = self.layout
@@ -43,7 +45,7 @@ class ConvertMaterialsForCycles(Operator):
     def execute(self, context):
         try:
             context.scene.render.engine = "CYCLES"
-        except:
+        except Exception:
             self.report({"ERROR"}, " * Failed to change to Cycles render engine.")
             return {"CANCELLED"}
         for obj in (x for x in context.selected_objects if x.type == "MESH"):
@@ -82,7 +84,7 @@ class ConvertMaterials(Operator):
 
     @classmethod
     def poll(cls, context):
-        return next((x for x in context.selected_objects if x.type == "MESH"), None)
+        return any(x.type == "MESH" for x in context.selected_objects)
 
     def execute(self, context):
         for obj in context.selected_objects:
@@ -91,22 +93,114 @@ class ConvertMaterials(Operator):
             cycles_converter.convertToBlenderShader(obj, use_principled=self.use_principled, clean_nodes=self.clean_nodes, subsurface=self.subsurface)
         return {"FINISHED"}
 
-class ConvertBSDFMaterials(Operator):
-    bl_idname = 'mmd_tools_local.convert_bsdf_materials'
-    bl_label = 'Convert Blender Materials'
-    bl_description = 'Convert materials of selected objects.'
-    bl_options = {'REGISTER', 'UNDO'}
+
+class MergeMaterials(Operator):
+    bl_idname = "mmd_tools_local.merge_materials"
+    bl_label = "Merge Materials"
+    bl_description = "Merge materials with the same texture in selected objects. Only merges materials with exactly one texture node. Materials with no texture or with multiple textures are not merged. Please convert to Blender materials first."
+    bl_options = {"REGISTER", "UNDO"}
 
     @classmethod
     def poll(cls, context):
-        return next((x for x in context.selected_objects if x.type == 'MESH'), None)
+        return any(x.type == "MESH" for x in context.selected_objects)
+
+    def execute(self, context):
+        # Process all selected mesh objects
+        for obj in context.selected_objects:
+            if obj.type != "MESH":
+                continue
+
+            self.merge_materials_for_object(context, obj)
+
+        return {"FINISHED"}
+
+    def merge_materials_for_object(self, context, obj):
+        """Merge materials with same texture for a single object"""
+        if not obj.data.materials:
+            self.report({"INFO"}, f"Object '{obj.name}' has no materials")
+            return
+
+        # Map texture paths to material indices and names
+        texture_to_materials = defaultdict(list)
+
+        # Check each material
+        for i, material in enumerate(obj.data.materials):
+            if not material or not material.use_nodes:
+                continue
+
+            # 1. Check texture node count (must be exactly 1)
+            texture_nodes = [node for node in material.node_tree.nodes if node.type == "TEX_IMAGE"]
+            if len(texture_nodes) != 1:
+                continue
+
+            # 2. Record texture path and material info
+            texture_node = texture_nodes[0]
+            if texture_node.image:
+                texture_path = bpy.path.abspath(texture_node.image.filepath)
+                texture_to_materials[texture_path].append({"index": i, "name": material.name})
+
+        # Find material groups that need merging
+        materials_to_merge = {path: materials for path, materials in texture_to_materials.items() if len(materials) > 1}
+
+        if not materials_to_merge:
+            self.report({"INFO"}, f"No materials to merge in object '{obj.name}'")
+            return
+
+        # Process each texture group
+        context.view_layer.objects.active = obj
+        bpy.ops.object.mode_set(mode="EDIT")
+        merge_details = []
+        for texture_path, materials in materials_to_merge.items():
+            # Use first material as target
+            target_material = materials[0]
+            target_index = target_material["index"]
+            target_name = target_material["name"]
+
+            source_materials = []
+
+            # Reassign faces from other materials to target material
+            for source_material in materials[1:]:
+                source_index = source_material["index"]
+                source_name = source_material["name"]
+                source_materials.append(source_name)
+
+                bpy.ops.mesh.select_all(action="DESELECT")
+                obj.active_material_index = source_index
+                bpy.ops.object.material_slot_select()
+                obj.active_material_index = target_index
+                bpy.ops.object.material_slot_assign()
+
+            # Record merge details
+            texture_name = bpy.path.basename(texture_path)
+            merge_details.append({"texture": texture_name, "target": target_name, "sources": source_materials})
+        bpy.ops.object.mode_set(mode="OBJECT")
+        bpy.ops.object.material_slot_remove_unused()
+
+        merged_count = sum(len(details["sources"]) for details in merge_details)
+        self.report({"INFO"}, f"Object '{obj.name}': Merged {merged_count} materials")
+
+        for details in merge_details:
+            sources_text = ", ".join(details["sources"])
+            self.report({"INFO"}, f"Same Texture '{details['texture']}': Merged materials [{sources_text}] into '{details['target']}'")
+
+
+class ConvertBSDFMaterials(Operator):
+    bl_idname = "mmd_tools_local.convert_bsdf_materials"
+    bl_label = "Convert Blender Materials"
+    bl_description = "Convert materials of selected objects."
+    bl_options = {"REGISTER", "UNDO"}
+
+    @classmethod
+    def poll(cls, context):
+        return any(x.type == "MESH" for x in context.selected_objects)
 
     def execute(self, context):
         for obj in context.selected_objects:
-            if obj.type != 'MESH':
+            if obj.type != "MESH":
                 continue
             cycles_converter.convertToMMDShader(obj)
-        return {'FINISHED'}
+        return {"FINISHED"}
+
 
 class _OpenTextureBase:
     """Create a texture for mmd model material."""
@@ -195,8 +289,7 @@ class MoveMaterialUp(Operator):
     @classmethod
     def poll(cls, context):
         obj = context.active_object
-        valid_mesh = obj and obj.type == "MESH" and obj.mmd_type == "NONE"
-        return valid_mesh and obj.active_material_index > 0
+        return obj is not None and obj.type == "MESH" and obj.mmd_type == "NONE" and obj.active_material_index > 0
 
     def execute(self, context):
         obj = context.active_object
@@ -221,8 +314,7 @@ class MoveMaterialDown(Operator):
     @classmethod
     def poll(cls, context):
         obj = context.active_object
-        valid_mesh = obj and obj.type == "MESH" and obj.mmd_type == "NONE"
-        return valid_mesh and obj.active_material_index < len(obj.material_slots) - 1
+        return obj is not None and obj.type == "MESH" and obj.mmd_type == "NONE" and obj.active_material_index < len(obj.material_slots) - 1
 
     def execute(self, context):
         obj = context.active_object
@@ -365,8 +457,8 @@ class EdgePreviewSetup(Operator):
 
         ng = _NodeGroupUtils(shader)
 
-        node_input = ng.new_node("NodeGroupInput", (-5, 0))
-        node_output = ng.new_node("NodeGroupOutput", (3, 0))
+        ng.new_node("NodeGroupInput", (-5, 0))
+        ng.new_node("NodeGroupOutput", (3, 0))
 
         ############################################################################
         node_color = ng.new_node("ShaderNodeMixRGB", (-1, -1.5))

--- a/extern_tools/mmd_tools_local/operators/misc.py
+++ b/extern_tools/mmd_tools_local/operators/misc.py
@@ -42,7 +42,7 @@ class MoveObject(bpy.types.Operator, utils.ItemMoveOp):
     def set_index(cls, obj, index):
         m = cls.__PREFIX_REGEXP.match(obj.name)
         name = m.group("name") if m else obj.name
-        obj.name = "%s_%s" % (utils.int2base(index, 36, 3), name)
+        obj.name = f"{utils.int2base(index, 36, 3)}_{name}"
 
     @classmethod
     def get_name(cls, obj, prefix=None):
@@ -57,13 +57,13 @@ class MoveObject(bpy.types.Operator, utils.ItemMoveOp):
 
     @classmethod
     def poll(cls, context):
-        return context.active_object
+        return context.active_object is not None
 
     def execute(self, context):
         obj = context.active_object
         objects = self.__get_objects(obj)
         if obj not in objects:
-            self.report({"ERROR"}, 'Can not move object "%s"' % obj.name)
+            self.report({"ERROR"}, f'Can not move object "{obj.name}"')
             return {"CANCELLED"}
 
         objects.sort(key=lambda x: x.name)
@@ -105,7 +105,7 @@ class CleanShapeKeys(bpy.types.Operator):
     def __can_remove(key_block):
         if key_block.relative_key == key_block:
             return False  # Basis
-        for v0, v1 in zip(key_block.relative_key.data, key_block.data):
+        for v0, v1 in zip(key_block.relative_key.data, key_block.data, strict=False):
             if v0.co != v1.co:
                 return False
         return True
@@ -130,7 +130,8 @@ class CleanShapeKeys(bpy.types.Operator):
 
 class SeparateByMaterials(bpy.types.Operator):
     bl_idname = "mmd_tools_local.separate_by_materials"
-    bl_label = "Separate By Materials"
+    bl_label = "Sep by Mat(High Risk)"
+    bl_description = "Separate by Materials (High Risk)\nSeparate the mesh into multiple objects based on materials.\nHIGH RISK & BUGGY: This operation is not reversible and may cause various issues. It splits adjacent geometry by material, and merging later will not reconnect shared edges.\nKnown issues include potential mesh corruption, UV mapping problems, and other unpredictable behaviors. Use with extreme caution and backup your work first."
     bl_options = {"REGISTER", "UNDO"}
 
     clean_shape_keys: bpy.props.BoolProperty(
@@ -139,19 +140,29 @@ class SeparateByMaterials(bpy.types.Operator):
         default=True,
     )
 
+    keep_normals: bpy.props.BoolProperty(
+        name="Keep Normals",
+        default=True,
+    )
+
     @classmethod
     def poll(cls, context):
         obj = context.active_object
-        return obj and obj.type == "MESH"
+        return obj is not None and obj.type == "MESH"
 
     def __separate_by_materials(self, obj):
-        utils.separateByMaterials(obj)
+        utils.separateByMaterials(obj, self.keep_normals)
         if self.clean_shape_keys:
             bpy.ops.mmd_tools_local.clean_shape_keys()
 
     def execute(self, context):
         obj = context.active_object
         root = FnModel.find_root_object(obj)
+
+        # Sep by Mat crashes Blender if used after morph assembly
+        rig = Model(root)
+        rig.morph_slider.unbind()
+
         if root is None:
             self.__separate_by_materials(obj)
         else:
@@ -265,7 +276,8 @@ class ChangeMMDIKLoopFactor(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return FnModel.find_root_object(context.active_object) is not None
+        root = FnModel.find_root_object(context.active_object)
+        return root is not None
 
     def invoke(self, context, event):
         root_object = FnModel.find_root_object(context.active_object)
@@ -288,7 +300,7 @@ class RecalculateBoneRoll(bpy.types.Operator):
     @classmethod
     def poll(cls, context):
         obj = context.active_object
-        return obj and obj.type == "ARMATURE"
+        return obj is not None and obj.type == "ARMATURE"
 
     def invoke(self, context, event):
         vm = context.window_manager

--- a/extern_tools/mmd_tools_local/operators/model.py
+++ b/extern_tools/mmd_tools_local/operators/model.py
@@ -62,7 +62,7 @@ class CleanRiggingObjects(bpy.types.Operator):
 class BuildRig(bpy.types.Operator):
     bl_idname = "mmd_tools_local.build_rig"
     bl_label = "Build Rig"
-    bl_description = "Translate physics of selected object into format usable by Blender"
+    bl_description = "Translate physics of selected object into format usable by Blender\n\nWarning: May cause crashes and performance issues. Consider using mmdbridge instead for better stability and accurate physics simulation."
     bl_options = {"REGISTER", "UNDO", "INTERNAL"}
 
     non_collision_distance_scale: bpy.props.FloatProperty(
@@ -190,36 +190,6 @@ class SetupBoneLocalAxes(bpy.types.Operator):
         return {"FINISHED"}
 
 
-class AddMissingVertexGroupsFromBones(bpy.types.Operator):
-    bl_idname = "mmd_tools_local.add_missing_vertex_groups_from_bones"
-    bl_label = "Add Missing Vertex Groups from Bones"
-    bl_description = "Add the missing vertex groups to the selected mesh"
-    bl_options = {"REGISTER", "UNDO"}
-
-    search_in_all_meshes: bpy.props.BoolProperty(
-        name="Search in all meshes",
-        description="Search for vertex groups in all meshes",
-        default=False,
-    )
-
-    @classmethod
-    def poll(cls, context: bpy.types.Context):
-        return FnModel.find_root_object(context.active_object) is not None
-
-    def execute(self, context: bpy.types.Context):
-        active_object: bpy.types.Object = context.active_object
-        root_object = FnModel.find_root_object(active_object)
-        assert root_object is not None
-
-        bone_order_mesh_object = FnModel.find_bone_order_mesh_object(root_object)
-        if bone_order_mesh_object is None:
-            return {"CANCELLED"}
-
-        FnModel.add_missing_vertex_groups_from_bones(root_object, bone_order_mesh_object, self.search_in_all_meshes)
-
-        return {"FINISHED"}
-
-
 class CreateMMDModelRoot(bpy.types.Operator):
     bl_idname = "mmd_tools_local.create_mmd_model_root_object"
     bl_label = "Create a MMD Model Root Object"
@@ -303,7 +273,7 @@ class ConvertToMMDModel(bpy.types.Operator):
     @classmethod
     def poll(cls, context):
         obj = context.active_object
-        return obj and obj.type == "ARMATURE" and obj.mode != "EDIT"
+        return obj is not None and obj.type == "ARMATURE" and obj.mode != "EDIT"
 
     def invoke(self, context, event):
         vm = context.window_manager
@@ -448,7 +418,9 @@ class AssembleAll(bpy.types.Operator):
             rig.build()
             rig.morph_slider.bind()
 
-            with context.temp_override(selected_objects=[active_object]):
+            mesh_objects = list(FnModel.iterate_mesh_objects(root_object))
+            FnModel.attach_mesh_objects(root_object, mesh_objects, add_armature_modifier=True)
+            with context.temp_override(selected_objects=mesh_objects):
                 bpy.ops.mmd_tools_local.sdef_bind()
             root_object.mmd_root.use_property_driver = True
 

--- a/extern_tools/mmd_tools_local/operators/model_edit.py
+++ b/extern_tools/mmd_tools_local/operators/model_edit.py
@@ -7,18 +7,21 @@ from typing import Dict, List, Optional, Set
 
 import bmesh
 import bpy
+import numpy as np
+from mathutils import Matrix
 
 from ..bpyutils import FnContext, select_object
 from ..core.model import FnModel, Model
 
 
-class MessageException(Exception):
-    """Class for error with message."""
+class NoModelSelectedError(Exception):
+    """Raised when no MMD model is selected."""
 
 
 class ModelJoinByBonesOperator(bpy.types.Operator):
     bl_idname = "mmd_tools_local.model_join_by_bones"
     bl_label = "Model Join by Bones"
+    bl_description = "Join multiple MMD models into one.\n\nWARNING: To align models before joining, only adjust the root (cross under the model) transformation. Do not move armatures, meshes, rigid bodies, or joints directly as they will not move together.\n\nIMPORTANT: Don't use any of the 'Assembly' functions before using this function. This function requires the models to be in a clean state."
     bl_options = {"REGISTER", "UNDO"}
 
     join_type: bpy.props.EnumProperty(
@@ -54,7 +57,7 @@ class ModelJoinByBonesOperator(bpy.types.Operator):
     def execute(self, context: bpy.types.Context):
         try:
             self.join(context)
-        except MessageException as ex:
+        except NoModelSelectedError as ex:
             self.report(type={"ERROR"}, message=str(ex))
             return {"CANCELLED"}
 
@@ -68,22 +71,25 @@ class ModelJoinByBonesOperator(bpy.types.Operator):
         child_root_objects.remove(parent_root_object)
 
         if parent_root_object is None or len(child_root_objects) == 0:
-            raise MessageException("No MMD Models selected")
+            raise NoModelSelectedError("No MMD Models selected")
 
         # Save original active_layer_collection
         orig_active_layer_collection = context.view_layer.active_layer_collection
-        
+
         # Find layer collection containing parent_root_object and set it as active
         layer_collection = FnContext.find_user_layer_collection_by_object(context, parent_root_object)
         if layer_collection:
             context.view_layer.active_layer_collection = layer_collection
-        
+
         # Execute the join operation
         FnModel.join_models(parent_root_object, child_root_objects)
-        
+
         # Restore original active_layer_collection
         context.view_layer.active_layer_collection = orig_active_layer_collection
 
+        bpy.ops.object.mode_set(mode="OBJECT")
+        parent_armature_object = FnModel.find_armature_object(parent_root_object)
+        FnContext.set_active_and_select_single_object(context, parent_armature_object)
         bpy.ops.object.mode_set(mode="EDIT")
         bpy.ops.armature.parent_set(type="OFFSET")
 
@@ -103,6 +109,7 @@ class ModelJoinByBonesOperator(bpy.types.Operator):
 class ModelSeparateByBonesOperator(bpy.types.Operator):
     bl_idname = "mmd_tools_local.model_separate_by_bones"
     bl_label = "Model Separate by Bones"
+    bl_description = "Separate MMD model into multiple models based on selected bones.\n\nWARNING: This operation will split meshes, armatures, rigid bodies and joints. To move models before separating, only adjust the root (cross under the model) transformation. Do not move armatures, meshes, rigid bodies, or joints directly before separating as they will not move together.\n\nIMPORTANT: Don't use any of the 'Assembly' functions before using this function. This function requires the model to be in a clean state."
     bl_options = {"REGISTER", "UNDO"}
 
     separate_armature: bpy.props.BoolProperty(name="Separate Armature", default=True)
@@ -141,7 +148,7 @@ class ModelSeparateByBonesOperator(bpy.types.Operator):
     def execute(self, context: bpy.types.Context):
         try:
             self.separate(context)
-        except MessageException as ex:
+        except NoModelSelectedError as ex:
             self.report(type={"ERROR"}, message=str(ex))
             return {"CANCELLED"}
 
@@ -155,38 +162,63 @@ class ModelSeparateByBonesOperator(bpy.types.Operator):
 
         bpy.ops.object.mode_set(mode="EDIT")
         root_bones: Set[bpy.types.EditBone] = set(context.selected_bones)
-
         if self.include_descendant_bones:
             original_active_bone = context.active_bone
             for edit_bone in root_bones:
-                context.object.data.edit_bones.active = edit_bone
+                context.active_object.data.edit_bones.active = edit_bone
                 bpy.ops.armature.select_similar(type="CHILDREN", threshold=0.1)
+            self._select_related_ik_bones(target_armature_object)
             if original_active_bone:
-                context.object.data.edit_bones.active = original_active_bone
+                context.active_object.data.edit_bones.active = original_active_bone
 
         separate_bones: Dict[str, bpy.types.EditBone] = {b.name: b for b in context.selected_bones}
         deform_bones: Dict[str, bpy.types.EditBone] = {b.name: b for b in target_armature_object.data.edit_bones if b.use_deform}
-
         mmd_root_object: bpy.types.Object = FnModel.find_root_object(context.active_object)
         mmd_model = Model(mmd_root_object)
         mmd_model_mesh_objects: List[bpy.types.Object] = list(mmd_model.meshes())
-
-        mmd_model_mesh_objects = list(self.select_weighted_vertices(mmd_model_mesh_objects, separate_bones, deform_bones, weight_threshold).keys())
-
-        # separate armature bones
-        separate_armature_object: Optional[bpy.types.Object]
-        if self.separate_armature:
-            target_armature_object.select_set(True)
-            bpy.ops.armature.separate()
-            separate_armature_object = next(iter([a for a in context.selected_objects if a != target_armature_object]), None)
+        mmd_model_mesh_objects = list(self._select_weighted_vertices(mmd_model_mesh_objects, separate_bones, deform_bones, weight_threshold).keys())
         bpy.ops.object.mode_set(mode="OBJECT")
 
-        # collect separate rigid bodies
+        # Store original transform matrix for root object
+        original_matrix_world = mmd_root_object.matrix_world.copy()
+        mmd_root_object.matrix_world = Matrix.Identity(4)
+
+        # Reset object visibility
+        FnContext.set_active_and_select_single_object(context, mmd_root_object)
+        bpy.ops.mmd_tools_local.reset_object_visibility()
+
+        # Clean additional transform
+        FnContext.set_active_and_select_single_object(context, mmd_root_object)
+        bpy.ops.mmd_tools_local.clean_additional_transform()
+
+        # Create new separate model first
+        separate_model: Model = Model.create(mmd_root_object.mmd_root.name, mmd_root_object.mmd_root.name_e, mmd_scale, obj_name=mmd_root_object.name, add_root_bone=False)
+        separate_model.initialDisplayFrames()
+        separate_root_object = separate_model.rootObject()
+        separate_root_object.matrix_world = mmd_root_object.matrix_world
+        separate_model_armature_object = separate_model.armature()
+
+        # Now separate armature bones from original model
+        separate_armature_object: Optional[bpy.types.Object] = None
+        if self.separate_armature:
+            FnContext.set_active_and_select_single_object(context, target_armature_object)
+            bpy.ops.object.mode_set(mode="EDIT")
+
+            # Re-select the bones that should be separated (they might have been deselected)
+            for bone_name in separate_bones.keys():
+                if bone_name in target_armature_object.data.edit_bones:
+                    target_armature_object.data.edit_bones[bone_name].select = True
+
+            bpy.ops.armature.separate()
+            separate_armature_object = next(iter([a for a in context.selected_objects if a != target_armature_object and a.type == "ARMATURE"]), None)
+        bpy.ops.object.mode_set(mode="OBJECT")
+
+        # Collect separate rigid bodies
         separate_rigid_bodies: Set[bpy.types.Object] = {rigid_body_object for rigid_body_object in mmd_model.rigidBodies() if rigid_body_object.mmd_rigid.bone in separate_bones}
 
         boundary_joint_owner_condition = any if self.boundary_joint_owner == "DESTINATION" else all
 
-        # collect separate joints
+        # Collect separate joints
         separate_joints: Set[bpy.types.Object] = {
             joint_object
             for joint_object in mmd_model.joints()
@@ -194,45 +226,83 @@ class ModelSeparateByBonesOperator(bpy.types.Operator):
                 [
                     joint_object.rigid_body_constraint.object1 in separate_rigid_bodies,
                     joint_object.rigid_body_constraint.object2 in separate_rigid_bodies,
-                ]
+                ],
             )
         }
 
-        separate_mesh_objects: Set[bpy.types.Object]
-        model2separate_mesh_objects: Dict[bpy.types.Object, bpy.types.Object]
-        if len(mmd_model_mesh_objects) == 0:
-            separate_mesh_objects = set()
-            model2separate_mesh_objects = dict()
-        else:
-            # select meshes
+        separate_mesh_objects: List[bpy.types.Object] = []
+        model2separate_mesh_objects: Dict[bpy.types.Object, bpy.types.Object] = {}
+        if len(mmd_model_mesh_objects) > 0:
+            # Find a single unique attribute name that doesn't conflict with any existing attributes.
+            all_attribute_names = {attr.name for obj in mmd_model_mesh_objects for attr in obj.data.attributes}
+            temp_normal_name = "mmd_temp_normal"
+            i = 0
+            while temp_normal_name in all_attribute_names:
+                temp_normal_name = f"mmd_temp_normal.{i:03d}"
+                i += 1
+
+            # Backup custom normals to the unique temporary attribute.
+            for mesh_obj in mmd_model_mesh_objects:
+                mesh_data = mesh_obj.data
+                existing_custom_normal = mesh_data.attributes.get("custom_normal")
+                if not existing_custom_normal:
+                    continue
+
+                if existing_custom_normal.data_type == "INT16_2D":
+                    normals_data = np.empty(len(mesh_data.loops) * 2, dtype=np.int16)
+                    existing_custom_normal.data.foreach_get("value", normals_data)
+                    temp_normal_attr = mesh_data.attributes.new(temp_normal_name, "INT16_2D", "CORNER")
+                    temp_normal_attr.data.foreach_set("value", normals_data)
+                else:
+                    raise TypeError(f"Unsupported custom_normal data type: '{existing_custom_normal.data_type}'. Supported types: 'INT16_2D'")
+
+            # Select meshes
             obj: bpy.types.Object
             for obj in context.view_layer.objects:
                 obj.select_set(obj in mmd_model_mesh_objects)
             context.view_layer.objects.active = mmd_model_mesh_objects[0]
 
-            # separate mesh by selected vertices
+            # Separate mesh by selected vertices
             bpy.ops.object.mode_set(mode="EDIT")
             bpy.ops.mesh.separate(type="SELECTED")
-            separate_mesh_objects: List[bpy.types.Object] = [m for m in context.selected_objects if m.type == "MESH" and m not in mmd_model_mesh_objects]
+            separate_mesh_objects = [m for m in context.selected_objects if m.type == "MESH" and m not in mmd_model_mesh_objects]
             bpy.ops.object.mode_set(mode="OBJECT")
 
-            model2separate_mesh_objects = dict(zip(mmd_model_mesh_objects, separate_mesh_objects))
+            model2separate_mesh_objects = dict(zip(mmd_model_mesh_objects, separate_mesh_objects, strict=False))
 
-        separate_model: Model = Model.create(mmd_root_object.mmd_root.name, mmd_root_object.mmd_root.name_e, mmd_scale, add_root_bone=False)
+            # Restore normal data for all meshes (original and separated)
+            all_mesh_objects = list(mmd_model_mesh_objects) + list(separate_mesh_objects)
+            for mesh_obj in all_mesh_objects:
+                mesh_data = mesh_obj.data
+                temp_normal_attr = mesh_data.attributes.get(temp_normal_name)
+                if not temp_normal_attr:
+                    continue
 
-        separate_model.initialDisplayFrames()
-        separate_root_object = separate_model.rootObject()
-        separate_root_object.matrix_world = mmd_root_object.matrix_world
-        separate_model_armature_object = separate_model.armature()
+                try:
+                    if temp_normal_attr.data_type == "INT16_2D":
+                        normals_data = np.empty(len(mesh_data.loops) * 2, dtype=np.int16)
+                        temp_normal_attr.data.foreach_get("value", normals_data)
+                        custom_normal_attr = mesh_data.attributes.get("custom_normal")
+                        if not custom_normal_attr:
+                            custom_normal_attr = mesh_data.attributes.new("custom_normal", "INT16_2D", "CORNER")
+                        custom_normal_attr.data.foreach_set("value", normals_data)
+                    else:
+                        raise TypeError(f"Unsupported custom_normal data type: '{temp_normal_attr.data_type}'. Supported types: 'INT16_2D'")
+                finally:
+                    mesh_data.attributes.remove(temp_normal_attr)
 
-        if self.separate_armature:
+        if self.separate_armature and separate_armature_object:
+            separate_armature_data = separate_armature_object.data
             with select_object(separate_model_armature_object, objects=[separate_model_armature_object, separate_armature_object]):
                 bpy.ops.object.join()
+            if separate_armature_data.users == 0:
+                bpy.data.armatures.remove(separate_armature_data)
 
-        with select_object(separate_model_armature_object, objects=[separate_model_armature_object] + list(separate_mesh_objects)):
-            bpy.ops.object.parent_set(type="OBJECT", keep_transform=True)
+        if separate_mesh_objects:
+            with select_object(separate_model_armature_object, objects=[separate_model_armature_object] + separate_mesh_objects):
+                bpy.ops.object.parent_set(type="OBJECT", keep_transform=True)
 
-        # replace mesh armature modifier.object
+        # Replace mesh armature modifier.object
         for separate_mesh in separate_mesh_objects:
             armature_modifier: Optional[bpy.types.ArmatureModifier] = next(iter([m for m in separate_mesh.modifiers if m.type == "ARMATURE"]), None)
             if armature_modifier is None:
@@ -240,13 +310,15 @@ class ModelSeparateByBonesOperator(bpy.types.Operator):
 
             armature_modifier.object = separate_model_armature_object
 
-        with select_object(separate_model.rigidGroupObject(), objects=[separate_model.rigidGroupObject()] + list(separate_rigid_bodies)):
-            bpy.ops.object.parent_set(type="OBJECT", keep_transform=True)
+        if separate_rigid_bodies:
+            with select_object(separate_model.rigidGroupObject(), objects=[separate_model.rigidGroupObject()] + list(separate_rigid_bodies)):
+                bpy.ops.object.parent_set(type="OBJECT", keep_transform=True)
 
-        with select_object(separate_model.jointGroupObject(), objects=[separate_model.jointGroupObject()] + list(separate_joints)):
-            bpy.ops.object.parent_set(type="OBJECT", keep_transform=True)
+        if separate_joints:
+            with select_object(separate_model.jointGroupObject(), objects=[separate_model.jointGroupObject()] + list(separate_joints)):
+                bpy.ops.object.parent_set(type="OBJECT", keep_transform=True)
 
-        # move separate objects to new collection
+        # Move separate objects to new collection
         mmd_layer_collection = FnContext.find_user_layer_collection_by_object(context, mmd_root_object)
         assert mmd_layer_collection is not None
 
@@ -255,23 +327,36 @@ class ModelSeparateByBonesOperator(bpy.types.Operator):
 
         if mmd_layer_collection.name != separate_layer_collection.name:
             for separate_object in itertools.chain(separate_mesh_objects, separate_rigid_bodies, separate_joints):
-                separate_layer_collection.collection.objects.link(separate_object)
-                mmd_layer_collection.collection.objects.unlink(separate_object)
+                if separate_object.name not in separate_layer_collection.collection.objects:
+                    separate_layer_collection.collection.objects.link(separate_object)
+                if separate_object.name in mmd_layer_collection.collection.objects:
+                    mmd_layer_collection.collection.objects.unlink(separate_object)
 
         FnModel.copy_mmd_root(
             separate_root_object,
             mmd_root_object,
             overwrite=True,
             replace_name2values={
-                # replace related_mesh property values
-                "related_mesh": {m.data.name: s.data.name for m, s in model2separate_mesh_objects.items()}
+                # Replace related_mesh property values
+                "related_mesh": {m.data.name: s.data.name for m, s in model2separate_mesh_objects.items()},
             },
         )
 
+        # Apply additional transform
+        FnContext.set_active_and_select_single_object(context, mmd_root_object)
+        bpy.ops.mmd_tools_local.apply_additional_transform()
+        FnContext.set_active_and_select_single_object(context, separate_root_object)
+        bpy.ops.mmd_tools_local.apply_additional_transform()
+
+        # Restore original transform matrix for root object
+        mmd_root_object.matrix_world = original_matrix_world
+        separate_root_object.matrix_world = original_matrix_world
+
+        # End state
         FnContext.set_active_and_select_single_object(context, separate_root_object)
 
-    def select_weighted_vertices(self, mmd_model_mesh_objects: List[bpy.types.Object], separate_bones: Dict[str, bpy.types.EditBone], deform_bones: Dict[str, bpy.types.EditBone], weight_threshold: float) -> Dict[bpy.types.Object, int]:
-        mesh2selected_vertex_count: Dict[bpy.types.Object, int] = dict()
+    def _select_weighted_vertices(self, mmd_model_mesh_objects: List[bpy.types.Object], separate_bones: Dict[str, bpy.types.EditBone], deform_bones: Dict[str, bpy.types.EditBone], weight_threshold: float) -> Dict[bpy.types.Object, int]:
+        mesh2selected_vertex_count: Dict[bpy.types.Object, int] = {}
         target_bmesh: bmesh.types.BMesh = bmesh.new()
         for mesh_object in mmd_model_mesh_objects:
             vertex_groups: bpy.types.VertexGroups = mesh_object.vertex_groups
@@ -310,3 +395,61 @@ class ModelSeparateByBonesOperator(bpy.types.Operator):
             target_bmesh.clear()
 
         return mesh2selected_vertex_count
+
+    def _select_related_ik_bones(self, armature_object: bpy.types.Object) -> None:
+        """
+        Expand the current selection to include any full IK systems that are
+        partially selected. An IK system includes the chain bones, the IK
+        target bone, and the pole target bone.
+
+        NOTE: This method operates entirely in EDIT mode and avoids mode switching
+        to prevent segmentation faults.
+        """
+        edit_bones = armature_object.data.edit_bones
+        initial_selection_names = {b.name for b in edit_bones if b.select}
+
+        # Access pose bones constraints directly without mode switching
+        pose_bones = armature_object.pose.bones
+
+        # Find all complete IK systems
+        ik_systems = []
+
+        for pose_bone in pose_bones:
+            for constraint in pose_bone.constraints:
+                if constraint.type == "IK":
+                    # Build the set of bones in this IK system
+                    system_bones = {pose_bone.name}
+
+                    # Add the main IK Target bone
+                    if constraint.target and constraint.subtarget:
+                        system_bones.add(constraint.subtarget)
+
+                    # Add the Pole Target bone
+                    if constraint.pole_target and constraint.pole_subtarget:
+                        system_bones.add(constraint.pole_subtarget)
+
+                    # Add all other bones in the IK chain
+                    current_bone_name = pose_bone.name
+                    chain_count = constraint.chain_count
+
+                    # Walk up the parent chain
+                    for _ in range(chain_count - 1):
+                        if current_bone_name not in edit_bones:
+                            break
+                        current_bone = edit_bones[current_bone_name]
+                        if not current_bone.parent:
+                            break
+                        current_bone_name = current_bone.parent.name
+                        system_bones.add(current_bone_name)
+
+                    ik_systems.append(system_bones)
+
+        # Expand selection to include any related, full IK systems
+        final_selection_names = set(initial_selection_names)
+        for system in ik_systems:
+            if not system.isdisjoint(initial_selection_names):
+                final_selection_names.update(system)
+
+        # Apply the final selection
+        for bone in edit_bones:
+            bone.select = bone.name in final_selection_names

--- a/extern_tools/mmd_tools_local/operators/model_validation.py
+++ b/extern_tools/mmd_tools_local/operators/model_validation.py
@@ -38,14 +38,22 @@ def log_message(prefix, message, level="INFO"):
         message (str): Message to log.
         level (str): Log level ('INFO', 'WARNING', 'ERROR').
     """
-    level = level.upper()
-    for line in message.split("\n"):
-        if level == "WARNING":
-            logging.warning("[%s] %s", prefix, line)
-        elif level == "ERROR":
-            logging.error("[%s] %s", prefix, line)
-        else:  # Default to INFO
-            logging.info("[%s] %s", prefix, line)
+    logger = logging.getLogger()
+    original_level = logger.level
+    # Set to DEBUG to ensure all messages are output.
+    logger.setLevel(logging.DEBUG)
+
+    try:
+        level = level.upper()
+        for line in message.split("\n"):
+            if level == "WARNING":
+                logging.warning("[%s] %s", prefix, line)
+            elif level == "ERROR":
+                logging.error("[%s] %s", prefix, line)
+            else:  # Default to INFO
+                logging.info("[%s] %s", prefix, line)
+    finally:
+        logger.setLevel(original_level)
 
 
 class MMDModelValidateBones(Operator):
@@ -87,13 +95,13 @@ class MMDModelValidateBones(Operator):
             else:
                 bone_names.add(name_j)
 
-            # Check Shift-JIS encoding and length
+            # Check cp932 encoding and length
             try:
-                encoded_name = name_j.encode("shift_jis")
+                encoded_name = name_j.encode("cp932")
                 if len(encoded_name) > 15:
-                    issues.append(f"Bone '{name_j}' exceeds 15 bytes in ShiftJIS")
+                    issues.append(f"Bone '{name_j}' exceeds 15 bytes in cp932")
             except UnicodeEncodeError:
-                issues.append(f"Bone '{name_j}' contains characters that cannot be encoded in ShiftJIS")
+                issues.append(f"Bone '{name_j}' contains characters that cannot be encoded in cp932")
 
         results = "\n".join(issues) or "No bone issues found"
         context.scene.mmd_validation_results = results
@@ -134,11 +142,11 @@ class MMDModelValidateMorphs(Operator):
                     morph_names.add(morph.name)
 
                 try:
-                    encoded_name = morph.name.encode("shift_jis")
+                    encoded_name = morph.name.encode("cp932")
                     if len(encoded_name) > 15:
-                        issues.append(f"Morph '{morph.name}' name too long (exceeds 15 bytes in ShiftJIS)")
+                        issues.append(f"Morph '{morph.name}' name too long (exceeds 15 bytes in cp932)")
                 except UnicodeEncodeError:
-                    issues.append(f"Morph '{morph.name}' contains characters that cannot be encoded in ShiftJIS")
+                    issues.append(f"Morph '{morph.name}' contains characters that cannot be encoded in cp932")
 
         results = "\n".join(issues) or "No morph issues found"
         context.scene.mmd_validation_results = results
@@ -275,11 +283,11 @@ class MMDModelFixBoneIssues(Operator):
 
             original_name = pose_bone.mmd_bone.name_j
 
-            # Check if name is too long in ShiftJIS
+            # Check if name is too long in cp932
             name_too_long = False
             has_non_japanese = False
             try:
-                encoded = original_name.encode("shift_jis")
+                encoded = original_name.encode("cp932")
                 name_too_long = len(encoded) > 15
             except UnicodeEncodeError:
                 has_non_japanese = True
@@ -298,7 +306,7 @@ class MMDModelFixBoneIssues(Operator):
             new_name = ""
             for char in converted_name:
                 try:
-                    char.encode("shift_jis")
+                    char.encode("cp932")
                     new_name += char
                 except UnicodeEncodeError:
                     continue
@@ -310,7 +318,7 @@ class MMDModelFixBoneIssues(Operator):
             # Then truncate from right if still too long
             while new_name:
                 try:
-                    encoded = new_name.encode("shift_jis")
+                    encoded = new_name.encode("cp932")
                     if len(encoded) <= 13:  # Leave room for suffixes
                         break
                     new_name = new_name[:-1]
@@ -323,7 +331,7 @@ class MMDModelFixBoneIssues(Operator):
                 for suffix in range(2, 100):
                     test_name = f"{new_name}{suffix}"
                     try:
-                        encoded_test = test_name.encode("shift_jis")
+                        encoded_test = test_name.encode("cp932")
                         if len(encoded_test) <= 15 and test_name not in processed_names:
                             final_name = test_name
                             break
@@ -372,11 +380,11 @@ class MMDModelFixMorphIssues(Operator):
             for morph in morphs:
                 original_name = morph.name
 
-                # Check if name is too long in ShiftJIS
+                # Check if name is too long in cp932
                 name_too_long = False
                 has_non_japanese = False
                 try:
-                    encoded = original_name.encode("shift_jis")
+                    encoded = original_name.encode("cp932")
                     name_too_long = len(encoded) > 15
                 except UnicodeEncodeError:
                     has_non_japanese = True
@@ -393,7 +401,7 @@ class MMDModelFixMorphIssues(Operator):
                 new_name = ""
                 for char in converted_name:
                     try:
-                        char.encode("shift_jis")
+                        char.encode("cp932")
                         new_name += char
                     except UnicodeEncodeError:
                         continue
@@ -405,7 +413,7 @@ class MMDModelFixMorphIssues(Operator):
                 # Then truncate from right if still too long
                 while new_name:
                     try:
-                        encoded = new_name.encode("shift_jis")
+                        encoded = new_name.encode("cp932")
                         if len(encoded) <= 14:
                             break
                         new_name = new_name[:-1]
@@ -418,7 +426,7 @@ class MMDModelFixMorphIssues(Operator):
                     for suffix in range(2, 10):  # Plenty of suffixes
                         test_name = f"{new_name}{suffix}"
                         try:
-                            encoded_test = test_name.encode("shift_jis")
+                            encoded_test = test_name.encode("cp932")
                             if len(encoded_test) <= 15 and test_name not in processed_names:
                                 final_name = test_name
                                 break
@@ -701,7 +709,7 @@ class MMDModelFixTextureIssues(Operator):
 
         # Clean up unused image blocks with missing files
         removed_images = []
-        for img in bpy.data.images:
+        for img in reversed(bpy.data.images):
             if img.users == 0 and (not os.path.exists(bpy.path.abspath(img.filepath)) and not img.packed_file):
                 removed_images.append(f"Removed unused image block: '{img.name}'")
                 bpy.data.images.remove(img)

--- a/extern_tools/mmd_tools_local/operators/morph.py
+++ b/extern_tools/mmd_tools_local/operators/morph.py
@@ -1,6 +1,7 @@
 # Copyright 2015 MMD Tools authors
 # This file is part of MMD Tools.
 
+from collections import namedtuple
 from typing import Optional, cast
 
 import bpy
@@ -19,7 +20,7 @@ def divide_vector_components(vec1, vec2):
     if len(vec1) != len(vec2):
         raise ValueError("Vectors should have the same number of components")
     result = []
-    for v1, v2 in zip(vec1, vec2):
+    for v1, v2 in zip(vec1, vec2, strict=False):
         if v2 == 0:
             if v1 == 0:
                 v2 = 1  # If we have a 0/0 case we change the divisor to 1
@@ -33,13 +34,13 @@ def multiply_vector_components(vec1, vec2):
     if len(vec1) != len(vec2):
         raise ValueError("Vectors should have the same number of components")
     result = []
-    for v1, v2 in zip(vec1, vec2):
+    for v1, v2 in zip(vec1, vec2, strict=False):
         result.append(v1 * v2)
     return result
 
 
 def special_division(n1, n2):
-    """This function returns 0 in case of 0/0. If non-zero divided by zero case is found, an Exception is raised"""
+    """Return 0 in case of 0/0. If non-zero divided by zero case is found, an Exception is raised"""
     if n2 == 0:
         if n1 == 0:
             n2 = 1
@@ -104,7 +105,7 @@ class RemoveMorph(bpy.types.Operator):
 class MoveMorph(bpy.types.Operator, ItemMoveOp):
     bl_idname = "mmd_tools_local.morph_move"
     bl_label = "Move Morph"
-    bl_description = "Move active morph item up/down in the list"
+    bl_description = "Move active morph item up/down in the list. This will not affect the morph order in exported PMX files (use Display Panel order instead)."
     bl_options = {"REGISTER", "UNDO", "INTERNAL"}
 
     def execute(self, context):
@@ -137,7 +138,7 @@ class CopyMorph(bpy.types.Operator):
         if morph is None:
             return {"CANCELLED"}
 
-        name_orig, name_tmp = morph.name, "_tmp%s" % str(morph.as_pointer())
+        name_orig, name_tmp = morph.name, f"_tmp{str(morph.as_pointer())}"
 
         if morph_type.startswith("vertex"):
             for obj in FnModel.iterate_mesh_objects(root):
@@ -163,10 +164,7 @@ class OverwriteBoneMorphsFromActionPose(bpy.types.Operator):
     @classmethod
     def poll(cls, context):
         root = FnModel.find_root_object(context.active_object)
-        if root is None:
-            return False
-
-        return root.mmd_root.active_morph_type == "bone_morphs"
+        return root is not None and root.mmd_root.active_morph_type == "bone_morphs"
 
     def execute(self, context):
         root = FnModel.find_root_object(context.active_object)
@@ -240,7 +238,7 @@ class RemoveMorphOffset(bpy.types.Operator):
                 for obj in FnModel.iterate_mesh_objects(root):
                     FnMorph.remove_shape_key(obj, morph.name)
                 return {"FINISHED"}
-            elif morph_type.startswith("uv"):
+            if morph_type.startswith("uv"):
                 if morph.data_type == "VERTEX_GROUP":
                     for obj in FnModel.iterate_mesh_objects(root):
                         FnMorph.store_uv_morph_data(obj, morph)
@@ -367,12 +365,12 @@ class CreateWorkMaterial(bpy.types.Operator):
 
         base_mat = meshObj.data.materials.get(mat_data.material, None)
         if base_mat is None:
-            self.report({"ERROR"}, 'Material "%s" not found' % mat_data.material)
+            self.report({"ERROR"}, f'Material "{mat_data.material}" not found')
             return {"CANCELLED"}
 
         work_mat_name = base_mat.name + "_temp"
         if work_mat_name in bpy.data.materials:
-            self.report({"ERROR"}, 'Temporary material "%s" is in use' % work_mat_name)
+            self.report({"ERROR"}, f'Temporary material "{work_mat_name}" is in use')
             return {"CANCELLED"}
 
         work_mat = base_mat.copy()
@@ -424,14 +422,14 @@ class ClearTempMaterials(bpy.types.Operator):
         assert root is not None
         for meshObj in FnModel.iterate_mesh_objects(root):
 
-            def __pre_remove(m):
+            def __pre_remove(m, meshObj=meshObj):
                 if m and "_temp" in m.name:
                     base_mat_name = m.name.split("_temp")[0]
                     try:
                         FnMaterial.swap_materials(meshObj, m.name, base_mat_name)
                         return True
                     except MaterialNotFoundError:
-                        self.report({"WARNING"}, "Base material for %s was not found" % m.name)
+                        self.report({"WARNING"}, f"Base material for {m.name} was not found")
                 return False
 
             FnMaterial.clean_materials(meshObj, can_remove=__pre_remove)
@@ -455,7 +453,7 @@ class ViewBoneMorph(bpy.types.Operator):
         for morph_data in morph.data:
             p_bone: Optional[bpy.types.PoseBone] = armature.pose.bones.get(morph_data.bone, None)
             if p_bone:
-                p_bone.bone.select = True
+                p_bone.select = True
                 mtx = (p_bone.matrix_basis.to_3x3() @ Quaternion(*morph_data.rotation.to_axis_angle()).to_matrix()).to_4x4()
                 mtx.translation = p_bone.location + morph_data.location
                 p_bone.matrix_basis = mtx
@@ -499,9 +497,9 @@ class ApplyBoneMorph(bpy.types.Operator):
                 item.bone = p_bone.name
                 item.location = p_bone.location
                 item.rotation = p_bone.rotation_quaternion if p_bone.rotation_mode == "QUATERNION" else p_bone.matrix_basis.to_quaternion()
-                p_bone.bone.select = True
+                p_bone.select = True
             else:
-                p_bone.bone.select = False
+                p_bone.select = False
         return {"FINISHED"}
 
 
@@ -590,11 +588,11 @@ class ViewUVMorph(bpy.types.Operator):
 
         selected = meshObj.select_get()
         with bpyutils.select_object(meshObj):
-            mesh = cast(bpy.types.Mesh, meshObj.data)
+            mesh = cast("bpy.types.Mesh", meshObj.data)
             morph = mmd_root.uv_morphs[mmd_root.active_morph]
             uv_textures = mesh.uv_layers
 
-            base_uv_layers = [l for l in mesh.uv_layers if not l.name.startswith("_")]
+            base_uv_layers = [layer for layer in mesh.uv_layers if not layer.name.startswith("_")]
             if morph.uv_index >= len(base_uv_layers):
                 self.report({"ERROR"}, "Invalid uv index: %d" % morph.uv_index)
                 return {"CANCELLED"}
@@ -604,7 +602,7 @@ class ViewUVMorph(bpy.types.Operator):
                 uv_textures.active = uv_textures[uv_layer_name]
 
             uv_layer_name = uv_textures.active.name
-            uv_tex = uv_textures.new(name="__uv.%s" % uv_layer_name)
+            uv_tex = uv_textures.new(name=f"__uv.{uv_layer_name}")
             if uv_tex is None:
                 self.report({"ERROR"}, "Failed to create a temporary uv layer")
                 return {"CANCELLED"}
@@ -614,10 +612,10 @@ class ViewUVMorph(bpy.types.Operator):
             if len(offsets) > 0:
                 base_uv_data = mesh.uv_layers.active.data
                 temp_uv_data = mesh.uv_layers[uv_tex.name].data
-                for i, l in enumerate(mesh.loops):
-                    select = temp_uv_data[i].select = l.vertex_index in offsets
+                for i, loop in enumerate(mesh.loops):
+                    select = temp_uv_data[i].select = loop.vertex_index in offsets
                     if select:
-                        temp_uv_data[i].uv = base_uv_data[i].uv + offsets[l.vertex_index]
+                        temp_uv_data[i].uv = base_uv_data[i].uv + offsets[loop.vertex_index]
 
             uv_textures.active = uv_tex
             uv_tex.active_render = True
@@ -639,7 +637,7 @@ class ClearUVMorphView(bpy.types.Operator):
         for m in FnModel.iterate_mesh_objects(root):
             mesh = m.data
             uv_textures = getattr(mesh, "uv_textures", mesh.uv_layers)
-            for t in uv_textures:
+            for t in reversed(uv_textures):
                 if t.name.startswith("__uv."):
                     uv_textures.remove(t)
             if len(uv_textures) > 0:
@@ -649,7 +647,7 @@ class ClearUVMorphView(bpy.types.Operator):
             animation_data = mesh.animation_data
             if animation_data:
                 nla_tracks = animation_data.nla_tracks
-                for t in nla_tracks:
+                for t in reversed(nla_tracks):
                     if t.name.startswith("__uv."):
                         nla_tracks.remove(t)
                 if animation_data.action and animation_data.action.name.startswith("__uv."):
@@ -657,7 +655,7 @@ class ClearUVMorphView(bpy.types.Operator):
                 if animation_data.action is None and len(nla_tracks) == 0:
                     mesh.animation_data_clear()
 
-        for act in bpy.data.actions:
+        for act in reversed(bpy.data.actions):
             if act.name.startswith("__uv.") and act.users < 1:
                 bpy.data.actions.remove(act)
         return {"FINISHED"}
@@ -672,10 +670,10 @@ class EditUVMorph(bpy.types.Operator):
     @classmethod
     def poll(cls, context):
         obj = context.active_object
-        if obj.type != "MESH":
+        if obj is None or obj.type != "MESH":
             return False
         active_uv_layer = obj.data.uv_layers.active
-        return active_uv_layer and active_uv_layer.name.startswith("__uv.")
+        return active_uv_layer is not None and active_uv_layer.name.startswith("__uv.")
 
     def execute(self, context):
         obj = context.active_object
@@ -683,7 +681,7 @@ class EditUVMorph(bpy.types.Operator):
 
         selected = meshObj.select_get()
         with bpyutils.select_object(meshObj):
-            mesh = cast(bpy.types.Mesh, meshObj.data)
+            mesh = cast("bpy.types.Mesh", meshObj.data)
             bpy.ops.object.mode_set(mode="EDIT")
             bpy.ops.mesh.select_mode(type="VERT", action="ENABLE")
             bpy.ops.mesh.reveal()  # unhide all vertices
@@ -691,9 +689,9 @@ class EditUVMorph(bpy.types.Operator):
             bpy.ops.object.mode_set(mode="OBJECT")
 
             vertices = mesh.vertices
-            for l, d in zip(mesh.loops, mesh.uv_layers.active.data):
+            for loop, d in zip(mesh.loops, mesh.uv_layers.active.data, strict=False):
                 if d.select:
-                    vertices[l.vertex_index].select = True
+                    vertices[loop.vertex_index].select = True
 
             polygons = mesh.polygons
             polygons.active = getattr(next((p for p in polygons if all(vertices[i].select for i in p.vertices)), None), "index", polygons.active)
@@ -712,10 +710,10 @@ class ApplyUVMorph(bpy.types.Operator):
     @classmethod
     def poll(cls, context):
         obj = context.active_object
-        if obj.type != "MESH":
+        if obj is None or obj.type != "MESH":
             return False
         active_uv_layer = obj.data.uv_layers.active
-        return active_uv_layer and active_uv_layer.name.startswith("__uv.")
+        return active_uv_layer is not None and active_uv_layer.name.startswith("__uv.")
 
     def execute(self, context):
         obj = context.active_object
@@ -725,28 +723,26 @@ class ApplyUVMorph(bpy.types.Operator):
 
         selected = meshObj.select_get()
         with bpyutils.select_object(meshObj):
-            mesh = cast(bpy.types.Mesh, meshObj.data)
+            mesh = cast("bpy.types.Mesh", meshObj.data)
             morph = mmd_root.uv_morphs[mmd_root.active_morph]
 
             base_uv_name = mesh.uv_layers.active.name[5:]
             if base_uv_name not in mesh.uv_layers:
-                self.report({"ERROR"}, ' * UV map "%s" not found' % base_uv_name)
+                self.report({"ERROR"}, f' * UV map "{base_uv_name}" not found')
                 return {"CANCELLED"}
 
             base_uv_data = mesh.uv_layers[base_uv_name].data
             temp_uv_data = mesh.uv_layers.active.data
             axis_type = "ZW" if base_uv_name.startswith("_") else "XY"
 
-            from collections import namedtuple
-
             __OffsetData = namedtuple("OffsetData", "index, offset")
             offsets = {}
             vertices = mesh.vertices
-            for l, i0, i1 in zip(mesh.loops, base_uv_data, temp_uv_data):
-                if vertices[l.vertex_index].select and l.vertex_index not in offsets:
+            for loop, i0, i1 in zip(mesh.loops, base_uv_data, temp_uv_data, strict=False):
+                if vertices[loop.vertex_index].select and loop.vertex_index not in offsets:
                     dx, dy = i1.uv - i0.uv
                     if abs(dx) > 0.0001 or abs(dy) > 0.0001:
-                        offsets[l.vertex_index] = __OffsetData(l.vertex_index, (dx, dy, dx, dy))
+                        offsets[loop.vertex_index] = __OffsetData(loop.vertex_index, (dx, dy, dx, dy))
 
             FnMorph.store_uv_morph_data(meshObj, morph, offsets.values(), axis_type)
             morph.data_type = "VERTEX_GROUP"
@@ -763,11 +759,189 @@ class CleanDuplicatedMaterialMorphs(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return FnModel.find_root_object(context.active_object) is not None
+        root = FnModel.find_root_object(context.active_object)
+        return root is not None
 
     def execute(self, context: bpy.types.Context):
         mmd_root_object = FnModel.find_root_object(context.active_object)
         FnMorph.clean_duplicated_material_morphs(mmd_root_object)
+
+        return {"FINISHED"}
+
+
+class ConvertBoneMorphToVertexMorph(bpy.types.Operator):
+    bl_idname = "mmd_tools_local.convert_bone_morph_to_vertex_morph"
+    bl_label = "Convert To Vertex Morph"
+    bl_description = "Convert a bone morph into a single vertex morph by applying the bone transformations.\nIf a corresponding vertex morph already exists, it will be updated."
+    bl_options = {"REGISTER", "UNDO", "INTERNAL"}
+
+    @classmethod
+    def poll(cls, context):
+        root = FnModel.find_root_object(context.active_object)
+        if root is None:
+            return False
+        mmd_root = root.mmd_root
+        if mmd_root.active_morph_type != "bone_morphs":
+            return False
+        morph = ItemOp.get_by_index(mmd_root.bone_morphs, mmd_root.active_morph)
+        return morph is not None and len(morph.data) > 0
+
+    def execute(self, context):
+        obj = context.active_object
+        root = FnModel.find_root_object(obj)
+        mmd_root = root.mmd_root
+
+        # Get the active bone morph
+        bone_morph = ItemOp.get_by_index(mmd_root.bone_morphs, mmd_root.active_morph)
+        if bone_morph is None:
+            self.report({"ERROR"}, "No active bone morph")
+            return {"CANCELLED"}
+
+        original_name = bone_morph.name
+        target_name = original_name
+
+        # Add 'B' suffix if necessary
+        if not original_name.endswith("B"):
+            bone_morph.name = original_name + "B"
+            target_name = original_name
+        else:
+            # If already has B suffix, use name without B
+            target_name = original_name[:-1]
+
+        try:
+            # Step 1: import
+            from ..core.model import Model
+
+            rig = Model(root)
+
+            # Ensure morph slider is bound
+            bpy.ops.mmd_tools_local.morph_slider_setup(type="BIND")
+
+            # Re-obtain placeholder object
+            placeholder_obj = rig.morph_slider.placeholder()
+            if placeholder_obj is None or placeholder_obj.data.shape_keys is None:
+                self.report({"ERROR"}, "Failed to create morph slider system")
+                return {"CANCELLED"}
+
+            shape_keys = placeholder_obj.data.shape_keys
+            key_blocks = shape_keys.key_blocks
+
+            # Step 2: Check if target bone morph exists
+            current_morph_name = bone_morph.name
+            if current_morph_name not in key_blocks:
+                self.report({"ERROR"}, f"Bone morph '{current_morph_name}' not found in morph sliders")
+                return {"CANCELLED"}
+
+            # Step 3: Save all current morph values
+            original_values = {}
+            for key_block in key_blocks:
+                if key_block.name != "--- morph sliders ---":
+                    original_values[key_block.name] = key_block.value
+
+            # Step 4: Set all morphs to 0
+            for key_block in key_blocks:
+                if key_block.name != "--- morph sliders ---":
+                    key_block.value = 0
+
+            # Step 5: Set target bone morph to 1.0
+            key_blocks[current_morph_name].value = 1.0
+
+            # Step 6: Use Armature Modifier's "Apply as Shape Key" functionality
+            created_shape_keys = []
+            for mesh_obj in FnModel.iterate_mesh_objects(root):
+                # Switch to this mesh object
+                context.view_layer.objects.active = mesh_obj
+
+                # Ensure mesh object has shape keys
+                if mesh_obj.data.shape_keys is None:
+                    mesh_obj.shape_key_add(name="Basis", from_mix=False)
+
+                # Delete existing shape key with same name
+                if target_name in mesh_obj.data.shape_keys.key_blocks:
+                    idx = mesh_obj.data.shape_keys.key_blocks.find(target_name)
+                    if idx >= 0:
+                        mesh_obj.active_shape_key_index = idx
+                        bpy.ops.object.shape_key_remove()
+
+                # Find armature modifier
+                armature_modifier = None
+                for modifier in mesh_obj.modifiers:
+                    if modifier.type == "ARMATURE":
+                        armature_modifier = modifier
+                        break
+
+                if armature_modifier is None:
+                    self.report({"WARNING"}, f"No armature modifier found on mesh '{mesh_obj.name}'")
+                    continue
+
+                # Use Apply as Shape Key functionality, keeping the modifier
+                bpy.ops.object.modifier_apply_as_shapekey(modifier=armature_modifier.name, keep_modifier=True)
+
+                # Rename the newly created shape key to target name
+                shape_key_blocks = mesh_obj.data.shape_keys.key_blocks
+                new_shape_key = shape_key_blocks[-1]  # Latest created shape key
+                new_shape_key.name = target_name
+                new_shape_key.value = 0.0  # Set to 0 to avoid double effect
+
+                created_shape_keys.append((mesh_obj.name, target_name))
+                self.report({"INFO"}, f"Created shape key '{target_name}' on mesh '{mesh_obj.name}'")
+
+            # Step 7: Restore all original morph values
+            for key_name, original_value in original_values.items():
+                if key_name in key_blocks:
+                    key_blocks[key_name].value = original_value
+
+            # Step 8: Create or update vertex morph entry
+            vertex_morph_exists = False
+            for i, morph in enumerate(mmd_root.vertex_morphs):
+                if morph.name == target_name:
+                    vertex_morph_exists = True
+                    mmd_root.active_morph_type = "vertex_morphs"
+                    mmd_root.active_morph = i
+                    break
+
+            if not vertex_morph_exists:
+                mmd_root.active_morph_type = "vertex_morphs"
+                morph, mmd_root.active_morph = ItemOp.add_after(mmd_root.vertex_morphs, mmd_root.active_morph)
+                morph.name = target_name
+
+            # Step 9: Add to facial expression display frame
+            facial_frame = None
+            for frame in mmd_root.display_item_frames:
+                if frame.name == "表情":
+                    facial_frame = frame
+                    break
+
+            if facial_frame:
+                morph_exists_in_frame = False
+                for item in facial_frame.data:
+                    if item.type == "MORPH" and item.name == target_name and item.morph_type == "vertex_morphs":
+                        morph_exists_in_frame = True
+                        break
+
+                if not morph_exists_in_frame:
+                    new_item = facial_frame.data.add()
+                    new_item.type = "MORPH"
+                    new_item.morph_type = "vertex_morphs"
+                    new_item.name = target_name
+
+                    facial_frame.active_item = len(facial_frame.data) - 1
+
+                    for i, frame in enumerate(mmd_root.display_item_frames):
+                        if frame.name == "表情":
+                            mmd_root.active_display_item_frame = i
+                            break
+
+            # UNBIND
+            bpy.ops.mmd_tools_local.morph_slider_setup(type="UNBIND")
+
+            # Success message
+            shape_key_info = ", ".join([f"{mesh}:{key}" for mesh, key in created_shape_keys])
+            self.report({"INFO"}, f"Successfully converted bone morph '{original_name}' to vertex morph '{target_name}'. Created shape keys: {shape_key_info}")
+
+        except Exception as e:
+            self.report({"ERROR"}, f"Error during conversion: {str(e)}")
+            return {"CANCELLED"}
 
         return {"FINISHED"}
 
@@ -780,8 +954,7 @@ class ConvertGroupMorphToVertexMorph(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        obj = context.active_object
-        root = FnModel.find_root_object(obj)
+        root = FnModel.find_root_object(context.active_object)
         if root is None:
             return False
         mmd_root = root.mmd_root

--- a/extern_tools/mmd_tools_local/operators/rigid_body.py
+++ b/extern_tools/mmd_tools_local/operators/rigid_body.py
@@ -236,8 +236,8 @@ class AddRigidBody(bpy.types.Operator):
     def execute(self, context):
         active_object = context.active_object
 
-        root_object = cast(bpy.types.Object, FnModel.find_root_object(active_object))
-        armature_object = cast(bpy.types.Object, FnModel.find_armature_object(root_object))
+        root_object = cast("bpy.types.Object", FnModel.find_root_object(active_object))
+        armature_object = cast("bpy.types.Object", FnModel.find_armature_object(root_object))
 
         if active_object != armature_object:
             FnContext.select_single_object(context, root_object).select_set(False)
@@ -441,9 +441,9 @@ class AddJoint(bpy.types.Operator):
 
     def execute(self, context):
         active_object = context.active_object
-        root_object = cast(bpy.types.Object, FnModel.find_root_object(active_object))
-        armature_object = cast(bpy.types.Object, FnModel.find_armature_object(root_object))
-        bones = cast(bpy.types.Armature, armature_object.data).bones
+        root_object = cast("bpy.types.Object", FnModel.find_root_object(active_object))
+        armature_object = cast("bpy.types.Object", FnModel.find_armature_object(root_object))
+        bones = cast("bpy.types.Armature", armature_object.data).bones
         bone_map: Dict[bpy.types.Object, Optional[bpy.types.Bone]] = {r: bones.get(r.mmd_rigid.bone, None) for r in FnModel.iterate_rigid_body_objects(root_object) if r.select_get()}
 
         if len(bone_map) < 2:
@@ -517,7 +517,7 @@ class UpdateRigidBodyWorld(bpy.types.Operator):
                 if obj not in group.values():
                     group.link(obj)
                 return True
-            elif obj in group.values():
+            if obj in group.values():
                 group.unlink(obj)
             return False
 

--- a/extern_tools/mmd_tools_local/operators/translations.py
+++ b/extern_tools/mmd_tools_local/operators/translations.py
@@ -1,6 +1,8 @@
 # Copyright 2021 MMD Tools authors
 # This file is part of MMD Tools.
 
+import csv
+import os
 from typing import TYPE_CHECKING, cast
 
 import bpy
@@ -10,7 +12,11 @@ from ..core.translations import MMD_DATA_TYPE_TO_HANDLERS, FnTranslations
 from ..translations import DictionaryEnum
 
 if TYPE_CHECKING:
-    from ..properties.translations import MMDTranslation, MMDTranslationElement, MMDTranslationElementIndex
+    from ..properties.translations import (
+        MMDTranslation,
+        MMDTranslationElement,
+        MMDTranslationElementIndex,
+    )
 
 
 class TranslateMMDModel(bpy.types.Operator):
@@ -73,7 +79,8 @@ class TranslateMMDModel(bpy.types.Operator):
     @classmethod
     def poll(cls, context):
         obj = context.active_object
-        return obj in context.selected_objects and FnModel.find_root_object(obj)
+        root = FnModel.find_root_object(obj)
+        return obj is not None and obj in context.selected_objects and root is not None
 
     def invoke(self, context, event):
         vm = context.window_manager
@@ -83,7 +90,7 @@ class TranslateMMDModel(bpy.types.Operator):
         try:
             self.__translator = DictionaryEnum.get_translator(self.dictionary)
         except Exception as e:
-            self.report({"ERROR"}, "Failed to load dictionary: %s" % e)
+            self.report({"ERROR"}, f"Failed to load dictionary: {e}")
             return {"CANCELLED"}
 
         obj = context.active_object
@@ -92,7 +99,7 @@ class TranslateMMDModel(bpy.types.Operator):
 
         if "MMD" in self.modes:
             for i in self.types:
-                getattr(self, "translate_%s" % i.lower())(rig)
+                getattr(self, f"translate_{i.lower()}")(rig)
 
         if "BLENDER" in self.modes:
             self.translate_blender_names(rig)
@@ -100,7 +107,11 @@ class TranslateMMDModel(bpy.types.Operator):
         translator = self.__translator
         txt = translator.save_fails()
         if translator.fails:
-            self.report({"WARNING"}, "Failed to translate %d names, see '%s' in text editor" % (len(translator.fails), txt.name))
+            self.report(
+                {"WARNING"},
+                "Failed to translate %d names, see '%s' in text editor"
+                % (len(translator.fails), txt.name),
+            )
         return {"FINISHED"}
 
     def translate(self, name_j, name_e):
@@ -126,7 +137,7 @@ class TranslateMMDModel(bpy.types.Operator):
 
         if "DISPLAY" in self.types:
             g: bpy.types.BoneCollection
-            for g in cast(bpy.types.Armature, rig.armature().data).collections:
+            for g in cast("bpy.types.Armature", rig.armature().data).collections:
                 g.name = self.translate(g.name, g.name)
 
         if "PHYSICS" in self.types:
@@ -149,7 +160,9 @@ class TranslateMMDModel(bpy.types.Operator):
         comment_text = bpy.data.texts.get(mmd_root.comment_text, None)
         comment_e_text = bpy.data.texts.get(mmd_root.comment_e_text, None)
         if comment_text and comment_e_text:
-            comment_e = self.translate(comment_text.as_string(), comment_e_text.as_string())
+            comment_e = self.translate(
+                comment_text.as_string(), comment_e_text.as_string(),
+            )
             comment_e_text.from_string(comment_e)
 
     def translate_bone(self, rig):
@@ -163,7 +176,7 @@ class TranslateMMDModel(bpy.types.Operator):
         mmd_root = rig.rootObject().mmd_root
         attr_list = ("group", "vertex", "bone", "uv", "material")
         prefix_list = ("G_", "", "B_", "UV_", "M_")
-        for attr, prefix in zip(attr_list, prefix_list):
+        for attr, prefix in zip(attr_list, prefix_list, strict=False):
             for m in getattr(mmd_root, attr + "_morphs", []):
                 m.name_e = self.translate(m.name, m.name_e)
                 if not prefix:
@@ -178,7 +191,9 @@ class TranslateMMDModel(bpy.types.Operator):
         for m in rig.materials():
             if m is None:
                 continue
-            m.mmd_material.name_e = self.translate(m.mmd_material.name_j, m.mmd_material.name_e)
+            m.mmd_material.name_e = self.translate(
+                m.mmd_material.name_j, m.mmd_material.name_e,
+            )
 
     def translate_display(self, rig):
         mmd_root = rig.rootObject().mmd_root
@@ -197,9 +212,23 @@ DEFAULT_SHOW_ROW_COUNT = 20
 
 
 class mmd_tools_local_UL_MMDTranslationElementIndex(bpy.types.UIList):
-    def draw_item(self, context, layout: bpy.types.UILayout, data, mmd_translation_element_index: "MMDTranslationElementIndex", icon, active_data, active_propname, index: int):
-        mmd_translation_element: "MMDTranslationElement" = data.translation_elements[mmd_translation_element_index.value]
-        MMD_DATA_TYPE_TO_HANDLERS[mmd_translation_element.type].draw_item(layout, mmd_translation_element, index)
+    def draw_item(
+        self,
+        context,
+        layout: bpy.types.UILayout,
+        data,
+        mmd_translation_element_index: "MMDTranslationElementIndex",
+        icon,
+        active_data,
+        active_propname,
+        index: int,
+    ):
+        mmd_translation_element: MMDTranslationElement = data.translation_elements[
+            mmd_translation_element_index.value
+        ]
+        MMD_DATA_TYPE_TO_HANDLERS[mmd_translation_element.type].draw_item(
+            layout, mmd_translation_element, index,
+        )
 
 
 class RestoreMMDDataReferenceOperator(bpy.types.Operator):
@@ -212,9 +241,15 @@ class RestoreMMDDataReferenceOperator(bpy.types.Operator):
     restore_value: bpy.props.StringProperty()
 
     def execute(self, context: bpy.types.Context):
-        root_object = FnModel.find_root_object(context.object)
-        mmd_translation_element_index = root_object.mmd_root.translation.filtered_translation_element_indices[self.index].value
-        mmd_translation_element = root_object.mmd_root.translation.translation_elements[mmd_translation_element_index]
+        root_object = FnModel.find_root_object(context.active_object)
+        mmd_translation_element_index = (
+            root_object.mmd_root.translation.filtered_translation_element_indices[
+                self.index
+            ].value
+        )
+        mmd_translation_element = root_object.mmd_root.translation.translation_elements[
+            mmd_translation_element_index
+        ]
         setattr(mmd_translation_element, self.prop_name, self.restore_value)
 
         return {"FINISHED"}
@@ -227,7 +262,8 @@ class GlobalTranslationPopup(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return FnModel.find_root_object(context.object) is not None
+        root = FnModel.find_root_object(context.active_object)
+        return root is not None
 
     def draw(self, _context):
         layout = self.layout
@@ -240,13 +276,33 @@ class GlobalTranslationPopup(bpy.types.Operator):
 
         group = row.row(align=True, heading="is Blank:")
         group.alignment = "RIGHT"
-        group.prop(mmd_translation, "filter_japanese_blank", toggle=True, text="Japanese")
+        group.prop(
+            mmd_translation, "filter_japanese_blank", toggle=True, text="Japanese",
+        )
         group.prop(mmd_translation, "filter_english_blank", toggle=True, text="English")
 
         group = row.row(align=True)
-        group.prop(mmd_translation, "filter_restorable", toggle=True, icon="FILE_REFRESH", icon_only=True)
-        group.prop(mmd_translation, "filter_selected", toggle=True, icon="RESTRICT_SELECT_OFF", icon_only=True)
-        group.prop(mmd_translation, "filter_visible", toggle=True, icon="HIDE_OFF", icon_only=True)
+        group.prop(
+            mmd_translation,
+            "filter_restorable",
+            toggle=True,
+            icon="FILE_REFRESH",
+            icon_only=True,
+        )
+        group.prop(
+            mmd_translation,
+            "filter_selected",
+            toggle=True,
+            icon="RESTRICT_SELECT_OFF",
+            icon_only=True,
+        )
+        group.prop(
+            mmd_translation,
+            "filter_visible",
+            toggle=True,
+            icon="HIDE_OFF",
+            icon_only=True,
+        )
 
         col = layout.column(align=True)
         box = col.box().column(align=True)
@@ -258,7 +314,10 @@ class GlobalTranslationPopup(bpy.types.Operator):
         row.label(text="", icon="RESTRICT_SELECT_OFF")
         row.label(text="", icon="HIDE_OFF")
 
-        if len(mmd_translation.filtered_translation_element_indices) > DEFAULT_SHOW_ROW_COUNT:
+        if (
+            len(mmd_translation.filtered_translation_element_indices)
+            > DEFAULT_SHOW_ROW_COUNT
+        ):
             row.label(text="", icon="BLANK1")
 
         col.template_list(
@@ -277,7 +336,12 @@ class GlobalTranslationPopup(bpy.types.Operator):
 
         box.separator()
         row = box.row()
-        row.prop(mmd_translation, "batch_operation_script_preset", text="Preset", icon="CON_TRANSFORM_CACHE")
+        row.prop(
+            mmd_translation,
+            "batch_operation_script_preset",
+            text="Preset",
+            icon="CON_TRANSFORM_CACHE",
+        )
         row.operator(ExecuteTranslationBatchOperator.bl_idname, text="Execute")
 
         box.separator()
@@ -285,18 +349,25 @@ class GlobalTranslationPopup(bpy.types.Operator):
         translation_box.label(text="Dictionaries:", icon="HELP")
         row = translation_box.row()
         row.prop(mmd_translation, "dictionary", text="to_english")
-        # row.operator(ExecuteTranslationScriptOperator.bl_idname, text='Write to .csv')
 
         translation_box.separator()
         row = translation_box.row()
         row.prop(mmd_translation, "dictionary", text="replace")
 
+        # CSV import/export
+        box.separator()
+        translation_box = box.box().column(align=True)
+        translation_box.label(text="CSV:", icon="FILE_TEXT")
+        row = translation_box.row()
+        row.operator(ImportTranslationCSVOperator.bl_idname, text="Import CSV")
+        row.operator(ExportTranslationCSVOperator.bl_idname, text="Export CSV")
+
     def invoke(self, context: bpy.types.Context, _event):
-        root_object = FnModel.find_root_object(context.object)
+        root_object = FnModel.find_root_object(context.active_object)
         if root_object is None:
             return {"CANCELLED"}
 
-        mmd_translation: "MMDTranslation" = root_object.mmd_root.translation
+        mmd_translation: MMDTranslation = root_object.mmd_root.translation
         self._mmd_translation = mmd_translation
         FnTranslations.clear_data(mmd_translation)
         FnTranslations.collect_data(mmd_translation)
@@ -305,7 +376,7 @@ class GlobalTranslationPopup(bpy.types.Operator):
         return context.window_manager.invoke_props_dialog(self, width=800)
 
     def execute(self, context):
-        root_object = FnModel.find_root_object(context.object)
+        root_object = FnModel.find_root_object(context.active_object)
         if root_object is None:
             return {"CANCELLED"}
 
@@ -321,12 +392,175 @@ class ExecuteTranslationBatchOperator(bpy.types.Operator):
     bl_options = {"INTERNAL"}
 
     def execute(self, context: bpy.types.Context):
-        root = FnModel.find_root_object(context.object)
+        root = FnModel.find_root_object(context.active_object)
         if root is None:
             return {"CANCELLED"}
 
         fails, text = FnTranslations.execute_translation_batch(root)
         if fails:
-            self.report({"WARNING"}, "Failed to translate %d names, see '%s' in text editor" % (len(fails), text.name))
+            self.report(
+                {"WARNING"},
+                "Failed to translate %d names, see '%s' in text editor"
+                % (len(fails), text.name),
+            )
 
+        return {"FINISHED"}
+
+
+class ExportTranslationCSVOperator(bpy.types.Operator):
+    bl_idname = "mmd_tools_local.export_translation_csv"
+    bl_description = "Export CSV for external translation."
+    bl_label = "Export Translation CSV"
+
+    filter_glob: bpy.props.StringProperty(default="*.csv", options={"HIDDEN"})
+    filename_ext = ".csv"
+    filepath: bpy.props.StringProperty(
+        name="File Path",
+        description="Path to save the translation CSV",
+        subtype="FILE_PATH",
+        default="mmd_translation.csv",
+    )
+
+    def _ensure_csv_extension(self):
+        """Ensure the file path ends with a .csv extension (case-insensitive)."""
+        if not self.filepath.lower().endswith(".csv"):
+            self.filepath = bpy.path.ensure_ext(self.filepath, ".csv")
+
+    def invoke(self, context, event):
+        self._ensure_csv_extension()
+        context.window_manager.fileselect_add(self)
+        return {"RUNNING_MODAL"}
+
+    def execute(self, context):
+        self._ensure_csv_extension()
+        root_object = FnModel.find_root_object(context.active_object)
+        if root_object is None:
+            self.report({"ERROR"}, "Root object not found")
+            return {"CANCELLED"}
+
+        mmd_translation = root_object.mmd_root.translation
+
+        try:
+            with open(self.filepath, "w", newline="", encoding="utf-8") as csvfile:
+                writer = csv.writer(csvfile)
+                writer.writerow(["type", "blender", "japanese", "english"])
+                for idx in mmd_translation.filtered_translation_element_indices:
+                    element = mmd_translation.translation_elements[idx.value]
+                    writer.writerow(
+                        [element.type, element.name, element.name_j, element.name_e],
+                    )
+        except Exception as e:
+            self.report({"ERROR"}, f"Failed to write CSV: {e}")
+            return {"CANCELLED"}
+
+        self.report({"INFO"}, f"Exported to {os.path.basename(self.filepath)}")
+        return {"FINISHED"}
+
+
+class ImportTranslationCSVOperator(bpy.types.Operator):
+    bl_idname = "mmd_tools_local.import_translation_csv"
+    bl_description = "Import translated CSV."
+    bl_label = "Import Translation CSV"
+
+    only_update_english_name: bpy.props.BoolProperty(
+        name="Only Update English Name",
+        description="(Enabled by default) Only update English name (name_e). otherwise, update all names when different",
+        default=True,
+    )
+
+    filter_glob: bpy.props.StringProperty(default="*.csv", options={"HIDDEN"})
+    filepath: bpy.props.StringProperty(
+        name="File Path",
+        description="Path to import the translation CSV",
+        subtype="FILE_PATH",
+        default="*.csv",
+    )
+
+    def invoke(self, context, event):
+        context.window_manager.fileselect_add(self)
+        return {"RUNNING_MODAL"}
+
+    def execute(self, context):
+        root_object = FnModel.find_root_object(context.active_object)
+        if root_object is None:
+            self.report({"ERROR"}, "Root object not found")
+            return {"CANCELLED"}
+
+        mmd_translation = root_object.mmd_root.translation
+        updated_count = 0
+        warnings = []
+
+        try:
+            with open(self.filepath, encoding="utf-8") as csvfile:
+                reader = csv.DictReader(csvfile)
+                required_headers = {"blender", "japanese", "english"}
+                if not required_headers.issubset(set(reader.fieldnames or [])):
+                    missing = required_headers - set(reader.fieldnames or [])
+                    self.report(
+                        {"ERROR"},
+                        f"Missing required headers in CSV: {', '.join(missing)}",
+                    )
+                    return {"CANCELLED"}
+
+                visible_indices = [
+                    i.value
+                    for i in mmd_translation.filtered_translation_element_indices
+                ]
+                translation_elements_list = list(mmd_translation.translation_elements)
+                row_count = 0
+
+                for row in reader:
+                    if row_count >= len(visible_indices):
+                        row_count += 1
+                        continue
+
+                    element = translation_elements_list[visible_indices[row_count]]
+
+                    b_name = row.get("blender", "").strip()
+                    j_name = row.get("japanese", "").strip()
+                    e_name = row.get("english", "").strip()
+
+                    updated = False
+                    if self.only_update_english_name:
+                        if element.name_e != e_name:
+                            element.name_e = e_name
+                            updated = True
+                    else:
+                        if element.name != b_name:
+                            element.name = b_name
+                            updated = True
+                        if element.name_j != j_name:
+                            element.name_j = j_name
+                            updated = True
+                        if element.name_e != e_name:
+                            element.name_e = e_name
+                            updated = True
+
+                    if updated:
+                        updated_count += 1
+
+                    row_count += 1
+
+                # Output warnings
+                if row_count > len(visible_indices):
+                    warnings.append(
+                        f"{row_count - len(visible_indices)} extra lines in CSV! (ignored)",
+                    )
+                elif row_count < len(visible_indices):
+                    warnings.append(
+                        f"{len(visible_indices) - row_count} missing lines in CSV! (aborted translation)",
+                    )
+        except Exception as e:
+            self.report({"ERROR"}, f"Failed to read CSV: {e}")
+            return {"CANCELLED"}
+
+        FnTranslations.update_query(mmd_translation)
+
+        msg = f"Imported {updated_count} entries from CSV"
+        if warnings:
+            for w in warnings:
+                self.report({"WARNING"}, w)
+            msg += " with warnings"
+
+        self.report({"INFO"}, msg)
         return {"FINISHED"}

--- a/extern_tools/mmd_tools_local/operators/view.py
+++ b/extern_tools/mmd_tools_local/operators/view.py
@@ -4,7 +4,7 @@
 import re
 
 from bpy.types import Operator
-from mathutils import Matrix
+from mathutils import Matrix, Quaternion
 
 
 class _SetShadingBase:
@@ -118,7 +118,7 @@ class FlipPose(Operator):
 
     @staticmethod
     def __cmul(vec1, vec2):
-        return type(vec1)([x * y for x, y in zip(vec1, vec2)])
+        return type(vec1)([x * y for x, y in zip(vec1, vec2, strict=False)])
 
     @staticmethod
     def __matrix_compose(loc, rot, scale):
@@ -126,8 +126,6 @@ class FlipPose(Operator):
 
     @classmethod
     def __flip_pose(cls, matrix_basis, bone_src, bone_dest):
-        from mathutils import Quaternion
-
         m = bone_dest.bone.matrix_local.to_3x3().transposed()
         mi = bone_src.bone.matrix_local.to_3x3().transposed().inverted() if bone_src != bone_dest else m.inverted()
         loc, rot, scale = matrix_basis.decompose()
@@ -137,7 +135,8 @@ class FlipPose(Operator):
 
     @classmethod
     def poll(cls, context):
-        return context.active_object and context.active_object.type == "ARMATURE" and context.active_object.mode == "POSE"
+        obj = context.active_object
+        return obj is not None and obj.type == "ARMATURE" and obj.mode == "POSE"
 
     def execute(self, context):
         pose_bones = context.active_object.pose.bones

--- a/extern_tools/mmd_tools_local/panels/prop_bone.py
+++ b/extern_tools/mmd_tools_local/panels/prop_bone.py
@@ -13,7 +13,7 @@ class MMDBonePanel(bpy.types.Panel):
 
     @classmethod
     def poll(cls, context):
-        return context.active_bone
+        return context.active_bone is not None
 
     def __draw_ik_data(self, pose_bone):
         bones = pose_bone.id_data.pose.bones
@@ -23,9 +23,9 @@ class MMDBonePanel(bpy.types.Panel):
             row = self.layout.column(align=True)
             for name in ik_bone_names:
                 if name in ik_custom_map:
-                    row.prop(bones[name].mmd_bone, "ik_rotation_constraint", text="IK Angle {%s}" % name)
+                    row.prop(bones[name].mmd_bone, "ik_rotation_constraint", text=f"IK Angle {{{name}}}")
                 else:
-                    row.prop(pose_bone.mmd_bone, "ik_rotation_constraint", text="IK Angle (%s)" % name)
+                    row.prop(pose_bone.mmd_bone, "ik_rotation_constraint", text=f"IK Angle ({name})")
 
     def draw(self, context):
         pose_bone = context.active_pose_bone or context.active_object.pose.bones.get(context.active_bone.name, None)
@@ -91,10 +91,10 @@ class MMDBonePanel(bpy.types.Panel):
         c.prop(mmd_bone, "additional_transform_influence", text="Influence", slider=True)
 
         c = layout.column(align=True)
-        c.label(text="Display Connection (Bone Target):")
+        c.label(text="Display Connection (Bone Tail Location):")
         c.row().prop(mmd_bone, "display_connection_type", text="Type")
 
         if mmd_bone.display_connection_type == "BONE":
             c.prop_search(mmd_bone, "display_connection_bone", pose_bone.id_data.pose, "bones", icon="BONE_DATA", text="Target Bone")
         elif mmd_bone.display_connection_type == "OFFSET":
-            c.label(text="Offset is auto-calculated at export.")
+            c.label(text="Offset is auto-calculated during export.")

--- a/extern_tools/mmd_tools_local/panels/prop_camera.py
+++ b/extern_tools/mmd_tools_local/panels/prop_camera.py
@@ -16,7 +16,7 @@ class MMDCameraPanel(Panel):
     @classmethod
     def poll(cls, context):
         obj = context.active_object
-        return obj and (obj.type == "CAMERA" or MMDCamera.isMMDCamera(obj))
+        return obj is not None and (obj.type == "CAMERA" or MMDCamera.isMMDCamera(obj))
 
     def draw(self, context):
         obj = context.active_object

--- a/extern_tools/mmd_tools_local/panels/prop_lamp.py
+++ b/extern_tools/mmd_tools_local/panels/prop_lamp.py
@@ -16,7 +16,7 @@ class MMDLampPanel(Panel):
     @classmethod
     def poll(cls, context):
         obj = context.active_object
-        return obj and (MMDLamp.isLamp(obj) or MMDLamp.isMMDLamp(obj))
+        return obj is not None and (MMDLamp.isLamp(obj) or MMDLamp.isMMDLamp(obj))
 
     def draw(self, context):
         obj = context.active_object
@@ -25,7 +25,7 @@ class MMDLampPanel(Panel):
 
         if MMDLamp.isMMDLamp(obj):
             mmd_lamp = MMDLamp(obj)
-            empty = mmd_lamp.object()
+            # empty = mmd_lamp.object()
             lamp = mmd_lamp.lamp()
 
             c = layout.column()

--- a/extern_tools/mmd_tools_local/panels/prop_material.py
+++ b/extern_tools/mmd_tools_local/panels/prop_material.py
@@ -16,7 +16,7 @@ class MMDMaterialPanel(Panel):
     @classmethod
     def poll(cls, context):
         obj = context.active_object
-        return obj.active_material and obj.mmd_type == "NONE"
+        return obj is not None and obj.active_material is not None and obj.mmd_type == "NONE"
 
     def draw(self, context):
         material = context.active_object.active_material
@@ -76,7 +76,7 @@ class MMDTexturePanel(Panel):
     @classmethod
     def poll(cls, context):
         obj = context.active_object
-        return obj.active_material and obj.mmd_type == "NONE"
+        return obj is not None and obj.active_material is not None and obj.mmd_type == "NONE"
 
     def draw(self, context):
         material = context.active_object.active_material

--- a/extern_tools/mmd_tools_local/panels/prop_object.py
+++ b/extern_tools/mmd_tools_local/panels/prop_object.py
@@ -15,7 +15,8 @@ class MMDModelObjectPanel(bpy.types.Panel):
 
     @classmethod
     def poll(cls, context):
-        return FnModel.find_root_object(context.active_object)
+        root = FnModel.find_root_object(context.active_object)
+        return root is not None
 
     def draw(self, context):
         layout = self.layout

--- a/extern_tools/mmd_tools_local/panels/prop_physics.py
+++ b/extern_tools/mmd_tools_local/panels/prop_physics.py
@@ -71,7 +71,7 @@ class MMDRigidPanel(bpy.types.Panel):
         col = c.column(align=True)
         col.label(text="Collision Group Mask:")
         row = col.row(align=True)
-        for i in range(0, 8):
+        for i in range(8):
             row.prop(obj.mmd_rigid, "collision_group_mask", index=i, text=str(i), toggle=True)
         row = col.row(align=True)
         for i in range(8, 16):

--- a/extern_tools/mmd_tools_local/panels/sidebar/__init__.py
+++ b/extern_tools/mmd_tools_local/panels/sidebar/__init__.py
@@ -20,8 +20,7 @@ class FnDraw:
             bone = p_bone.bone
             if mmd_name:
                 row.prop(p_bone.mmd_bone, mmd_name, text="", emboss=True)
-            ic = "RESTRICT_VIEW_ON" if bone.hide else "RESTRICT_VIEW_OFF"
-            row.prop(bone, "hide", text="", emboss=p_bone.mmd_bone.is_tip, icon=ic)
+            row.prop(bone, "hide", text="", emboss=p_bone.mmd_bone.is_tip, icon_only=True)
             row.active = armature.mode != "EDIT"
         else:
             row.label()  # for alignment only
@@ -64,7 +63,7 @@ class UL_ObjectsMixIn:
             row = row.row(align=True)
             row.prop(item_prop, "name_e", text="", emboss=True)
             self.draw_item_special(context, row, item)
-        elif self.layout_type in {"GRID"}:
+        elif self.layout_type == "GRID":
             layout.alignment = "CENTER"
             layout.label(text="", icon=self.icon)
 

--- a/extern_tools/mmd_tools_local/panels/sidebar/bone_order.py
+++ b/extern_tools/mmd_tools_local/panels/sidebar/bone_order.py
@@ -12,28 +12,33 @@ class MMDToolsBoneIdMoveUp(bpy.types.Operator):
     bl_idname = "mmd_tools_local.bone_id_move_up"
     bl_label = "Move Bone ID Up"
     bl_description = "Move active bone up in bone order"
-    bl_options = {'REGISTER', 'UNDO'}
+    bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
-        root = FnModel.find_root_object(context.object)
+        root = FnModel.find_root_object(context.active_object)
         armature = FnModel.find_armature_object(root)
 
         if not root or not armature:
-            return {'CANCELLED'}
+            return {"CANCELLED"}
 
         active_bone_index = root.mmd_root.active_bone_index
-        if active_bone_index >= len(armature.pose.bones):
-            return {'CANCELLED'}
+        if active_bone_index < 0 or active_bone_index >= len(armature.pose.bones):
+            return {"CANCELLED"}
 
         active_bone = armature.pose.bones[active_bone_index]
         active_id = active_bone.mmd_bone.bone_id
+
+        # Check if bone_id is -1 and show warning
+        if active_id == -1:
+            self.report({"WARNING"}, "Bone ID is invalid (-1). Please click 'Fix Bone Order' button first to assign proper bone IDs.")
+            return {"CANCELLED"}
 
         # Find bone with smaller bone_id
         prev_bone = None
         prev_id = -1
 
         for bone in armature.pose.bones:
-            is_shadow = getattr(bone, 'is_mmd_shadow_bone', False) is True
+            is_shadow = getattr(bone, "is_mmd_shadow_bone", False) is True
             if not is_shadow and bone.mmd_bone.bone_id < active_id and bone.mmd_bone.bone_id > prev_id:
                 prev_bone = bone
                 prev_id = bone.mmd_bone.bone_id
@@ -42,39 +47,40 @@ class MMDToolsBoneIdMoveUp(bpy.types.Operator):
             # safe swap bone IDs
             FnModel.swap_bone_ids(active_bone, prev_bone, root.mmd_root.bone_morphs, armature.pose.bones)
 
-            # Refresh UI
-            for area in context.screen.areas:
-                area.tag_redraw()
-
-        return {'FINISHED'}
+        return {"FINISHED"}
 
 
 class MMDToolsBoneIdMoveDown(bpy.types.Operator):
     bl_idname = "mmd_tools_local.bone_id_move_down"
     bl_label = "Move Bone ID Down"
     bl_description = "Move active bone down in bone order"
-    bl_options = {'REGISTER', 'UNDO'}
+    bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
-        root = FnModel.find_root_object(context.object)
+        root = FnModel.find_root_object(context.active_object)
         armature = FnModel.find_armature_object(root)
 
         if not root or not armature:
-            return {'CANCELLED'}
+            return {"CANCELLED"}
 
         active_bone_index = root.mmd_root.active_bone_index
-        if active_bone_index >= len(armature.pose.bones):
-            return {'CANCELLED'}
+        if active_bone_index < 0 or active_bone_index >= len(armature.pose.bones):
+            return {"CANCELLED"}
 
         active_bone = armature.pose.bones[active_bone_index]
         active_id = active_bone.mmd_bone.bone_id
 
+        # Check if bone_id is -1 and show warning
+        if active_id == -1:
+            self.report({"WARNING"}, "Bone ID is invalid (-1). Please click 'Fix Bone Order' button first to assign proper bone IDs.")
+            return {"CANCELLED"}
+
         # Find bone with larger bone_id
         next_bone = None
-        next_id = float('inf')
+        next_id = float("inf")
 
         for bone in armature.pose.bones:
-            is_shadow = getattr(bone, 'is_mmd_shadow_bone', False) is True
+            is_shadow = getattr(bone, "is_mmd_shadow_bone", False) is True
             if not is_shadow and bone.mmd_bone.bone_id > active_id and bone.mmd_bone.bone_id < next_id:
                 next_bone = bone
                 next_id = bone.mmd_bone.bone_id
@@ -83,84 +89,87 @@ class MMDToolsBoneIdMoveDown(bpy.types.Operator):
             # safe swap bone IDs
             FnModel.swap_bone_ids(active_bone, next_bone, root.mmd_root.bone_morphs, armature.pose.bones)
 
-            # Refresh UI
-            for area in context.screen.areas:
-                area.tag_redraw()
-
-        return {'FINISHED'}
+        return {"FINISHED"}
 
 
 class MMDToolsBoneIdMoveTop(bpy.types.Operator):
     bl_idname = "mmd_tools_local.bone_id_move_top"
     bl_label = "Move Bone ID to Top"
     bl_description = "Move active bone to the top of bone order"
-    bl_options = {'REGISTER', 'UNDO'}
+    bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
-        root = FnModel.find_root_object(context.object)
+        root = FnModel.find_root_object(context.active_object)
         armature = FnModel.find_armature_object(root)
 
         if not root or not armature:
-            return {'CANCELLED'}
+            return {"CANCELLED"}
 
         active_bone_index = root.mmd_root.active_bone_index
-        if active_bone_index >= len(armature.pose.bones):
-            return {'CANCELLED'}
+        if active_bone_index < 0 or active_bone_index >= len(armature.pose.bones):
+            return {"CANCELLED"}
 
         active_bone = armature.pose.bones[active_bone_index]
+        old_bone_id = active_bone.mmd_bone.bone_id
+        new_bone_id = 0
+        bone_morphs = root.mmd_root.bone_morphs
+        pose_bones = armature.pose.bones
+        FnModel.shift_bone_id(old_bone_id, new_bone_id, bone_morphs, pose_bones)
 
-        # Change bone ID to 0 safely
-        FnModel.safe_change_bone_id(active_bone, 0, root.mmd_root.bone_morphs, armature.pose.bones)
-
-        # Refresh UI
-        for area in context.screen.areas:
-            area.tag_redraw()
-
-        return {'FINISHED'}
+        return {"FINISHED"}
 
 
 class MMDToolsBoneIdMoveBottom(bpy.types.Operator):
     bl_idname = "mmd_tools_local.bone_id_move_bottom"
     bl_label = "Move Bone ID to Bottom"
     bl_description = "Move active bone to the bottom of bone order"
-    bl_options = {'REGISTER', 'UNDO'}
+    bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
-        root = FnModel.find_root_object(context.object)
+        root = FnModel.find_root_object(context.active_object)
         armature = FnModel.find_armature_object(root)
 
         if not root or not armature:
-            return {'CANCELLED'}
+            return {"CANCELLED"}
 
         active_bone_index = root.mmd_root.active_bone_index
-        if active_bone_index >= len(armature.pose.bones):
-            return {'CANCELLED'}
+        if active_bone_index < 0 or active_bone_index >= len(armature.pose.bones):
+            return {"CANCELLED"}
 
         active_bone = armature.pose.bones[active_bone_index]
+        old_bone_id = active_bone.mmd_bone.bone_id
+        new_bone_id = FnModel.get_max_bone_id(armature.pose.bones)
+        bone_morphs = root.mmd_root.bone_morphs
+        pose_bones = armature.pose.bones
+        FnModel.shift_bone_id(old_bone_id, new_bone_id, bone_morphs, pose_bones)
 
-        # Get the maximum bone ID and add 1 to place at the bottom
-        max_bone_id = FnModel.get_max_bone_id(armature.pose.bones)
-        FnModel.safe_change_bone_id(active_bone, max_bone_id + 1, root.mmd_root.bone_morphs, armature.pose.bones)
-
-        # Refresh UI
-        for area in context.screen.areas:
-            area.tag_redraw()
-
-        return {'FINISHED'}
+        return {"FINISHED"}
 
 
 class MMDToolsRealignBoneIds(bpy.types.Operator):
     bl_idname = "mmd_tools_local.fix_bone_order"
     bl_label = "Realign Bone IDs"
-    bl_description = "Realign bone IDs to be sequential without gaps and apply additional transforms"
-    bl_options = {'REGISTER', 'UNDO'}
+    bl_description = "Realign bone IDs to be sequential without gaps. Sorted primarily by hierarchy depth (ensuring parents have lower IDs than children), then by bone_id (valid ones prioritized), then by bone name. Apply additional transforms afterward (Assembly -> Bone button)."
+    bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
-        root = FnModel.find_root_object(context.object)
-        armature = FnModel.find_armature_object(root)
+        root = FnModel.find_root_object(context.active_object)
+        if not root:
+            return {"CANCELLED"}
 
-        if not root or not armature:
-            return {'CANCELLED'}
+        # Clean invalid bone references first
+        cleaned_count = FnModel.clean_invalid_bone_id_references(root)
+        if cleaned_count > 0:
+            self.report({"INFO"}, f"Cleaned {cleaned_count} invalid bone reference(s).")
+
+        armature = FnModel.find_armature_object(root)
+        if not armature:
+            return {"FINISHED"}
+
+        # Trigger mode switch to sync newly created bones from Edit mode
+        current_mode = armature.mode
+        bpy.ops.object.mode_set(mode="OBJECT")
+        bpy.ops.object.mode_set(mode=current_mode)
 
         # Migrate bone layers from Blender 3.6 and earlier to bone collections in newer versions
         self.check_and_rename_collections(armature)
@@ -169,19 +178,31 @@ class MMDToolsRealignBoneIds(bpy.types.Operator):
         bone_order_mesh_object = self.find_old_bone_order_mesh_object(root)
         if bone_order_mesh_object:
             self.migrate_from_vertex_groups(bone_order_mesh_object, armature, root)
-        else:
-            # safe realign bone IDs
-            FnModel.realign_bone_ids(armature.pose.bones, 0, root.mmd_root.bone_morphs, armature.pose.bones)
 
-        # Apply additional transformation (Assembly -> Bone button) (Very Slow)
+        # Fix bone order
+        for iteration in range(10):
+            current_state = {}
+            for bone in armature.pose.bones:
+                if not getattr(bone, "is_mmd_shadow_bone", False):
+                    current_state[bone.name] = bone.mmd_bone.bone_id
+
+            FnModel.realign_bone_ids(0, root.mmd_root.bone_morphs, armature.pose.bones)
+
+            new_state = {}
+            for bone in armature.pose.bones:
+                if not getattr(bone, "is_mmd_shadow_bone", False):
+                    new_state[bone.name] = bone.mmd_bone.bone_id
+
+            if current_state == new_state:
+                break
+        else:
+            self.report({"WARNING"}, "Bone order did not converge after 10 iterations")
+
+        # Apply additional transform (Assembly -> Bone button) (Very Slow)
         MigrationFnBone.fix_mmd_ik_limit_override(armature)
         FnBone.apply_additional_transformation(armature)
 
-        # Refresh UI
-        for area in context.screen.areas:
-            area.tag_redraw()
-
-        return {'FINISHED'}
+        return {"FINISHED"}
 
     def check_and_rename_collections(self, armature_object):
         """
@@ -199,7 +220,7 @@ class MMDToolsRealignBoneIds(bpy.types.Operator):
         collection_map = {
             "Layer 1": {"new_name": "mmd_normal", "should_be_shadow": False},
             "Layer 9": {"new_name": BONE_COLLECTION_NAME_SHADOW, "should_be_shadow": True},
-            "Layer 10": {"new_name": BONE_COLLECTION_NAME_DUMMY, "should_be_shadow": True}
+            "Layer 10": {"new_name": BONE_COLLECTION_NAME_DUMMY, "should_be_shadow": True},
         }
 
         # Check if all three collections exist
@@ -217,7 +238,7 @@ class MMDToolsRealignBoneIds(bpy.types.Operator):
             for bone in collection.bones:
                 pose_bone = armature_object.pose.bones.get(bone.name)
                 if pose_bone:
-                    is_shadow = getattr(pose_bone, 'is_mmd_shadow_bone', False)
+                    is_shadow = getattr(pose_bone, "is_mmd_shadow_bone", False)
                     if is_shadow != should_be_shadow:
                         all_conditions_met = False
                         break
@@ -227,7 +248,7 @@ class MMDToolsRealignBoneIds(bpy.types.Operator):
 
         # If all conditions are met, rename the collections
         if all_conditions_met:
-            self.report({'INFO'}, "Converting layer collections to MMD collections")
+            self.report({"INFO"}, "Converting layer collections to MMD collections")
             for old_name, settings in collection_map.items():
                 new_name = settings["new_name"]
                 if old_name in bone_collections and new_name not in bone_collections:
@@ -243,16 +264,16 @@ class MMDToolsRealignBoneIds(bpy.types.Operator):
             return None
 
         for mesh in armature.children:
-            if mesh.type != 'MESH':
+            if mesh.type != "MESH":
                 continue
             for mod in mesh.modifiers:
-                if mod.type == 'ARMATURE' and mod.name == 'mmd_bone_order_override':
+                if mod.type == "ARMATURE" and mod.name == "mmd_bone_order_override":
                     return mesh
         return None
 
     def migrate_from_vertex_groups(self, mesh_object, armature, root):
         """Migrate bone order from vertex groups to bone_id"""
-        self.report({'INFO'}, "Migrating from old vertex group ordering to bone_id system")
+        self.report({"INFO"}, "Migrating from old vertex group ordering to bone_id system")
 
         # Create mapping from bone name to index in vertex_groups
         vg_index_map = {}
@@ -262,8 +283,8 @@ class MMDToolsRealignBoneIds(bpy.types.Operator):
 
         # Assign bone_id based on vertex group index
         next_id = 0
-        for bone in sorted(armature.pose.bones, key=lambda b: vg_index_map.get(b.name, float('inf'))):
-            is_shadow = getattr(bone, 'is_mmd_shadow_bone', False) is True
+        for bone in sorted(armature.pose.bones, key=lambda b: vg_index_map.get(b.name, float("inf"))):
+            is_shadow = getattr(bone, "is_mmd_shadow_bone", False) is True
             if is_shadow:
                 continue
 
@@ -273,11 +294,39 @@ class MMDToolsRealignBoneIds(bpy.types.Operator):
 
         # Rename the mmd_bone_order_override modifier of the mesh
         for modifier in mesh_object.modifiers:
-            if modifier.name == 'mmd_bone_order_override':
-                modifier.name = 'mmd_armature'
+            if modifier.name == "mmd_bone_order_override":
+                modifier.name = "mmd_armature"
                 break
 
-        self.report({'INFO'}, f"Successfully migrated {next_id} bones from vertex groups to bone_id system")
+        self.report({"INFO"}, f"Successfully migrated {next_id} bones from vertex groups to bone_id system")
+
+
+class MMDToolsCleanInvalidBoneIdReferences(bpy.types.Operator):
+    bl_idname = "mmd_tools_local.clean_invalid_bone_id_references"
+    bl_label = "Clean Invalid Bone References"
+    bl_description = "Scans the active MMD model for any references to bone_ids that no longer exist, then cleans them up. This is useful after deleting bones to maintain data integrity."
+    bl_options = {"REGISTER", "UNDO"}
+
+    @classmethod
+    def poll(cls, context):
+        return FnModel.find_root_object(context.active_object) is not None
+
+    def execute(self, context):
+        self.report({"INFO"}, "Cleaning invalid bone references...")
+
+        root = FnModel.find_root_object(context.active_object)
+        if not root:
+            self.report({"WARNING"}, "Operation cancelled: No active MMD model found.")
+            return {"CANCELLED"}
+
+        cleaned_count = FnModel.clean_invalid_bone_id_references(root)
+
+        if cleaned_count > 0:
+            self.report({"INFO"}, f"Successfully cleaned or removed {cleaned_count} invalid bone reference(s).")
+        else:
+            self.report({"INFO"}, "No invalid bone references were found.")
+
+        return {"FINISHED"}
 
 
 class mmd_tools_local_UL_ModelBones(bpy.types.UIList):
@@ -297,7 +346,7 @@ class mmd_tools_local_UL_ModelBones(bpy.types.UIList):
         valid_bone_count = 0
 
         for bone in armature.pose.bones:
-            is_shadow = getattr(bone, 'is_mmd_shadow_bone', False) is True
+            is_shadow = getattr(bone, "is_mmd_shadow_bone", False) is True
             if is_shadow:
                 continue
 
@@ -341,13 +390,13 @@ class mmd_tools_local_UL_ModelBones(bpy.types.UIList):
         # Create index to bone_id mapping
         bone_id_list = []
         for i, bone in enumerate(armature.pose.bones):
-            is_shadow = getattr(bone, 'is_mmd_shadow_bone', False) is True
+            is_shadow = getattr(bone, "is_mmd_shadow_bone", False) is True
             if not is_shadow:
-                bone_id = bone.mmd_bone.bone_id if hasattr(bone.mmd_bone, 'bone_id') else -1
+                bone_id = bone.mmd_bone.bone_id if hasattr(bone.mmd_bone, "bone_id") else -1
                 bone_id_list.append((i, bone_id))
 
         # Sort by bone_id
-        bone_id_list.sort(key=lambda x: x[1] if x[1] >= 0 else float('inf'))
+        bone_id_list.sort(key=lambda x: x[1] if x[1] >= 0 else float("inf"))
 
         # Create order mapping
         for new_idx, (orig_idx, _) in enumerate(bone_id_list):
@@ -359,7 +408,7 @@ class mmd_tools_local_UL_ModelBones(bpy.types.UIList):
         r = None
         min_length = None
         for child in target_bone.children:
-            is_shadow = getattr(child, 'is_mmd_shadow_bone', False) is True
+            is_shadow = getattr(child, "is_mmd_shadow_bone", False) is True
             if is_shadow:
                 continue
             if child.bone.use_connect:
@@ -375,33 +424,62 @@ class mmd_tools_local_UL_ModelBones(bpy.types.UIList):
         bones = getattr(data, propname)
         bone_count = len(bones)
 
+        helper_funcs = bpy.types.UI_UL_list
+
         # Filter out shadow bones
         filtered_flags = []
         for bone in bones:
-            is_shadow = getattr(bone, 'is_mmd_shadow_bone', False) is True
+            is_shadow = getattr(bone, "is_mmd_shadow_bone", False) is True
             if is_shadow:
                 filtered_flags.append(0)  # Filter out shadow bones
             else:
                 filtered_flags.append(self.bitflag_filter_item)  # Show non-shadow bones
 
-        # Use defined sort order
-        if not self._bone_order_map:
-            # If no sort mapping yet, update once
-            self.update_sorted_bones(data)
+        # Apply name search filter
+        if self.filter_name:
+            filtered_flags = helper_funcs.filter_items_by_name(self.filter_name, self.bitflag_filter_item, bones, "name", reverse=False)
+            # Re-apply shadow bone filter
+            for i, bone in enumerate(bones):
+                is_shadow = getattr(bone, "is_mmd_shadow_bone", False) is True
+                if is_shadow:
+                    filtered_flags[i] = 0
 
+        # Apply invert filter
+        if self.use_filter_invert:
+            for i in range(bone_count):
+                if filtered_flags[i]:
+                    filtered_flags[i] = 0
+                else:
+                    # Only show non-shadow bones when inverted
+                    is_shadow = getattr(bones[i], "is_mmd_shadow_bone", False) is True
+                    if not is_shadow:
+                        filtered_flags[i] = self.bitflag_filter_item
+
+        # Sort items
         ordered_indices = []
-        for i in range(bone_count):
-            if filtered_flags[i]:  # Only sort displayed bones
-                ordered_indices.append(self._bone_order_map.get(i, i))
-            else:
-                ordered_indices.append(i)  # Keep filtered items in original position
+
+        if self.use_filter_sort_alpha:
+            # Sort by name alphabetically
+            ordered_indices = helper_funcs.sort_items_by_name(bones, "name")
+        else:
+            # Sort by bone_id (default)
+            # Use defined sort order
+            if not self._bone_order_map:
+                # If no sort mapping yet, update once
+                self.update_sorted_bones(data)
+
+            for i in range(bone_count):
+                if filtered_flags[i]:  # Only sort displayed bones
+                    ordered_indices.append(self._bone_order_map.get(i, i))
+                else:
+                    ordered_indices.append(i)  # Keep filtered items in original position
 
         return filtered_flags, ordered_indices
 
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
-        if self.layout_type in {"DEFAULT"}:
+        if self.layout_type == "DEFAULT":
             self._draw_bone_item(layout, item)
-        elif self.layout_type in {"GRID"}:
+        elif self.layout_type == "GRID":
             layout.alignment = "CENTER"
             layout.label(text="", icon_value=icon)
 
@@ -410,7 +488,7 @@ class mmd_tools_local_UL_ModelBones(bpy.types.UIList):
         """Draw a single bone item in the UI list"""
         is_shadow = False
         if bone:
-            is_shadow = getattr(bone, 'is_mmd_shadow_bone', False) is True
+            is_shadow = getattr(bone, "is_mmd_shadow_bone", False) is True
 
         if not bone or is_shadow:
             layout.active = False
@@ -423,14 +501,14 @@ class mmd_tools_local_UL_ModelBones(bpy.types.UIList):
         has_duplicate = False
         if bone_id >= 0:
             for other_bone in bone.id_data.pose.bones:
-                if other_bone != bone and not getattr(other_bone, 'is_mmd_shadow_bone', False) and other_bone.mmd_bone.bone_id == bone_id:
+                if other_bone != bone and not getattr(other_bone, "is_mmd_shadow_bone", False) and other_bone.mmd_bone.bone_id == bone_id:
                     has_duplicate = True
                     break
 
         count = len(bone.id_data.pose.bones)
         bone_transform_rank = bone_id + bone.mmd_bone.transform_order * count
 
-        row = layout.split(factor=0.45, align=False)
+        row = layout.split(factor=0.4, align=False)
         r0 = row.row()
         r0.label(text=bone.name, translate=False, icon="POSE_HLT" if bone.name in cls._IK_BONES else "BONE_DATA")
         r = r0.row()
@@ -442,7 +520,7 @@ class mmd_tools_local_UL_ModelBones(bpy.types.UIList):
         else:
             r.label(text=str(bone_id))
 
-        row_sub = row.split(factor=0.67, align=False)
+        row_sub = row.split(factor=0.5, align=False)
 
         # Display bone relationships
         r = row_sub.row()
@@ -454,7 +532,7 @@ class mmd_tools_local_UL_ModelBones(bpy.types.UIList):
             parent_icon = "ERROR"
             if parent_bone_id >= 0:
                 if bone_transform_rank >= (parent_bone_id + bone_parent.mmd_bone.transform_order * count):
-                    parent_icon = "INFO" if bone_id < parent_bone_id else "FILE_PARENT"
+                    parent_icon = "FILE_PARENT"
             r.label(text=str(parent_bone_id), icon=parent_icon)
         else:
             r.label()
@@ -497,7 +575,7 @@ class mmd_tools_local_UL_ModelBones(bpy.types.UIList):
             ik_bones_data.append((ik_bone_id, ik_bone, icon))
 
         # Sort by bone_id (similar to the old version's vertex_group index sorting)
-        for bone_id, ik_bone, icon in sorted(ik_bones_data, key=lambda x: x[0] if x[0] >= 0 else float('inf')):
+        for bone_id, ik_bone, icon in sorted(ik_bones_data, key=lambda x: x[0] if x[0] >= 0 else float("inf")):
             r.prop(ik_bone, "mmd_ik_toggle", text=str(bone_id), toggle=True, icon=icon)
 
         # Display transform order and post-dynamics transform
@@ -508,6 +586,9 @@ class mmd_tools_local_UL_ModelBones(bpy.types.UIList):
         else:
             row.prop(mmd_bone, "transform_after_dynamics", text="", toggle=True, icon="BLANK1")
         row.prop(mmd_bone, "transform_order", text="", slider=bool(mmd_bone.transform_order))
+
+        row.prop(bone.bone, "select", text="", emboss=False, icon_only=True, icon="RESTRICT_SELECT_OFF" if bone.select else "RESTRICT_SELECT_ON")
+        row.prop(bone.bone, "hide", text="", emboss=False, icon_only=True)  # auto icon
 
 
 class MMDBoneOrderMenu(bpy.types.Menu):

--- a/extern_tools/mmd_tools_local/panels/sidebar/display_panel.py
+++ b/extern_tools/mmd_tools_local/panels/sidebar/display_panel.py
@@ -77,7 +77,7 @@ class MMDDisplayItemsPanel(PT_ProductionPanelBase, bpy.types.Panel):
 class MMD_ROOT_UL_display_item_frames(bpy.types.UIList):
     def draw_item(self, _context, layout, _data, item, icon, _active_data, _active_propname, _index):
         frame = item
-        if self.layout_type in {"DEFAULT"}:
+        if self.layout_type == "DEFAULT":
             row = layout.split(factor=0.5, align=True)
             if frame.is_special:
                 row.label(text=frame.name, translate=False)
@@ -87,9 +87,9 @@ class MMD_ROOT_UL_display_item_frames(bpy.types.UIList):
             else:
                 row.prop(frame, "name", text="", emboss=False)
                 row.prop(frame, "name_e", text="", emboss=True)
-        elif self.layout_type in {"COMPACT"}:
+        elif self.layout_type == "COMPACT":
             pass
-        elif self.layout_type in {"GRID"}:
+        elif self.layout_type == "GRID":
             layout.alignment = "CENTER"
             layout.label(text="", icon_value=icon)
 
@@ -125,7 +125,7 @@ class MMD_ROOT_UL_display_items(bpy.types.UIList):
     )
 
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
-        if self.layout_type in {"DEFAULT"}:
+        if self.layout_type == "DEFAULT":
             if item.type == "BONE":
                 row = layout.split(factor=0.5, align=True)
                 row.prop(item, "name", text="", emboss=False, icon="BONE_DATA")
@@ -137,9 +137,9 @@ class MMD_ROOT_UL_display_items(bpy.types.UIList):
                 row.prop(item, "morph_type", text="", emboss=False)
                 if item.name not in getattr(item.id_data.mmd_root, item.morph_type):
                     row.label(icon="ERROR")
-        elif self.layout_type in {"COMPACT"}:
+        elif self.layout_type == "COMPACT":
             pass
-        elif self.layout_type in {"GRID"}:
+        elif self.layout_type == "GRID":
             layout.alignment = "CENTER"
             layout.label(text="", icon_value=icon)
 

--- a/extern_tools/mmd_tools_local/panels/sidebar/material_sorter.py
+++ b/extern_tools/mmd_tools_local/panels/sidebar/material_sorter.py
@@ -30,17 +30,17 @@ class MMDMaterialSorter(PT_ProductionPanelBase, bpy.types.Panel):
 
 class mmd_tools_local_UL_Materials(bpy.types.UIList):
     def draw_item(self, _context, layout, _data, item, icon, _active_data, _active_propname, _index):
-        if self.layout_type in {"DEFAULT"}:
+        if self.layout_type == "DEFAULT":
             if item:
                 row = layout.row(align=True)
-                item_prop = getattr(item, "mmd_material")
+                item_prop = item.mmd_material
                 row.prop(item_prop, "name_j", text="", emboss=False, icon="MATERIAL")
                 row.prop(item_prop, "name_e", text="", emboss=True)
             else:
                 layout.label(text="UNSET", translate=False, icon="ERROR")
-        elif self.layout_type in {"COMPACT"}:
+        elif self.layout_type == "COMPACT":
             pass
-        elif self.layout_type in {"GRID"}:
+        elif self.layout_type == "GRID":
             layout.alignment = "CENTER"
             layout.label(text="", icon_value=icon)
 

--- a/extern_tools/mmd_tools_local/panels/sidebar/meshes_sorter.py
+++ b/extern_tools/mmd_tools_local/panels/sidebar/meshes_sorter.py
@@ -35,11 +35,11 @@ class MMDMeshSorter(PT_ProductionPanelBase, bpy.types.Panel):
 
 class mmd_tools_local_UL_ModelMeshes(bpy.types.UIList):
     def draw_item(self, _context, layout, _data, item, icon, _active_data, _active_propname, _index):
-        if self.layout_type in {"DEFAULT"}:
+        if self.layout_type == "DEFAULT":
             layout.label(text=item.name, translate=False, icon="OBJECT_DATA")
-        elif self.layout_type in {"COMPACT"}:
+        elif self.layout_type == "COMPACT":
             pass
-        elif self.layout_type in {"GRID"}:
+        elif self.layout_type == "GRID":
             layout.alignment = "CENTER"
             layout.label(text="", icon_value=icon)
 
@@ -53,7 +53,9 @@ class mmd_tools_local_UL_ModelMeshes(bpy.types.UIList):
         flt_neworder = list(range(len(objects)))
 
         armature = FnModel.find_armature_object(FnModel.find_root_object(context.active_object))
-        __is_child_of_armature = lambda x: x.parent and (x.parent == armature or __is_child_of_armature(x.parent))
+
+        def __is_child_of_armature(x):
+            return x.parent and (x.parent == armature or __is_child_of_armature(x.parent))
 
         name_dict = {}
         for i, obj in enumerate(objects):

--- a/extern_tools/mmd_tools_local/panels/sidebar/model_production.py
+++ b/extern_tools/mmd_tools_local/panels/sidebar/model_production.py
@@ -35,7 +35,7 @@ class MMDModelProductionPanel(PT_ProductionPanelBase, bpy.types.Panel):
 
     def draw_edit(self, _context):
         col = self.layout.column(align=True)
-        col.label(text="Model Surgery:", icon="MOD_ARMATURE")
+        col.label(text="Model Surgery (Experimental):", icon="MOD_ARMATURE")
         grid = col.grid_flow(row_major=True, align=True)
 
         separate_row = grid.row(align=True)

--- a/extern_tools/mmd_tools_local/panels/sidebar/model_setup.py
+++ b/extern_tools/mmd_tools_local/panels/sidebar/model_setup.py
@@ -99,6 +99,8 @@ class MMDToolsModelSetupPanel(PT_PanelBase, bpy.types.Panel):
         self.__toggle_items_ttl = time.time() + 10
         self.__toggle_items_cache = []
         armature_object = FnModel.find_armature_object(mmd_root_object)
+        if armature_object is None:
+            return self.__toggle_items_cache
         pose_bones = armature_object.pose.bones
         ik_map = {pose_bones[c.subtarget]: (b.bone, c.chain_count, not c.is_valid) for b in pose_bones for c in b.constraints if c.type == "IK" and c.subtarget in pose_bones}
 
@@ -134,7 +136,7 @@ class MMDToolsModelSetupPanel(PT_PanelBase, bpy.types.Panel):
         col = self.layout.column(align=True)
         col.label(text="Mesh:", icon="MESH_DATA")
         grid = col.grid_flow(row_major=True, align=True)
-        grid.row(align=True).operator("mmd_tools_local.separate_by_materials", text="Separate by Materials", icon="MOD_EXPLODE")
+        grid.row(align=True).operator("mmd_tools_local.separate_by_materials", text="Sep by Mat(High Risk)", icon="MOD_EXPLODE")
         grid.row(align=True).operator("mmd_tools_local.join_meshes", text="Join", icon="MESH_CUBE")
 
     def draw_material(self, context, mmd_root_object):
@@ -150,7 +152,8 @@ class MMDToolsModelSetupPanel(PT_PanelBase, bpy.types.Panel):
         row.operator("mmd_tools_local.edge_preview_setup", text="", icon="TRASH").action = "CLEAN"
         row = grid.row(align=True)
         row.operator("mmd_tools_local.convert_materials", text="Convert to Blender", icon="BLENDER")
-        row.operator('mmd_tools_local.convert_bsdf_materials', text='Convert to MMD', icon='MATSPHERE')
+        row.operator("mmd_tools_local.merge_materials", text="", icon="LINK_BLEND")
+        row.operator("mmd_tools_local.convert_bsdf_materials", text="Convert to MMD", icon="MATSPHERE")
 
     def draw_misc(self, context, mmd_root_object):
         col = self.layout.column(align=True)

--- a/extern_tools/mmd_tools_local/panels/sidebar/morph_tools.py
+++ b/extern_tools/mmd_tools_local/panels/sidebar/morph_tools.py
@@ -30,6 +30,11 @@ class MMDMorphToolsPanel(PT_ProductionPanelBase, bpy.types.Panel):
         row.prop(mmd_root, "active_morph_type", expand=True)
         morph_type = mmd_root.active_morph_type
 
+        grid = col.grid_flow(row_major=True, align=False)
+        row = grid.row(align=True)
+        row.prop(mmd_root, "show_japanese_name", toggle=True)
+        row.prop(mmd_root, "show_english_name", toggle=True)
+
         c = col.column(align=True)
         row = c.row()
         row.template_list("mmd_tools_local_UL_Morphs", "", mmd_root, morph_type, mmd_root, "active_morph")
@@ -59,7 +64,7 @@ class MMDMorphToolsPanel(PT_ProductionPanelBase, bpy.types.Panel):
             )
             row.label(text="Morph Settings")
             if mmd_root.morph_panel_show_settings:
-                draw_func = getattr(self, "_draw_%s_data" % morph_type[:-7], None)
+                draw_func = getattr(self, f"_draw_{morph_type[:-7]}_data", None)
                 if draw_func:
                     draw_func(context, rig, col, morph)
 
@@ -111,7 +116,7 @@ class MMDMorphToolsPanel(PT_ProductionPanelBase, bpy.types.Panel):
         c_mat.prop_search(data, "material", related_mesh or bpy.data, "materials")
 
         base_mat_name = data.material
-        if "_temp" in base_mat_name:
+        if base_mat_name and "_temp" in base_mat_name:
             col.label(text="This is not a valid base material", icon="ERROR")
             return
 
@@ -182,6 +187,9 @@ class MMDMorphToolsPanel(PT_ProductionPanelBase, bpy.types.Panel):
         row.operator(operators_morph.ApplyBoneMorph.bl_idname, text="Apply")
         row.operator(operators_morph.ClearBoneMorphView.bl_idname, text="Clear")
 
+        row = col.row(align=True)
+        row.operator("mmd_tools_local.convert_bone_morph_to_vertex_morph", text="Convert To Vertex Morph", icon="SHAPEKEY_DATA")
+
         col.label(text=bpy.app.translations.pgettext_iface("Bone Offsets (%d)") % len(morph.data))
         data = self._template_morph_offset_list(col, morph, "mmd_tools_local_UL_BoneMorphOffsets")
         if data is None:
@@ -223,7 +231,7 @@ class MMDMorphToolsPanel(PT_ProductionPanelBase, bpy.types.Panel):
 
     def _draw_group_data(self, context, rig, col, morph):
         row = col.row(align=True)
-        row.operator("mmd_tools_local.convert_group_morph_to_vertex_morph", text="Merge Group Vertex Morphs", icon="SHAPEKEY_DATA")
+        row.operator("mmd_tools_local.convert_group_morph_to_vertex_morph", text="Convert To Vertex Morph", icon="SHAPEKEY_DATA")
 
         col.label(text=bpy.app.translations.pgettext_iface("Group Offsets (%d)") % len(morph.data))
         item = self._template_morph_offset_list(col, morph, "mmd_tools_local_UL_GroupMorphOffsets")
@@ -237,71 +245,91 @@ class MMDMorphToolsPanel(PT_ProductionPanelBase, bpy.types.Panel):
 
 
 class mmd_tools_local_UL_Morphs(bpy.types.UIList):
-    def draw_item(self, _context, layout, data, item, icon, _active_data, _active_propname, _index):
+    def draw_item(self, context, layout, data, item, icon, _active_data, _active_propname, _index):
         mmd_root = data
-        if self.layout_type in {"DEFAULT"}:
-            row = layout.split(factor=0.4, align=True)
-            row.prop(item, "name", text="", emboss=False, icon="SHAPEKEY_DATA")
-            row = row.split(factor=0.6, align=True)
-            row.prop(item, "name_e", text="", emboss=True)
-            row = row.row(align=True)
-            row.prop(item, "category", text="", emboss=False)
+        if self.layout_type == "DEFAULT":
+            # main row
+            row = layout.row(align=True)
+
+            # Left part
+            info_split = row.split(factor=0.7, align=True)
+            left_row = info_split.row(align=True)
+            if mmd_root.show_japanese_name:
+                left_row.prop(item, "name", text="", emboss=False, icon="SHAPEKEY_DATA")
+            if mmd_root.show_english_name:
+                left_row.prop(item, "name_e", text="", emboss=True)
+
+            # Morph category
+            cat_row = info_split.row(align=True)
+            cat_row.prop(item, "category", text="", emboss=False)
+
+            # Facial Frame
             frame_facial = mmd_root.display_item_frames.get("表情")
             morph_item = frame_facial.data.get(item.name) if frame_facial else None
             if morph_item is None:
-                row.label(icon="INFO")
+                cat_row.label(icon="INFO")
             elif morph_item.morph_type != mmd_root.active_morph_type:
-                row.label(icon="SHAPEKEY_DATA")
+                cat_row.label(icon="SHAPEKEY_DATA")
             else:
-                row.label(icon="BLANK1")
+                cat_row.label(icon="BLANK1")
+
+            # Value Slider
+            slider_row = row.row(align=True)
+            root = FnModel.find_root_object(context.active_object)
+            if root:
+                rig = Model(root)
+                slider = rig.morph_slider.get(item.name)
+                if slider:
+                    slider_row.prop(slider, "value", text="", slider=True)
+
             if isinstance(item, MaterialMorph) and any(not d.material for d in item.data):
                 row.label(icon="TEMP")
-        elif self.layout_type in {"COMPACT"}:
+        elif self.layout_type == "COMPACT":
             pass
-        elif self.layout_type in {"GRID"}:
+        elif self.layout_type == "GRID":
             layout.alignment = "CENTER"
             layout.label(text="", icon_value=icon)
 
 
 class mmd_tools_local_UL_MaterialMorphOffsets(bpy.types.UIList):
     def draw_item(self, _context, layout, _data, item, icon, _active_data, _active_propname, _index):
-        if self.layout_type in {"DEFAULT"}:
+        if self.layout_type == "DEFAULT":
             material = item.material
             layout.label(text=material or "All Materials", translate=False, icon="MATERIAL")
-        elif self.layout_type in {"COMPACT"}:
+        elif self.layout_type == "COMPACT":
             pass
-        elif self.layout_type in {"GRID"}:
+        elif self.layout_type == "GRID":
             layout.alignment = "CENTER"
             layout.label(text="", icon_value=icon)
 
 
 class mmd_tools_local_UL_UVMorphOffsets(bpy.types.UIList):
     def draw_item(self, _context, layout, _data, item, icon, _active_data, _active_propname, _index):
-        if self.layout_type in {"DEFAULT"}:
+        if self.layout_type == "DEFAULT":
             layout.label(text=str(item.index), translate=False, icon="MESH_DATA")
             layout.prop(item, "offset", text="", emboss=False, slider=True)
-        elif self.layout_type in {"COMPACT"}:
+        elif self.layout_type == "COMPACT":
             pass
-        elif self.layout_type in {"GRID"}:
+        elif self.layout_type == "GRID":
             layout.alignment = "CENTER"
             layout.label(text="", icon_value=icon)
 
 
 class mmd_tools_local_UL_BoneMorphOffsets(bpy.types.UIList):
     def draw_item(self, _context, layout, _data, item, icon, _active_data, _active_propname, _index):
-        if self.layout_type in {"DEFAULT"}:
+        if self.layout_type == "DEFAULT":
             layout.prop(item, "bone", text="", emboss=False, icon="BONE_DATA")
             FnDraw.draw_bone_special(layout, FnModel.find_armature_object(item.id_data), item.bone)
-        elif self.layout_type in {"COMPACT"}:
+        elif self.layout_type == "COMPACT":
             pass
-        elif self.layout_type in {"GRID"}:
+        elif self.layout_type == "GRID":
             layout.alignment = "CENTER"
             layout.label(text="", icon_value=icon)
 
 
 class mmd_tools_local_UL_GroupMorphOffsets(bpy.types.UIList):
     def draw_item(self, _context, layout, _data, item, icon, _active_data, _active_propname, _index):
-        if self.layout_type in {"DEFAULT"}:
+        if self.layout_type == "DEFAULT":
             row = layout.split(factor=0.5, align=True)
             row.prop(item, "name", text="", emboss=False, icon="SHAPEKEY_DATA")
             row = row.row(align=True)
@@ -310,9 +338,9 @@ class mmd_tools_local_UL_GroupMorphOffsets(bpy.types.UIList):
                 row.prop(item, "factor", text="", emboss=False, slider=True)
             else:
                 row.label(icon="ERROR")
-        elif self.layout_type in {"COMPACT"}:
+        elif self.layout_type == "COMPACT":
             pass
-        elif self.layout_type in {"GRID"}:
+        elif self.layout_type == "GRID":
             layout.alignment = "CENTER"
             layout.label(text="", icon_value=icon)
 

--- a/extern_tools/mmd_tools_local/preferences.py
+++ b/extern_tools/mmd_tools_local/preferences.py
@@ -6,6 +6,43 @@ import os
 import bpy
 
 
+def get_preset_items_for_operator(operator_bl_idname):
+    """Get preset items for EnumProperty"""
+    items = [("__DEFAULT__", "Default", "Use built-in defaults")]
+    try:
+        from .operators import fileio
+
+        presets = fileio.get_available_presets(operator_bl_idname)
+        items.extend((preset, preset, f"Use preset: {preset}") for preset in presets)
+    except Exception:
+        pass
+    return items
+
+
+def get_pmx_import_preset_items(self, context):
+    return get_preset_items_for_operator("mmd_tools_local.import_model")
+
+
+def get_vmd_import_preset_items(self, context):
+    return get_preset_items_for_operator("mmd_tools_local.import_vmd")
+
+
+def get_vpd_import_preset_items(self, context):
+    return get_preset_items_for_operator("mmd_tools_local.import_vpd")
+
+
+def get_pmx_export_preset_items(self, context):
+    return get_preset_items_for_operator("mmd_tools_local.export_pmx")
+
+
+def get_vmd_export_preset_items(self, context):
+    return get_preset_items_for_operator("mmd_tools_local.export_vmd")
+
+
+def get_vpd_export_preset_items(self, context):
+    return get_preset_items_for_operator("mmd_tools_local.export_vpd")
+
+
 class MMDToolsAddonPreferences(bpy.types.AddonPreferences):
     bl_idname = __package__
 
@@ -31,9 +68,75 @@ class MMDToolsAddonPreferences(bpy.types.AddonPreferences):
         default=os.path.dirname(__file__),
     )
 
+    # Preset selection properties
+    default_pmx_import_preset: bpy.props.EnumProperty(
+        name="Default PMX Import Operator Preset",
+        description="Default preset to use for PMX import operations",
+        items=get_pmx_import_preset_items,
+        default=0,
+    )
+    default_vmd_import_preset: bpy.props.EnumProperty(
+        name="Default VMD Import Operator Preset",
+        description="Default preset to use for VMD import operations",
+        items=get_vmd_import_preset_items,
+        default=0,
+    )
+    default_vpd_import_preset: bpy.props.EnumProperty(
+        name="Default VPD Import Operator Preset",
+        description="Default preset to use for VPD import operations",
+        items=get_vpd_import_preset_items,
+        default=0,
+    )
+    default_pmx_export_preset: bpy.props.EnumProperty(
+        name="Default PMX Export Operator Preset",
+        description="Default preset to use for PMX export operations",
+        items=get_pmx_export_preset_items,
+        default=0,
+    )
+    default_vmd_export_preset: bpy.props.EnumProperty(
+        name="Default VMD Export Operator Preset",
+        description="Default preset to use for VMD export operations",
+        items=get_vmd_export_preset_items,
+        default=0,
+    )
+    default_vpd_export_preset: bpy.props.EnumProperty(
+        name="Default VPD Export Operator Preset",
+        description="Default preset to use for VPD export operations",
+        items=get_vpd_export_preset_items,
+        default=0,
+    )
+
+    def initialize_defaults(self):
+        """Initialize default preset values, converting empty strings to default preset"""
+        preset_configs = [
+            ("default_pmx_import_preset", "mmd_tools_local.import_model"),
+            ("default_pmx_export_preset", "mmd_tools_local.export_pmx"),
+            ("default_vmd_import_preset", "mmd_tools_local.import_vmd"),
+            ("default_vmd_export_preset", "mmd_tools_local.export_vmd"),
+            ("default_vpd_import_preset", "mmd_tools_local.import_vpd"),
+            ("default_vpd_export_preset", "mmd_tools_local.export_vpd"),
+        ]
+
+        for prop_name, operator_name in preset_configs:
+            current_value = getattr(self, prop_name, "")
+            if current_value == "":  # Uninitialized
+                setattr(self, prop_name, "__DEFAULT__")
+
     def draw(self, _context):
         layout: bpy.types.UILayout = self.layout  # pylint: disable=no-member
+
+        self.initialize_defaults()
+
         layout.prop(self, "enable_mmd_model_production_features")
         layout.prop(self, "shared_toon_folder")
         layout.prop(self, "base_texture_folder")
         layout.prop(self, "dictionary_folder")
+
+        layout.separator()
+        layout.label(text="Default Operator Presets:")
+        layout.prop(self, "default_pmx_import_preset", text="PMX Import")
+        layout.prop(self, "default_pmx_export_preset", text="PMX Export")
+        layout.prop(self, "default_vmd_import_preset", text="VMD Import")
+        layout.prop(self, "default_vmd_export_preset", text="VMD Export")
+        layout.prop(self, "default_vpd_import_preset", text="VPD Import")
+        layout.prop(self, "default_vpd_export_preset", text="VPD Export")

--- a/extern_tools/mmd_tools_local/properties/__init__.py
+++ b/extern_tools/mmd_tools_local/properties/__init__.py
@@ -4,20 +4,20 @@
 import bpy
 
 
-def patch_library_overridable(property: "bpy.props._PropertyDeferred") -> "bpy.props._PropertyDeferred":
+def patch_library_overridable(prop: "bpy.props._PropertyDeferred") -> "bpy.props._PropertyDeferred":
     """Apply recursively for each mmd_tools_local property class annotations.
     Args:
-        property: The property to be patched.
+        prop: The property to be patched.
 
     Returns:
         The patched property.
     """
-    property.keywords.setdefault("override", set()).add("LIBRARY_OVERRIDABLE")
+    prop.keywords.setdefault("override", set()).add("LIBRARY_OVERRIDABLE")
 
-    if property.function.__name__ not in {"PointerProperty", "CollectionProperty"}:
-        return property
+    if prop.function.__name__ not in {"PointerProperty", "CollectionProperty"}:
+        return prop
 
-    property_type = property.keywords["type"]
+    property_type = prop.keywords["type"]
     # The __annotations__ cannot be inherited. Manually search for base classes.
     for inherited_type in (property_type, *property_type.__bases__):
         if not inherited_type.__module__.startswith("mmd_tools_local.properties"):
@@ -27,4 +27,4 @@ def patch_library_overridable(property: "bpy.props._PropertyDeferred") -> "bpy.p
                 continue
             patch_library_overridable(annotation)
 
-    return property
+    return prop

--- a/extern_tools/mmd_tools_local/properties/morph.py
+++ b/extern_tools/mmd_tools_local/properties/morph.py
@@ -17,7 +17,7 @@ def _morph_base_get_name(prop: "_MorphBase") -> str:
 def _morph_base_set_name(prop: "_MorphBase", value: str):
     mmd_root = prop.id_data.mmd_root
     # morph_type = mmd_root.active_morph_type
-    morph_type = "%s_morphs" % prop.bl_rna.identifier[:-5].lower()
+    morph_type = f"{prop.bl_rna.identifier[:-5].lower()}_morphs"
     # assert(prop.bl_rna.identifier.endswith('Morph'))
     # logging.debug('_set_name: %s %s %s', prop, value, morph_type)
     prop_name = prop.get("name", None)
@@ -96,6 +96,10 @@ class _MorphBase:
     )
 
 
+def _bone_morph_data_update_bone_id(prop: "BoneMorphData", context: bpy.types.Context):
+    pass  # Empty function is sufficient to trigger UI update
+
+
 def _bone_morph_data_get_bone(prop: "BoneMorphData") -> str:
     bone_id = prop.get("bone_id", -1)
     if bone_id < 0:
@@ -120,10 +124,10 @@ def _bone_morph_data_set_bone(prop: "BoneMorphData", value: str):
         return
 
     if value not in arm.pose.bones.keys():
-        prop["bone_id"] = -1
+        prop.bone_id = -1
         return
     pose_bone = arm.pose.bones[value]
-    prop["bone_id"] = FnBone.get_or_assign_bone_id(pose_bone)
+    prop.bone_id = FnBone.get_or_assign_bone_id(pose_bone)
 
 
 def _bone_morph_data_update_location_or_rotation(prop: "BoneMorphData", _context):
@@ -138,8 +142,6 @@ def _bone_morph_data_update_location_or_rotation(prop: "BoneMorphData", _context
 
 
 class BoneMorphData(bpy.types.PropertyGroup):
-    """ """
-
     bone: bpy.props.StringProperty(
         name="Bone",
         description="Target bone",
@@ -149,6 +151,7 @@ class BoneMorphData(bpy.types.PropertyGroup):
 
     bone_id: bpy.props.IntProperty(
         name="Bone ID",
+        update=_bone_morph_data_update_bone_id,
     )
 
     location: bpy.props.FloatVectorProperty(
@@ -185,35 +188,35 @@ class BoneMorph(_MorphBase, bpy.types.PropertyGroup):
 
 
 def _material_morph_data_get_material(prop: "MaterialMorphData"):
-    mat_p = prop.get("material_data", None)
-    if mat_p is not None:
-        return mat_p.name
+    mat_data = prop.get("material_data", None)
+    if mat_data is not None:
+        return mat_data.name
     return ""
 
 
 def _material_morph_data_set_material(prop: "MaterialMorphData", value: str):
     if value not in bpy.data.materials:
-        prop["material_data"] = None
-        prop["material_id"] = -1
+        prop.material_data = None
+        prop.material_id = -1
     else:
         mat = bpy.data.materials[value]
         fnMat = FnMaterial(mat)
-        prop["material_data"] = mat
-        prop["material_id"] = fnMat.material_id
+        prop.material_data = mat
+        prop.material_id = fnMat.material_id
 
 
 def _material_morph_data_set_related_mesh(prop: "MaterialMorphData", value: str):
     mesh = FnModel.find_mesh_object_by_name(prop.id_data, value)
     if mesh is not None:
-        prop["related_mesh_data"] = mesh.data
+        prop.related_mesh_data = mesh.data
     else:
-        prop["related_mesh_data"] = None
+        prop.related_mesh_data = None
 
 
 def _material_morph_data_get_related_mesh(prop):
-    mesh_p = prop.get("related_mesh_data", None)
-    if mesh_p is not None:
-        return mesh_p.name
+    mesh_data = prop.get("related_mesh_data", None)
+    if mesh_data is not None:
+        return mesh_data.name
     return ""
 
 
@@ -222,17 +225,15 @@ def _material_morph_data_update_modifiable_values(prop: "MaterialMorphData", _co
         return
     from ..core.shader import _MaterialMorph
 
-    mat = prop["material_data"]
-    if mat is not None:
-        _MaterialMorph.update_morph_inputs(mat, prop)
+    mat_data = prop.get("material_data", None)
+    if mat_data is not None:
+        _MaterialMorph.update_morph_inputs(mat_data, prop)
     else:
-        for mat in FnModel(prop.id_data).materials():
-            _MaterialMorph.update_morph_inputs(mat, prop)
+        for mat_data in FnModel(prop.id_data).materials():
+            _MaterialMorph.update_morph_inputs(mat_data, prop)
 
 
 class MaterialMorphData(bpy.types.PropertyGroup):
-    """ """
-
     related_mesh: bpy.props.StringProperty(
         name="Related Mesh",
         description="Stores a reference to the mesh where this morph data belongs to",

--- a/extern_tools/mmd_tools_local/properties/rigid_body.py
+++ b/extern_tools/mmd_tools_local/properties/rigid_body.py
@@ -88,7 +88,10 @@ def _set_size(prop, value):
     mesh = obj.data
     rb = obj.rigid_body
 
-    if len(mesh.vertices) == 0 or rb is None or rb.collision_shape != shape:
+    current_size = FnRigidBody.get_rigid_body_size(obj)
+    is_zero_size = all(abs(s) < 1e-6 for s in current_size)
+
+    if len(mesh.vertices) == 0 or rb is None or rb.collision_shape != shape or is_zero_size:
         if shape == "SPHERE":
             bpyutils.makeSphere(
                 radius=value[0],

--- a/extern_tools/mmd_tools_local/properties/root.py
+++ b/extern_tools/mmd_tools_local/properties/root.py
@@ -5,7 +5,6 @@
 
 import bpy
 
-from .. import utils
 from ..bpyutils import FnContext
 from ..core.material import FnMaterial
 from ..core.model import FnModel
@@ -14,11 +13,13 @@ from . import patch_library_overridable
 from .morph import BoneMorph, GroupMorph, MaterialMorph, UVMorph, VertexMorph
 from .translations import MMDTranslation
 
+IS_BLENDER_50_UP = bpy.app.version >= (5, 0)
+
 
 def __driver_variables(constraint: bpy.types.Constraint, path: str, index=-1):
     d = constraint.driver_add(path, index)
     variables = d.driver.variables
-    for x in variables:
+    for x in reversed(variables):
         variables.remove(x)
     return d.driver, variables
 
@@ -164,7 +165,7 @@ def _getVisibilityOfMMDRigArmature(prop: "MMDRoot"):
     if prop.id_data.mmd_type != "ROOT":
         return False
     arm = FnModel.find_armature_object(prop.id_data)
-    return arm and not arm.hide_get()
+    return arm is not None and not arm.hide_get()
 
 
 def _setActiveRigidbodyObject(prop: "MMDRoot", v: int):
@@ -375,6 +376,18 @@ class MMDRoot(bpy.types.PropertyGroup):
         update=_toggleShowNamesOfJoints,
     )
 
+    show_japanese_name: bpy.props.BoolProperty(
+        name="Japanese name",
+        description="Toggle Japanese name display",
+        default=True,
+    )
+
+    show_english_name: bpy.props.BoolProperty(
+        name="English name",
+        description="Toggle English name display",
+        default=True,
+    )
+
     use_toon_texture: bpy.props.BoolProperty(
         name="Use Toon Texture",
         description="Use toon texture",
@@ -529,6 +542,14 @@ class MMDRoot(bpy.types.PropertyGroup):
             prop.hide_viewport = value
 
     @staticmethod
+    def __get_pose_bone_select(prop: bpy.types.PoseBone) -> bool:
+        return prop.bone.select
+
+    @staticmethod
+    def __set_pose_bone_select(prop: bpy.types.PoseBone, value: bool) -> None:
+        prop.bone.select = value
+
+    @staticmethod
     def register():
         bpy.types.Object.mmd_type = patch_library_overridable(
             bpy.props.EnumProperty(
@@ -551,7 +572,7 @@ class MMDRoot(bpy.types.PropertyGroup):
                     ("SPRING_CONSTRAINT", "Spring Constraint", "", 53),
                     ("SPRING_GOAL", "Spring Goal", "", 54),
                 ],
-            )
+            ),
         )
         bpy.types.Object.mmd_root = patch_library_overridable(bpy.props.PointerProperty(type=MMDRoot))
 
@@ -564,7 +585,7 @@ class MMDRoot(bpy.types.PropertyGroup):
                     "ANIMATABLE",
                     "LIBRARY_EDITABLE",
                 },
-            )
+            ),
         )
         bpy.types.Object.hide = patch_library_overridable(
             bpy.props.BoolProperty(
@@ -575,8 +596,23 @@ class MMDRoot(bpy.types.PropertyGroup):
                     "ANIMATABLE",
                     "LIBRARY_EDITABLE",
                 },
-            )
+            ),
         )
+
+        if not IS_BLENDER_50_UP:
+            bpy.types.PoseBone.select = patch_library_overridable(
+                bpy.props.BoolProperty(
+                    name="Select",
+                    description="Pose bone selection state (compatibility layer for Blender 4.x, forwards to bone.select)",
+                    get=MMDRoot.__get_pose_bone_select,
+                    set=MMDRoot.__set_pose_bone_select,
+                    options={
+                        "SKIP_SAVE",
+                        "ANIMATABLE",
+                        "LIBRARY_EDITABLE",
+                    },
+                ),
+            )
 
     @staticmethod
     def unregister():
@@ -584,3 +620,5 @@ class MMDRoot(bpy.types.PropertyGroup):
         del bpy.types.Object.select
         del bpy.types.Object.mmd_root
         del bpy.types.Object.mmd_type
+        if not IS_BLENDER_50_UP:
+            del bpy.types.PoseBone.select

--- a/extern_tools/mmd_tools_local/translations.py
+++ b/extern_tools/mmd_tools_local/translations.py
@@ -3,7 +3,9 @@
 
 import csv
 import logging
+import os
 import time
+from collections import OrderedDict
 
 import bpy
 
@@ -290,9 +292,9 @@ jp_to_en_tuples = [
 
 
 def translateFromJp(name):
-    for tuple in jp_to_en_tuples:
-        if tuple[0] in name:
-            name = name.replace(tuple[0], tuple[1])
+    for t in jp_to_en_tuples:
+        if t[0] in name:
+            name = name.replace(t[0], t[1])
     return name
 
 
@@ -349,8 +351,6 @@ class MMDTranslator:
         self.__csv_tuples.sort(key=lambda row: (-len(row[0]), row))
 
     def update(self):
-        from collections import OrderedDict
-
         count_old = len(self.__csv_tuples)
         tuples_dict = OrderedDict((row[0], row) for row in self.__csv_tuples if len(row) >= 2 and row[0])
         self.__csv_tuples.clear()
@@ -387,7 +387,7 @@ class MMDTranslator:
     def load_from_stream(self, csvfile=None):
         csvfile = csvfile or self.get_csv_text()
         if isinstance(csvfile, bpy.types.Text):
-            csvfile = (l.body + "\n" for l in csvfile.lines)
+            csvfile = (line.body + "\n" for line in csvfile.lines)
         spamreader = csv.reader(csvfile, delimiter=",", skipinitialspace=True)
         csv_tuples = [tuple(row) for row in spamreader if len(row) >= 2]
         self.__csv_tuples = csv_tuples
@@ -406,13 +406,13 @@ class MMDTranslator:
     def load(self, filepath=None):
         filepath = filepath or self.default_csv_filepath()
         logging.info("Loading csv file:\t%s", filepath)
-        with open(filepath, "rt", encoding="utf-8", newline="") as csvfile:
+        with open(filepath, encoding="utf-8", newline="") as csvfile:
             self.load_from_stream(csvfile)
 
     def save(self, filepath=None):
         filepath = filepath or self.default_csv_filepath()
         logging.info("Saving csv file:\t%s", filepath)
-        with open(filepath, "wt", encoding="utf-8", newline="") as csvfile:
+        with open(filepath, "w", encoding="utf-8", newline="") as csvfile:
             self.save_to_stream(csvfile)
 
 
@@ -433,9 +433,7 @@ class DictionaryEnum:
         items.append(("INTERNAL", "Internal Dictionary", "The dictionary defined in " + __name__, len(items)))
 
         for txt_name in sorted(x.name for x in bpy.data.texts if x.name.lower().endswith(".csv")):
-            items.append((txt_name, txt_name, "bpy.data.texts['%s']" % txt_name, "TEXT", len(items)))
-
-        import os
+            items.append((txt_name, txt_name, f"bpy.data.texts['{txt_name}']", "TEXT", len(items)))
 
         folder = FnContext.get_addon_preferences_attribute(context, "dictionary_folder", "")
         if os.path.isdir(folder):

--- a/extern_tools/mmd_tools_local/utils.py
+++ b/extern_tools/mmd_tools_local/utils.py
@@ -4,14 +4,16 @@
 import logging
 import os
 import re
+import string
 from typing import Callable, Optional, Set
 
 import bpy
+import numpy as np
 
 from .bpyutils import FnContext
 
 
-## 指定したオブジェクトのみを選択状態かつアクティブにする
+# 指定したオブジェクトのみを選択状態かつアクティブにする
 def selectAObject(obj):
     try:
         bpy.ops.object.mode_set(mode="OBJECT")
@@ -22,7 +24,7 @@ def selectAObject(obj):
     FnContext.set_active_object(FnContext.ensure_context(), obj)
 
 
-## 現在のモードを指定したオブジェクトのEdit Modeに変更する
+# 現在のモードを指定したオブジェクトのEdit Modeに変更する
 def enterEditMode(obj):
     selectAObject(obj)
     if obj.mode != "EDIT":
@@ -41,8 +43,8 @@ def setParentToBone(obj, parent, bone_name):
 def selectSingleBone(context, armature, bone_name, reset_pose=False):
     try:
         bpy.ops.object.mode_set(mode="OBJECT")
-    except:
-        pass
+    except Exception as e:
+        logging.warning(f"Failed to set object mode: {e}")
     for i in context.selected_objects:
         i.select_set(False)
     FnContext.set_active_object(context, armature)
@@ -50,21 +52,20 @@ def selectSingleBone(context, armature, bone_name, reset_pose=False):
     if reset_pose:
         for p_bone in armature.pose.bones:
             p_bone.matrix_basis.identity()
-    armature_bones: bpy.types.ArmatureBones = armature.data.bones
-    i: bpy.types.Bone
-    for i in armature_bones:
-        i.select = i.name == bone_name
-        i.select_head = i.select_tail = i.select
-        if i.select:
-            armature_bones.active = i
-            i.hide = False
+
+    for p_bone in armature.pose.bones:
+        is_target = p_bone.name == bone_name
+        p_bone.select = is_target
+        if is_target:
+            armature.data.bones.active = p_bone.bone
+            p_bone.bone.hide = False
 
 
-__CONVERT_NAME_TO_L_REGEXP = re.compile("^(.*)左(.*)$")
-__CONVERT_NAME_TO_R_REGEXP = re.compile("^(.*)右(.*)$")
+__CONVERT_NAME_TO_L_REGEXP = re.compile(r"^(.*)左(.*)$")
+__CONVERT_NAME_TO_R_REGEXP = re.compile(r"^(.*)右(.*)$")
 
 
-## 日本語で左右を命名されている名前をblender方式のL(R)に変更する
+# 日本語で左右を命名されている名前をblender方式のL(R)に変更する
 def convertNameToLR(name, use_underscore=False):
     m = __CONVERT_NAME_TO_L_REGEXP.match(name)
     delimiter = "_" if use_underscore else "."
@@ -92,7 +93,7 @@ def convertLRToName(name):
     return name
 
 
-## src_vertex_groupのWeightをdest_vertex_groupにaddする
+# src_vertex_groupのWeightをdest_vertex_groupにaddする
 def mergeVertexGroup(meshObj, src_vertex_group_name, dest_vertex_group_name):
     mesh = meshObj.data
     src_vertex_group = meshObj.vertex_groups[src_vertex_group_name]
@@ -107,40 +108,70 @@ def mergeVertexGroup(meshObj, src_vertex_group_name, dest_vertex_group_name):
             pass
 
 
-def separateByMaterials(meshObj: bpy.types.Object):
-    if len(meshObj.data.materials) < 2:
+def separateByMaterials(meshObj: bpy.types.Object, keep_normals: bool = False):
+    meshData = meshObj.data
+    if len(meshData.materials) < 2:
         selectAObject(meshObj)
         return
-    matrix_parent_inverse = meshObj.matrix_parent_inverse.copy()
-    prev_parent = meshObj.parent
-    dummy_parent = bpy.data.objects.new(name="tmp", object_data=None)
-    meshObj.parent = dummy_parent
-    meshObj.active_shape_key_index = 0
+
+    dummy_parent = None
     try:
-        enterEditMode(meshObj)
-        bpy.ops.mesh.select_all(action="SELECT")
-        bpy.ops.mesh.separate(type="MATERIAL")
+        dummy_parent = bpy.data.objects.new(name="tmp", object_data=None)
+        matrix_parent_inverse = meshObj.matrix_parent_inverse.copy()
+        prev_parent = meshObj.parent
+        meshObj.parent = dummy_parent
+        meshObj.active_shape_key_index = 0
+        mmd_normal_name = None  # To avoid conflict ("mmd_normal.001", etc.)
+        if keep_normals:
+            existing_custom_normal = meshData.attributes.get("custom_normal")
+            if existing_custom_normal:
+                if existing_custom_normal.data_type == "INT16_2D":
+                    normals_data = np.empty(len(meshData.loops) * 2, dtype=np.int16)
+                    existing_custom_normal.data.foreach_get("value", normals_data)
+                    mmd_normal = meshData.attributes.new("mmd_normal", "INT16_2D", "CORNER")
+                    mmd_normal_name = mmd_normal.name
+                    mmd_normal.data.foreach_set("value", normals_data)
+                else:
+                    raise TypeError(f"Unsupported custom_normal data type: '{existing_custom_normal.data_type}'. Supported types: 'INT16_2D'")
+
+        try:
+            enterEditMode(meshObj)
+            bpy.ops.mesh.separate(type="MATERIAL")
+        finally:
+            bpy.ops.object.mode_set(mode="OBJECT")
+
+        for i in dummy_parent.children:
+            materials = i.data.materials
+            i.name = getattr(materials[0], "name", "None") if len(materials) else "None"
+            i.parent = prev_parent
+            i.matrix_parent_inverse = matrix_parent_inverse
+
+            if keep_normals and mmd_normal_name:
+                mmd_normal = i.data.attributes.get(mmd_normal_name)
+                if mmd_normal:
+                    if mmd_normal.data_type == "INT16_2D":
+                        normals_data = np.empty(len(i.data.loops) * 2, dtype=np.int16)
+                        mmd_normal.data.foreach_get("value", normals_data)
+                        custom_normal_attr = i.data.attributes.get("custom_normal")
+                        if not custom_normal_attr:
+                            custom_normal_attr = i.data.attributes.new("custom_normal", "INT16_2D", "CORNER")
+                        custom_normal_attr.data.foreach_set("value", normals_data)
+                    else:
+                        raise TypeError(f"Unsupported custom_normal data type: '{mmd_normal.data_type}'. Supported types: 'INT16_2D'")
+                    i.data.attributes.remove(mmd_normal)
     finally:
-        bpy.ops.object.mode_set(mode="OBJECT")
-    for i in dummy_parent.children:
-        materials = i.data.materials
-        i.name = getattr(materials[0], "name", "None") if len(materials) else "None"
-        i.parent = prev_parent
-        i.matrix_parent_inverse = matrix_parent_inverse
-    bpy.data.objects.remove(dummy_parent)
+        if dummy_parent and dummy_parent.name in bpy.data.objects:
+            bpy.data.objects.remove(dummy_parent)
 
 
 def clearUnusedMeshes():
-    meshes_to_delete = []
-    for mesh in bpy.data.meshes:
-        if mesh.users == 0:
-            meshes_to_delete.append(mesh)
+    meshes_to_delete = [mesh for mesh in bpy.data.meshes if mesh.users == 0]
 
     for mesh in meshes_to_delete:
         bpy.data.meshes.remove(mesh)
 
 
-## Boneのカスタムプロパティにname_jが存在する場合、name_jの値を
+# Boneのカスタムプロパティにname_jが存在する場合、name_jの値を
 # それ以外の場合は通常のbone名をキーとしたpose_boneへの辞書を作成
 def makePmxBoneMap(armObj):
     # Maintain backward compatibility with mmd_tools_local v0.4.x or older.
@@ -151,7 +182,7 @@ __REMOVE_PREFIX_DIGITS_REGEXP = re.compile(r"\.\d{1,}$")
 
 
 def unique_name(name: str, used_names: Set[str]) -> str:
-    """Helper function for storing unique names.
+    """Generate a unique name from the given name.
     This function is a limited and simplified version of bpy_extras.io_utils.unique_name.
 
     Args:
@@ -173,11 +204,9 @@ def unique_name(name: str, used_names: Set[str]) -> str:
 
 def int2base(x, base, width=0):
     """
-    Method to convert an int to a base
+    Convert an int to a base
     Source: http://stackoverflow.com/questions/2267362
     """
-    import string
-
     digs = string.digits + string.ascii_uppercase
     assert 2 <= base <= len(digs)
     digits, negtive = "", False
@@ -220,6 +249,7 @@ def saferelpath(path, start, strategy="inside"):
             return ".." + os.sep + os.path.basename(path)
 
     return os.path.relpath(path, start)
+
 
 class ItemOp:
     @staticmethod
@@ -271,7 +301,7 @@ class ItemMoveOp:
         if index < index_min:
             items.move(index, index_min)
             return index_min
-        elif index > index_max:
+        if index > index_max:
             items.move(index, index_max)
             return index_max
 
@@ -291,7 +321,7 @@ class ItemMoveOp:
 
 
 def deprecated(deprecated_in: Optional[str] = None, details: Optional[str] = None):
-    """Decorator to mark a function as deprecated.
+    """Mark a function as deprecated.
     Args:
         deprecated_in (Optional[str]): Version in which the function was deprecated.
         details (Optional[str]): Additional details about the deprecation.
@@ -310,7 +340,7 @@ def deprecated(deprecated_in: Optional[str] = None, details: Optional[str] = Non
 
 
 def warn_deprecation(function_name: str, deprecated_in: Optional[str] = None, details: Optional[str] = None) -> None:
-    """Reports a deprecation warning.
+    """Report a deprecation warning.
     Args:
         function_name (str): Name of the deprecated function.
         deprecated_in (Optional[str]): Version in which the function was deprecated.

--- a/resources/translations/en_US.json
+++ b/resources/translations/en_US.json
@@ -819,6 +819,6 @@
         "EyeTrackingPanel.troubleshooting.shapeKeys": "• Check shape keys are named correctly", 
         "EyeTrackingPanel.troubleshooting.boneWeights": "• Ensure eye bones are properly weighted",
         "EyeTrackingPanel.troubleshooting.restPosition": "• Confirm armature is in rest position",
-        "merge_armatures.error.mustapplytransforms": "Your armature has different scale values for X, Y, and Z axes, rather\nthan having uniform scaling (where all axes have the same scale value)\n\nThis is important to fix before merging armatures to ensure proper bone\ntransformations and avoid potential deformation issues.\n\nIf you want to continue with this merge even with this warning please\nmake sure apply transforms is checked before you start merging."
+        "merge_armatures.error.mustapplytransforms": "Transform Issue Detected!\n\nYour armatures have non-uniform scaling or rotations that need to be fixed before merging.\nThis is important to prevent size changes and deformation issues.\n\nTo fix this:\n1. Enable the 'Apply Transforms' checkbox in the merge settings\n2. Try the merge again\n\nThe 'Apply Transforms' option will normalize all scale, rotation, and position values\nso your armatures merge correctly without changing size.\n\nIf you've already checked 'Apply Transforms' and still see this error,\nplease report this as a bug."
     }
 }

--- a/tools/armature.py
+++ b/tools/armature.py
@@ -289,7 +289,11 @@ class FixArmature(bpy.types.Operator):
                 
         if mmd_root:
             # This is an MMD model, back up and remove bone collections
-            for collection in list(armature.data.collections):
+            # First, collect all bone collection data in EDIT mode
+            Common.set_active(armature)
+            Common.switch('EDIT')
+            
+            for collection in armature.data.collections:
                 # Store collection data
                 collection_data = {
                     'name': collection.name,
@@ -297,14 +301,17 @@ class FixArmature(bpy.types.Operator):
                     'bones': []
                 }
                 
-                # Store bones in edit mode
-                Common.set_active(armature)
-                Common.switch('EDIT')
+                # Store bones while in edit mode
                 for bone in collection.bones:
                     collection_data['bones'].append(bone.name)
                 
                 bone_collections_backup.append(collection_data)
-                # Remove the collection
+            
+            # Switch to OBJECT mode before removing collections to avoid crashes
+            Common.switch('OBJECT')
+            
+            # Now safely remove collections in OBJECT mode
+            for collection in list(armature.data.collections):
                 armature.data.collections.remove(collection)
         
         # Check for Rigify/Metarig
@@ -708,6 +715,9 @@ class FixArmature(bpy.types.Operator):
         for bone in armature.data.edit_bones:
             bone.hide = False
 
+        # Switch to OBJECT mode before removing bone collections to avoid crashes
+        Common.switch('OBJECT')
+
         # Remove Bone Groups
         # Replaced in 4.0 with Bone Collections (Armature.collections), which also subsumed Armature.layers. Bone colors
         # are now defined per-bone, Bone.color.palette and PoseBone.color.palette
@@ -715,8 +725,11 @@ class FixArmature(bpy.types.Operator):
             for group in armature.pose.bone_groups:
                 armature.pose.bone_groups.remove(group)
         else:
-            for collection in armature.data.collections:
+            for collection in list(armature.data.collections):
                 armature.data.collections.remove(collection)
+
+        # Re-enter EDIT mode for subsequent operations
+        Common.switch('EDIT')
 
         # Bone constraints should be deleted
         # if context.scene.remove_constraints:

--- a/tools/armature_custom.py
+++ b/tools/armature_custom.py
@@ -463,8 +463,10 @@ def merge_armatures(
                 return
             Common.apply_transforms(armature_name=merge_armature_name)
         else:
-            adjust_merge_armature_transforms(merge_armature, mesh_merge)
-            Common.apply_transforms(armature_name=merge_armature_name)
+            # Only adjust and apply transforms if the checkbox is enabled
+            if bpy.context.scene.apply_transforms:
+                adjust_merge_armature_transforms(merge_armature, mesh_merge)
+                Common.apply_transforms(armature_name=merge_armature_name)
     elif bpy.context.scene.apply_transforms:
         Common.apply_transforms(armature_name=merge_armature_name)
 

--- a/tools/common.py
+++ b/tools/common.py
@@ -842,6 +842,14 @@ def apply_transforms(armature_name=None):
         bpy.ops.object.transform_apply(location=True, rotation=True, scale=True)
 
 
+def apply_transforms_to_mesh(mesh):
+    """Apply transforms to a single mesh object."""
+    unselect_all()
+    set_active(mesh)
+    switch('OBJECT')
+    bpy.ops.object.transform_apply(location=True, rotation=True, scale=True)
+
+
 def apply_all_transforms():
 
     def apply_transforms_with_children(parent):


### PR DESCRIPTION
This is the Finale Release for Blender 4.5, after this Cats for Blender 4.5 LTS is EOL.

- MMD Tools Upgade to 4.5.2
- Added missing apply_transforms_to_mesh() function
- Fixed transforms being applied even when checkbox was disabled
- Improved error message clarity for transform issues
- Bone collections must be removed in OBJECT mode in Blender 4.5+.
- Fixed two locations where collections were being removed while in EDIT mode, causing crashes during Fix Model operation.

This fixes issue with MMD Tools, issue where merging armatures would unexpectedly change model size even with Apply Transforms unchecked and a issue where all MMD models would crash Blender when using Fix Model.

Due to release 16/11/2025. 