### PR TITLE
Fix Blender UIList class naming conventions and add missing translations

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # MIT License
 
-CATS_VERSION = "5.0.1.0"
+CATS_VERSION = "5.0.1.1"
 dev_branch = True
 
 import os

--- a/extern_tools/mmd_tools_local/m17n.py
+++ b/extern_tools/mmd_tools_local/m17n.py
@@ -5503,8 +5503,8 @@ translations_tuple = (
         ("*", "Model Filter"),
         (
             (
-                "bpy.types.mmd_tools_local_UL_joints.model_filter",
-                "bpy.types.mmd_tools_local_UL_rigidbodies.model_filter",
+                "bpy.types.MMD_TOOLS_LOCAL_UL_Joints.model_filter",
+                "bpy.types.MMD_TOOLS_LOCAL_UL_RigidBodies.model_filter",
             ),
             (),
         ),
@@ -5515,8 +5515,8 @@ translations_tuple = (
         ("*", "Show items of active model or all models"),
         (
             (
-                "bpy.types.mmd_tools_local_UL_joints.model_filter",
-                "bpy.types.mmd_tools_local_UL_rigidbodies.model_filter",
+                "bpy.types.MMD_TOOLS_LOCAL_UL_Joints.model_filter",
+                "bpy.types.MMD_TOOLS_LOCAL_UL_RigidBodies.model_filter",
             ),
             (),
         ),
@@ -5527,8 +5527,8 @@ translations_tuple = (
         ("*", "Active Model"),
         (
             (
-                "bpy.types.mmd_tools_local_UL_joints.model_filter:'ACTIVE'",
-                "bpy.types.mmd_tools_local_UL_rigidbodies.model_filter:'ACTIVE'",
+                "bpy.types.MMD_TOOLS_LOCAL_UL_Joints.model_filter:'ACTIVE'",
+                "bpy.types.MMD_TOOLS_LOCAL_UL_RigidBodies.model_filter:'ACTIVE'",
             ),
             (),
         ),
@@ -5539,8 +5539,8 @@ translations_tuple = (
         ("*", "All Models"),
         (
             (
-                "bpy.types.mmd_tools_local_UL_joints.model_filter:'ALL'",
-                "bpy.types.mmd_tools_local_UL_rigidbodies.model_filter:'ALL'",
+                "bpy.types.MMD_TOOLS_LOCAL_UL_Joints.model_filter:'ALL'",
+                "bpy.types.MMD_TOOLS_LOCAL_UL_RigidBodies.model_filter:'ALL'",
             ),
             (),
         ),
@@ -5551,8 +5551,8 @@ translations_tuple = (
         ("*", "Only show visible items"),
         (
             (
-                "bpy.types.mmd_tools_local_UL_joints.visible_only",
-                "bpy.types.mmd_tools_local_UL_rigidbodies.visible_only",
+                "bpy.types.MMD_TOOLS_LOCAL_UL_Joints.visible_only",
+                "bpy.types.MMD_TOOLS_LOCAL_UL_RigidBodies.visible_only",
             ),
             (),
         ),

--- a/extern_tools/mmd_tools_local/operators/translations.py
+++ b/extern_tools/mmd_tools_local/operators/translations.py
@@ -211,7 +211,7 @@ class TranslateMMDModel(bpy.types.Operator):
 DEFAULT_SHOW_ROW_COUNT = 20
 
 
-class mmd_tools_local_UL_MMDTranslationElementIndex(bpy.types.UIList):
+class MMD_TOOLS_LOCAL_UL_MMDTranslationElementIndex(bpy.types.UIList):
     def draw_item(
         self,
         context,
@@ -321,7 +321,7 @@ class GlobalTranslationPopup(bpy.types.Operator):
             row.label(text="", icon="BLANK1")
 
         col.template_list(
-            "mmd_tools_local_UL_MMDTranslationElementIndex",
+            "MMD_TOOLS_LOCAL_UL_MMDTranslationElementIndex",
             "",
             mmd_translation,
             "filtered_translation_element_indices",

--- a/extern_tools/mmd_tools_local/panels/sidebar/bone_order.py
+++ b/extern_tools/mmd_tools_local/panels/sidebar/bone_order.py
@@ -329,7 +329,7 @@ class MMDToolsCleanInvalidBoneIdReferences(bpy.types.Operator):
         return {"FINISHED"}
 
 
-class mmd_tools_local_UL_ModelBones(bpy.types.UIList):
+class MMD_TOOLS_LOCAL_UL_ModelBones(bpy.types.UIList):
     # Static data for bone relationships
     _IK_MAP = {}
     _IK_BONES = {}
@@ -620,14 +620,14 @@ class MMDBoneOrder(PT_ProductionPanelBase, bpy.types.Panel):
             return
 
         # Update bone tables
-        valid_bone_count = mmd_tools_local_UL_ModelBones.update_bone_tables(armature)
+        valid_bone_count = MMD_TOOLS_LOCAL_UL_ModelBones.update_bone_tables(armature)
 
         # UI
         col = layout.column(align=True)
         row = col.row()
 
         # Bone list sorted by bone_id
-        row.template_list("mmd_tools_local_UL_ModelBones", "", armature.pose, "bones", root.mmd_root, "active_bone_index")
+        row.template_list("MMD_TOOLS_LOCAL_UL_ModelBones", "", armature.pose, "bones", root.mmd_root, "active_bone_index")
 
         # Bone order controls
         tb = row.column()

--- a/extern_tools/mmd_tools_local/panels/sidebar/joints.py
+++ b/extern_tools/mmd_tools_local/panels/sidebar/joints.py
@@ -25,7 +25,7 @@ class MMDJointSelectorPanel(PT_ProductionPanelBase, bpy.types.Panel):
 
         row = c.row()
         row.template_list(
-            "mmd_tools_local_UL_joints",
+            "MMD_TOOLS_LOCAL_UL_Joints",
             "",
             context.scene,
             "objects",
@@ -44,7 +44,7 @@ class MMDJointSelectorPanel(PT_ProductionPanelBase, bpy.types.Panel):
         tb1.operator("mmd_tools_local.object_move", text="", icon="TRIA_DOWN").type = "DOWN"
 
 
-class mmd_tools_local_UL_joints(bpy.types.UIList, UL_ObjectsMixIn):
+class MMD_TOOLS_LOCAL_UL_Joints(bpy.types.UIList, UL_ObjectsMixIn):
     mmd_type = "JOINT"
     icon = "CONSTRAINT"
     prop_name = "mmd_joint"

--- a/extern_tools/mmd_tools_local/panels/sidebar/material_sorter.py
+++ b/extern_tools/mmd_tools_local/panels/sidebar/material_sorter.py
@@ -21,14 +21,14 @@ class MMDMaterialSorter(PT_ProductionPanelBase, bpy.types.Panel):
 
         col = layout.column(align=True)
         row = col.row()
-        row.template_list("mmd_tools_local_UL_Materials", "", active_obj.data, "materials", active_obj, "active_material_index")
+        row.template_list("MMD_TOOLS_LOCAL_UL_Materials", "", active_obj.data, "materials", active_obj, "active_material_index")
         tb = row.column()
         tb1 = tb.column(align=True)
         tb1.operator("mmd_tools_local.move_material_up", text="", icon="TRIA_UP")
         tb1.operator("mmd_tools_local.move_material_down", text="", icon="TRIA_DOWN")
 
 
-class mmd_tools_local_UL_Materials(bpy.types.UIList):
+class MMD_TOOLS_LOCAL_UL_Materials(bpy.types.UIList):
     def draw_item(self, _context, layout, _data, item, icon, _active_data, _active_propname, _index):
         if self.layout_type == "DEFAULT":
             if item:

--- a/extern_tools/mmd_tools_local/panels/sidebar/meshes_sorter.py
+++ b/extern_tools/mmd_tools_local/panels/sidebar/meshes_sorter.py
@@ -23,7 +23,7 @@ class MMDMeshSorter(PT_ProductionPanelBase, bpy.types.Panel):
 
         col = layout.column(align=True)
         row = col.row()
-        row.template_list("mmd_tools_local_UL_ModelMeshes", "", context.scene, "objects", root.mmd_root, "active_mesh_index")
+        row.template_list("MMD_TOOLS_LOCAL_UL_ModelMeshes", "", context.scene, "objects", root.mmd_root, "active_mesh_index")
         tb = row.column()
         tb1 = tb.column(align=True)
         tb1.enabled = active_obj.type == "MESH" and active_obj.mmd_type == "NONE"
@@ -33,7 +33,7 @@ class MMDMeshSorter(PT_ProductionPanelBase, bpy.types.Panel):
         tb1.operator("mmd_tools_local.object_move", text="", icon="TRIA_DOWN_BAR").type = "BOTTOM"
 
 
-class mmd_tools_local_UL_ModelMeshes(bpy.types.UIList):
+class MMD_TOOLS_LOCAL_UL_ModelMeshes(bpy.types.UIList):
     def draw_item(self, _context, layout, _data, item, icon, _active_data, _active_propname, _index):
         if self.layout_type == "DEFAULT":
             layout.label(text=item.name, translate=False, icon="OBJECT_DATA")

--- a/extern_tools/mmd_tools_local/panels/sidebar/morph_tools.py
+++ b/extern_tools/mmd_tools_local/panels/sidebar/morph_tools.py
@@ -37,7 +37,7 @@ class MMDMorphToolsPanel(PT_ProductionPanelBase, bpy.types.Panel):
 
         c = col.column(align=True)
         row = c.row()
-        row.template_list("mmd_tools_local_UL_Morphs", "", mmd_root, morph_type, mmd_root, "active_morph")
+        row.template_list("MMD_TOOLS_LOCAL_UL_Morphs", "", mmd_root, morph_type, mmd_root, "active_morph")
         tb = row.column()
         tb1 = tb.column(align=True)
         tb1.operator("mmd_tools_local.morph_add", text="", icon="ADD")
@@ -105,7 +105,7 @@ class MMDMorphToolsPanel(PT_ProductionPanelBase, bpy.types.Panel):
 
     def _draw_material_data(self, context, rig, col, morph):
         col.label(text=bpy.app.translations.pgettext_iface("Material Offsets (%d)") % len(morph.data))
-        data = self._template_morph_offset_list(col, morph, "mmd_tools_local_UL_MaterialMorphOffsets")
+        data = self._template_morph_offset_list(col, morph, "MMD_TOOLS_LOCAL_UL_MaterialMorphOffsets")
         if data is None:
             return
 
@@ -191,7 +191,7 @@ class MMDMorphToolsPanel(PT_ProductionPanelBase, bpy.types.Panel):
         row.operator("mmd_tools_local.convert_bone_morph_to_vertex_morph", text="Convert To Vertex Morph", icon="SHAPEKEY_DATA")
 
         col.label(text=bpy.app.translations.pgettext_iface("Bone Offsets (%d)") % len(morph.data))
-        data = self._template_morph_offset_list(col, morph, "mmd_tools_local_UL_BoneMorphOffsets")
+        data = self._template_morph_offset_list(col, morph, "MMD_TOOLS_LOCAL_UL_BoneMorphOffsets")
         if data is None:
             return
 
@@ -225,7 +225,7 @@ class MMDMorphToolsPanel(PT_ProductionPanelBase, bpy.types.Panel):
             row.prop(morph, "vertex_group_scale", text="Scale")
         else:
             row.label(text=bpy.app.translations.pgettext_iface("UV Offsets (%d)") % len(morph.data))
-            # self._template_morph_offset_list(c, morph, 'mmd_tools_local_UL_UVMorphOffsets')
+            # self._template_morph_offset_list(c, morph, 'MMD_TOOLS_LOCAL_UL_UVMorphOffsets')
         row.prop(morph, "uv_index")
         row.operator("mmd_tools_local.morph_offset_remove", text="", icon="X").all = True
 
@@ -234,7 +234,7 @@ class MMDMorphToolsPanel(PT_ProductionPanelBase, bpy.types.Panel):
         row.operator("mmd_tools_local.convert_group_morph_to_vertex_morph", text="Convert To Vertex Morph", icon="SHAPEKEY_DATA")
 
         col.label(text=bpy.app.translations.pgettext_iface("Group Offsets (%d)") % len(morph.data))
-        item = self._template_morph_offset_list(col, morph, "mmd_tools_local_UL_GroupMorphOffsets")
+        item = self._template_morph_offset_list(col, morph, "MMD_TOOLS_LOCAL_UL_GroupMorphOffsets")
         if item is None:
             return
 
@@ -244,7 +244,7 @@ class MMDMorphToolsPanel(PT_ProductionPanelBase, bpy.types.Panel):
         row.prop(item, "morph_type", text="")
 
 
-class mmd_tools_local_UL_Morphs(bpy.types.UIList):
+class MMD_TOOLS_LOCAL_UL_Morphs(bpy.types.UIList):
     def draw_item(self, context, layout, data, item, icon, _active_data, _active_propname, _index):
         mmd_root = data
         if self.layout_type == "DEFAULT":
@@ -291,7 +291,7 @@ class mmd_tools_local_UL_Morphs(bpy.types.UIList):
             layout.label(text="", icon_value=icon)
 
 
-class mmd_tools_local_UL_MaterialMorphOffsets(bpy.types.UIList):
+class MMD_TOOLS_LOCAL_UL_MaterialMorphOffsets(bpy.types.UIList):
     def draw_item(self, _context, layout, _data, item, icon, _active_data, _active_propname, _index):
         if self.layout_type == "DEFAULT":
             material = item.material
@@ -303,7 +303,7 @@ class mmd_tools_local_UL_MaterialMorphOffsets(bpy.types.UIList):
             layout.label(text="", icon_value=icon)
 
 
-class mmd_tools_local_UL_UVMorphOffsets(bpy.types.UIList):
+class MMD_TOOLS_LOCAL_UL_UVMorphOffsets(bpy.types.UIList):
     def draw_item(self, _context, layout, _data, item, icon, _active_data, _active_propname, _index):
         if self.layout_type == "DEFAULT":
             layout.label(text=str(item.index), translate=False, icon="MESH_DATA")
@@ -315,7 +315,7 @@ class mmd_tools_local_UL_UVMorphOffsets(bpy.types.UIList):
             layout.label(text="", icon_value=icon)
 
 
-class mmd_tools_local_UL_BoneMorphOffsets(bpy.types.UIList):
+class MMD_TOOLS_LOCAL_UL_BoneMorphOffsets(bpy.types.UIList):
     def draw_item(self, _context, layout, _data, item, icon, _active_data, _active_propname, _index):
         if self.layout_type == "DEFAULT":
             layout.prop(item, "bone", text="", emboss=False, icon="BONE_DATA")
@@ -327,7 +327,7 @@ class mmd_tools_local_UL_BoneMorphOffsets(bpy.types.UIList):
             layout.label(text="", icon_value=icon)
 
 
-class mmd_tools_local_UL_GroupMorphOffsets(bpy.types.UIList):
+class MMD_TOOLS_LOCAL_UL_GroupMorphOffsets(bpy.types.UIList):
     def draw_item(self, _context, layout, _data, item, icon, _active_data, _active_propname, _index):
         if self.layout_type == "DEFAULT":
             row = layout.split(factor=0.5, align=True)

--- a/extern_tools/mmd_tools_local/panels/sidebar/rigid_bodies.py
+++ b/extern_tools/mmd_tools_local/panels/sidebar/rigid_bodies.py
@@ -24,7 +24,7 @@ class MMDRigidbodySelectorPanel(PT_ProductionPanelBase, bpy.types.Panel):
         c = col.column(align=True)
         row = c.row()
         row.template_list(
-            "mmd_tools_local_UL_rigidbodies",
+            "MMD_TOOLS_LOCAL_UL_RigidBodies",
             "",
             context.scene,
             "objects",
@@ -43,7 +43,7 @@ class MMDRigidbodySelectorPanel(PT_ProductionPanelBase, bpy.types.Panel):
         tb1.operator("mmd_tools_local.object_move", text="", icon="TRIA_DOWN").type = "DOWN"
 
 
-class mmd_tools_local_UL_rigidbodies(bpy.types.UIList, UL_ObjectsMixIn):
+class MMD_TOOLS_LOCAL_UL_RigidBodies(bpy.types.UIList, UL_ObjectsMixIn):
     mmd_type = "RIGID_BODY"
     icon = "MESH_ICOSPHERE"
     prop_name = "mmd_rigid"

--- a/resources/translations/en_US.json
+++ b/resources/translations/en_US.json
@@ -842,6 +842,8 @@
         "EyeTrackingPanel.troubleshooting.shapeKeys": "• Check shape keys are named correctly", 
         "EyeTrackingPanel.troubleshooting.boneWeights": "• Ensure eye bones are properly weighted",
         "EyeTrackingPanel.troubleshooting.restPosition": "• Confirm armature is in rest position",
-        "merge_armatures.error.mustapplytransforms": "Transform Issue Detected!\n\nYour armatures have non-uniform scaling or rotations that need to be fixed before merging.\nThis is important to prevent size changes and deformation issues.\n\nTo fix this:\n1. Enable the 'Apply Transforms' checkbox in the merge settings\n2. Try the merge again\n\nThe 'Apply Transforms' option will normalize all scale, rotation, and position values\nso your armatures merge correctly without changing size.\n\nIf you've already checked 'Apply Transforms' and still see this error,\nplease report this as a bug."
+        "merge_armatures.error.mustapplytransforms": "Transform Issue Detected!\n\nYour armatures have non-uniform scaling or rotations that need to be fixed before merging.\nThis is important to prevent size changes and deformation issues.\n\nTo fix this:\n1. Enable the 'Apply Transforms' checkbox in the merge settings\n2. Try the merge again\n\nThe 'Apply Transforms' option will normalize all scale, rotation, and position values\nso your armatures merge correctly without changing size.\n\nIf you've already checked 'Apply Transforms' and still see this error,\nplease report this as a bug.",
+        "Scene.progress_update.label": "Progress",
+        "Scene.progress_update.desc": "Progress indicator for operations"
     }
 }

--- a/resources/translations/ja_JP.json
+++ b/resources/translations/ja_JP.json
@@ -814,6 +814,8 @@
         "EyeTrackingPanel.troubleshooting.shapeKeys": "• シェイプキーの名前が正しく付けられていることを確認",
         "EyeTrackingPanel.troubleshooting.boneWeights": "• 目のボーンが適切にウェイト付けされていることを確認",
         "EyeTrackingPanel.troubleshooting.restPosition": "• アーマチュアが静止位置にあることを確認",
-        "merge_armatures.error.mustapplytransforms": "アーマチュアのX、Y、Z軸のスケール値が異なっており、\n統一されたスケーリング（すべての軸が同じスケール値）になっていません。\n\nアーマチュアをマージする前にこれを修正することは、\n適切なボーンの変換と変形の問題を防ぐために重要です。\n\nこの警告があってもマージを続行したい場合は、\nマージを開始する前に「トランスフォームを適用」にチェックを入れてください。"
+        "merge_armatures.error.mustapplytransforms": "アーマチュアのX、Y、Z軸のスケール値が異なっており、\n統一されたスケーリング（すべての軸が同じスケール値）になっていません。\n\nアーマチュアをマージする前にこれを修正することは、\n適切なボーンの変換と変形の問題を防ぐために重要です。\n\nこの警告があってもマージを続行したい場合は、\nマージを開始する前に「トランスフォームを適用」にチェックを入れてください。",
+        "Scene.progress_update.label": "進行状況",
+        "Scene.progress_update.desc": "操作の進行状況インジケーター"
     }
 }

--- a/resources/translations/ko_KR.json
+++ b/resources/translations/ko_KR.json
@@ -816,6 +816,8 @@
         "EyeTrackingPanel.troubleshooting.shapeKeys": "• 쉐이프 키의 이름이 올바른지 확인",
         "EyeTrackingPanel.troubleshooting.boneWeights": "• 눈 본이 올바르게 가중치가 적용되어 있는지 확인",
         "EyeTrackingPanel.troubleshooting.restPosition": "• 아마추어가 기본 자세에 있는지 확인",
-        "merge_armatures.error.mustapplytransforms": "아마추어의 X, Y, Z축 스케일 값이 서로 다르며,\n균일한 스케일링(모든 축이 동일한 스케일 값)이 되어있지 않습니다.\n\n아마추어 병합 전 이를 수정하는 것은\n올바른 본 변환과 변형 문제를 방지하는데 중요합니다.\n\n이 경고에도 불구하고 병합을 진행하려면\n병합을 시작하기 전에 '트랜스폼 적용'을 체크해주세요."
+        "merge_armatures.error.mustapplytransforms": "아마추어의 X, Y, Z축 스케일 값이 서로 다르며,\n균일한 스케일링(모든 축이 동일한 스케일 값)이 되어있지 않습니다.\n\n아마추어 병합 전 이를 수정하는 것은\n올바른 본 변환과 변형 문제를 방지하는데 중요합니다.\n\n이 경고에도 불구하고 병합을 진행하려면\n병합을 시작하기 전에 '트랜스폼 적용'을 체크해주세요.",
+        "Scene.progress_update.label": "진행률",
+        "Scene.progress_update.desc": "작업의 진행률 표시기"
     }
 }

--- a/resources/translations_Template.json
+++ b/resources/translations_Template.json
@@ -2,6 +2,8 @@
     "localeCode": "en_US",
     "authors": ["My name here"],
     "messages":{
-        "Main.error.deleteFollowing": "ldawlwlkda;ldkal;wdk;la;lkd;kldaks;lkd;lawkd"
+        "Main.error.deleteFollowing": "ldawlwlkda;ldkal;wdk;la;lkd;kldaks;lkd;lawkd",
+        "Scene.progress_update.label": "Progress",
+        "Scene.progress_update.desc": "Progress indicator for operations"
     }
 }


### PR DESCRIPTION
These were some small bugs that existed in Cats since 4.1, didn't affect the addon, but spammed the console which things.

- Renamed 11 UIList classes to use uppercase alphanumeric prefix (MMD_TOOLS_LOCAL_UL_*)
- Updated all 20+ references throughout codebase to new class names
- Added missing Scene.progress_update translation entries in en_US, ja_JP, and ko_KR
- Version Bump