### PR TITLE
Fix texture import loss in PMX models #381

### DIFF
--- a/extern_tools/mmd_tools_local/core/material.py
+++ b/extern_tools/mmd_tools_local/core/material.py
@@ -170,6 +170,12 @@ class FnMaterial:
         if self._nodes_are_readonly:
             return
         mmd_mat: MMDMaterial = self.__material.mmd_material
+        # Check if toon texture is already loaded in shader nodes
+        toon_tex_node = self.__get_texture_node("mmd_toon_tex")
+        if toon_tex_node is not None:
+            # Toon texture is already loaded, skip update
+            return
+        
         if mmd_mat.is_shared_toon_texture:
             shared_toon_folder = FnContext.get_addon_preferences_attribute(FnContext.ensure_context(), "shared_toon_folder", "")
             toon_path = os.path.join(shared_toon_folder, "toon%02d.bmp" % (mmd_mat.shared_toon_texture + 1))

--- a/extern_tools/mmd_tools_local/core/pmx/importer.py
+++ b/extern_tools/mmd_tools_local/core/pmx/importer.py
@@ -188,7 +188,7 @@ class PMXImporter:
 
         self.__textureTable = []
         for i in pmxModel.textures:
-            self.__textureTable.append(str(Path(i.path).resolve()))
+            self.__textureTable.append(i.path)
 
     def __createEditBones(self, obj, pmx_bones):
         """Create EditBones from pmx file data.
@@ -576,12 +576,24 @@ class PMXImporter:
                 self.__imageTable[len(self.__materialTable) - 1] = texture_slot.texture.image
 
             if i.is_shared_toon_texture:
-                mmd_mat.is_shared_toon_texture = True
-                mmd_mat.shared_toon_texture = i.toon_texture
+                # Try to load shared toon texture from model directory first
+                toon_filename = "toon%02d.bmp" % (i.toon_texture + 1)
+                toon_path = os.path.join(os.path.dirname(pmxModel.filepath), toon_filename)
+                # If not in model directory, try embedded MMD Tools folder
+                if not os.path.exists(toon_path):
+                    mmd_tools_dir = Path(__file__).parent.parent.parent / "externals" / "MikuMikuDance"
+                    toon_path = str(mmd_tools_dir / toon_filename)
+                # Load the texture if it exists
+                if os.path.exists(toon_path):
+                    texture_slot = fnMat.create_toon_texture(toon_path)
+                    # Store metadata but don't trigger update callbacks
+                    mmd_mat.is_shared_toon_texture = True
+                    mmd_mat.shared_toon_texture = i.toon_texture
             else:
                 mmd_mat.is_shared_toon_texture = False
                 if i.toon_texture >= 0:
                     mmd_mat.toon_texture = self.__textureTable[i.toon_texture]
+                    texture_slot = fnMat.create_toon_texture(self.__textureTable[i.toon_texture])
 
             if i.sphere_texture_mode == 2:
                 amount = self.__spa_blend_factor


### PR DESCRIPTION
I don't know why MMD Tools did things this way but it was stupid.

- Remove unnecessary Path.resolve() call that was corrupting texture paths
- Load shared toon textures directly from model directory or embedded MMD Tools folder during import
- Skip update_toon_texture() callback if texture node already exists to prevent re-loading with wrong paths
- Prevents textures from being lost when importing PMX files via Cats with MMD Tools embedded