### PR TITLE
Fix armature merge search dropdown not displaying items #396

### DIFF
--- a/ui/custom.py
+++ b/ui/custom.py
@@ -13,56 +13,87 @@ from ..tools.translations import t
 
 
 @register_wrap
-class SearchMenuOperator_merge_armature_into(SearchMenuOperatorBase, bpy.types.Operator):
+class SearchMenuOperator_merge_armature_into(bpy.types.Operator):
     bl_description = t('Scene.merge_armature_into.desc')
     bl_idname = "scene.search_menu_merge_armature_into"
     bl_label = ""
-    scene_property = "merge_armature_into"
+    bl_property = "my_enum"
 
     my_enum: bpy.props.EnumProperty(
         name=t('Scene.merge_armature_into.label'),
         description=t('Scene.merge_armature_into.desc'),
-        items=Common.wrap_dynamic_enum_items(Common.get_armature_list, bl_idname, is_holder=False),
+        items=Common.get_armature_list,
     )
 
+    def execute(self, context):
+        context.scene.merge_armature_into = self.my_enum
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        wm = context.window_manager
+        wm.invoke_search_popup(self)
+        return {'FINISHED'}
+
 @register_wrap
-class SearchMenuOperator_merge_armature(SearchMenuOperatorBase, bpy.types.Operator):
+class SearchMenuOperator_merge_armature(bpy.types.Operator):
     bl_description = t('Scene.merge_armature.desc')
     bl_idname = "scene.search_menu_merge_armature"
     bl_label = t('Scene.root_bone.label')
-    scene_property = "merge_armature"
+    bl_property = "my_enum"
 
     my_enum: bpy.props.EnumProperty(
         name=t('Scene.merge_armature.label'),
         description=t('Scene.merge_armature.desc'),
-        items=Common.wrap_dynamic_enum_items(Common.get_armature_merge_list, bl_idname, is_holder=False),
+        items=Common.get_armature_merge_list,
     )
 
+    def execute(self, context):
+        context.scene.merge_armature = self.my_enum
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        wm = context.window_manager
+        wm.invoke_search_popup(self)
+        return {'FINISHED'}
+
 @register_wrap
-class SearchMenuOperator_attach_to_bone(SearchMenuOperatorBase, bpy.types.Operator):
+class SearchMenuOperator_attach_to_bone(bpy.types.Operator):
     bl_description = t('Scene.attach_to_bone.desc')
     bl_idname = "scene.search_menu_attach_to_bone"
     bl_label = ""
-    scene_property = "attach_to_bone"
+    bl_property = "my_enum"
 
     my_enum: bpy.props.EnumProperty(
         name=t('Scene.attach_to_bone.label'),
         description=t('Scene.attach_to_bone.desc'),
-        items=Common.wrap_dynamic_enum_items(Common.get_bones_merge, bl_idname, sort=False, is_holder=False),
+        items=Common.get_bones_merge,
     )
 
+    def execute(self, context):
+        context.scene.attach_to_bone = self.my_enum
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        wm = context.window_manager
+        wm.invoke_search_popup(self)
+        return {'FINISHED'}
+
 @register_wrap
-class SearchMenuOperator_attach_mesh(SearchMenuOperatorBase, bpy.types.Operator):
+class SearchMenuOperator_attach_mesh(bpy.types.Operator):
     bl_description = t('Scene.attach_mesh.desc')
     bl_idname = "scene.search_menu_attach_mesh"
     bl_label = ""
-    scene_property = "attach_mesh"
+    bl_property = "my_enum"
 
     my_enum: bpy.props.EnumProperty(
         name=t('Scene.attach_mesh.label'),
         description=t('Scene.attach_mesh.desc'),
-        items=Common.wrap_dynamic_enum_items(Common.get_top_meshes, bl_idname, is_holder=False),
+        items=Common.get_top_meshes,
     )
+
+    def execute(self, context):
+        context.scene.attach_mesh = self.my_enum
+        return {'FINISHED'}
 
     def invoke(self, context, event):
         wm = context.window_manager

--- a/ui/visemes.py
+++ b/ui/visemes.py
@@ -8,43 +8,70 @@ from ..tools.register import register_wrap
 from ..tools.translations import t
 
 @register_wrap
-class SearchMenuOperatorMouthA(SearchMenuOperatorBase, bpy.types.Operator):
+class SearchMenuOperatorMouthA(bpy.types.Operator):
     bl_description = t('Scene.mouth_a.desc')
     bl_idname = "scene.search_menu_mouth_a"
     bl_label = ""
-    scene_property = "mouth_a"
+    bl_property = "my_enum"
     
     my_enum: bpy.props.EnumProperty(
         name="shapekeys",
         description=t('Scene.mouth_a.desc'),
-        items=Common.wrap_dynamic_enum_items(Common.get_shapekeys_mouth_ah, bl_idname, sort=False, is_holder=False),
+        items=Common.get_shapekeys_mouth_ah,
     )
 
+    def execute(self, context):
+        context.scene.mouth_a = self.my_enum
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        wm = context.window_manager
+        wm.invoke_search_popup(self)
+        return {'FINISHED'}
+
 @register_wrap
-class SearchMenuOperatorMouthO(SearchMenuOperatorBase, bpy.types.Operator):
+class SearchMenuOperatorMouthO(bpy.types.Operator):
     bl_description = t('Scene.mouth_o.desc')
     bl_idname = "scene.search_menu_mouth_o"
     bl_label = ""
-    scene_property = "mouth_o"
+    bl_property = "my_enum"
     
     my_enum: bpy.props.EnumProperty(
         name="shapekeys",
         description=t('Scene.mouth_o.desc'),
-        items=Common.wrap_dynamic_enum_items(Common.get_shapekeys_mouth_oh, bl_idname, sort=False, is_holder=False),
+        items=Common.get_shapekeys_mouth_oh,
     )
 
+    def execute(self, context):
+        context.scene.mouth_o = self.my_enum
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        wm = context.window_manager
+        wm.invoke_search_popup(self)
+        return {'FINISHED'}
+
 @register_wrap
-class SearchMenuOperatorMouthCH(SearchMenuOperatorBase, bpy.types.Operator):
+class SearchMenuOperatorMouthCH(bpy.types.Operator):
     bl_description = t('Scene.mouth_ch.desc')
     bl_idname = "scene.search_menu_mouth_ch"
     bl_label = ""
-    scene_property = "mouth_ch"
+    bl_property = "my_enum"
     
     my_enum: bpy.props.EnumProperty(
         name="shapekeys",
         description=t('Scene.mouth_ch.desc'),
-        items=Common.wrap_dynamic_enum_items(Common.get_shapekeys_mouth_ch, bl_idname, sort=False, is_holder=False),
+        items=Common.get_shapekeys_mouth_ch,
     )
+
+    def execute(self, context):
+        context.scene.mouth_ch = self.my_enum
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        wm = context.window_manager
+        wm.invoke_search_popup(self)
+        return {'FINISHED'}
 
 @register_wrap
 class VisemePanel(ToolPanel, bpy.types.Panel):


### PR DESCRIPTION
- Remove SearchMenuOperatorBase inheritance from search operators
- Add explicit bl_property attribute pointing to my_enum
- Implement direct execute() and invoke() methods in each operator
- Match implementation pattern used in eye_tracking.py
- Fixes: Armatures, bones, meshes, and shapekeys now display in search popups

Closes #396 