### PR TITLE
Blender 4.5: Cats 4.5.3.2 Release Candiate Release

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 # MIT License
 
 CATS_VERSION = "4.5.3.0"
-dev_branch = False
+dev_branch = True
 
 import os
 import sys

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # MIT License
 
-CATS_VERSION = "4.5.3.0"
+CATS_VERSION = "4.5.3.1"
 dev_branch = True
 
 import os

--- a/extern_tools/mmd_tools_local/core/material.py
+++ b/extern_tools/mmd_tools_local/core/material.py
@@ -170,6 +170,12 @@ class FnMaterial:
         if self._nodes_are_readonly:
             return
         mmd_mat: MMDMaterial = self.__material.mmd_material
+        # Check if toon texture is already loaded in shader nodes
+        toon_tex_node = self.__get_texture_node("mmd_toon_tex")
+        if toon_tex_node is not None:
+            # Toon texture is already loaded, skip update
+            return
+        
         if mmd_mat.is_shared_toon_texture:
             shared_toon_folder = FnContext.get_addon_preferences_attribute(FnContext.ensure_context(), "shared_toon_folder", "")
             toon_path = os.path.join(shared_toon_folder, "toon%02d.bmp" % (mmd_mat.shared_toon_texture + 1))

--- a/extern_tools/mmd_tools_local/core/pmx/importer.py
+++ b/extern_tools/mmd_tools_local/core/pmx/importer.py
@@ -188,7 +188,7 @@ class PMXImporter:
 
         self.__textureTable = []
         for i in pmxModel.textures:
-            self.__textureTable.append(str(Path(i.path).resolve()))
+            self.__textureTable.append(i.path)
 
     def __createEditBones(self, obj, pmx_bones):
         """Create EditBones from pmx file data.
@@ -574,12 +574,24 @@ class PMXImporter:
                 self.__imageTable[len(self.__materialTable) - 1] = texture_slot.texture.image
 
             if i.is_shared_toon_texture:
-                mmd_mat.is_shared_toon_texture = True
-                mmd_mat.shared_toon_texture = i.toon_texture
+                # Try to load shared toon texture from model directory first
+                toon_filename = "toon%02d.bmp" % (i.toon_texture + 1)
+                toon_path = os.path.join(os.path.dirname(pmxModel.filepath), toon_filename)
+                # If not in model directory, try embedded MMD Tools folder
+                if not os.path.exists(toon_path):
+                    mmd_tools_dir = Path(__file__).parent.parent.parent / "externals" / "MikuMikuDance"
+                    toon_path = str(mmd_tools_dir / toon_filename)
+                # Load the texture if it exists
+                if os.path.exists(toon_path):
+                    texture_slot = fnMat.create_toon_texture(toon_path)
+                    # Store metadata but don't trigger update callbacks
+                    mmd_mat.is_shared_toon_texture = True
+                    mmd_mat.shared_toon_texture = i.toon_texture
             else:
                 mmd_mat.is_shared_toon_texture = False
                 if i.toon_texture >= 0:
                     mmd_mat.toon_texture = self.__textureTable[i.toon_texture]
+                    texture_slot = fnMat.create_toon_texture(self.__textureTable[i.toon_texture])
 
             if i.sphere_texture_mode == 2:
                 amount = self.__spa_blend_factor

--- a/extern_tools/mmd_tools_local/properties/__init__.py
+++ b/extern_tools/mmd_tools_local/properties/__init__.py
@@ -20,7 +20,7 @@ def patch_library_overridable(prop: "bpy.props._PropertyDeferred") -> "bpy.props
     property_type = prop.keywords["type"]
     # The __annotations__ cannot be inherited. Manually search for base classes.
     for inherited_type in (property_type, *property_type.__bases__):
-        if not inherited_type.__module__.startswith("mmd_tools_local.properties"):
+        if not (inherited_type.__module__.startswith("mmd_tools_local.properties") or inherited_type.__module__.startswith("mmd_tools.properties")):
             continue
         for annotation in inherited_type.__annotations__.values():
             if not isinstance(annotation, bpy.props._PropertyDeferred):

--- a/resources/translations/en_US.json
+++ b/resources/translations/en_US.json
@@ -396,7 +396,7 @@
         "EnableMMD.required1": "The plugin \"mmd_tools\" is required for this function.",
         "EnableMMD.required2": "Please restart Blender.",
         "XpsToolsButton.label": "Download XPS Tools",
-        "XpsToolsButton.URL": "https://github.com/johnzero7/XNALaraMesh",
+        "XpsToolsButton.URL": "https://github.com/Valerie-Bosco/XNALara-io-Tools",
         "XpsToolsButton.success": "XPS Tools link opened",
         "SourceToolsButton.label": "Download Source Tools",
         "SourceToolsButton.URL": "https://github.com/Artfunkel/BlenderSourceTools",

--- a/resources/translations/ja_JP.json
+++ b/resources/translations/ja_JP.json
@@ -109,7 +109,8 @@
         "DecimationPanel.warn.noMeshSelected": "メッシュが選択されていません",
         "DecimationPanel.warn.emptyList": "両方のリストが空で、これは完全なデシメーションに等しい!",
         "DecimationPanel.warn.correctWhitelist": "両方のホワイトリストはデシメーション中に考慮されます",
-        "A hard limit will be established in the future that will not be much more than this.\"": "퀘스트용 아바타들을 위해 권장되는 삼각폴리곤(Tris)의 개수입니다.\n앞으로는 이보다 심하지는 않을 엄격한 제한이 설정될 것입니다。",
+        "Scene.skip_locked_shape_keys.label": "ロックされたシェイプキーをスキップ",
+        "Scene.skip_locked_shape_keys.desc": "チェックされている場合、ロックされたシェイプキーの翻訳をスキップします。シェイプキーをロック/ロック解除するには、その横のロックアイコンをクリックするか、複数のロックアイコンをクリックしてドラッグして複数をロック/ロック解除します。",
         "EyeTrackingPanel.label": "アイトラッキング",
         "EyeTrackingPanel.error.noMesh": "メッシュが見つかりません!",
         "EyeTrackingPanel.error.noArm": "モデルが見つかりません!",
@@ -793,9 +794,9 @@
         "RemoveDoubles.warning.shapekeys.impact": "重複を削除すると、シェイプキーの変形に影響を与える可能性があります",
         "RemoveDoubles.warning.shapekeys.continue": "続行しますか？",
         "CreditsPanel.label": "クレジット",
-        "CreditsPanel.desc1": "Cats ブレンダープラグイン (",
-        "CreditsPanel.desc4": "特別な感謝:",
-        "CreditsPanel.descContributors": "Feilen, Jordo, Ruubick, triazo, Mysteryem",
+        "CreditsPanel.desc1": "Cats Blender プラグイン (",
+        "CreditsPanel.desc4": "特別な感謝：",
+        "CreditsPanel.descContributors": "Feilen, Jordo, Ruubick, triazo, Mysteryem, rurre",
         "CreditsPanel.descContributors2": "Shotariya と Neitri",
         "CreditsPanel.maintainers1": "Neoneko チームによって維持されています",
         "CreditsPanel.maintainers2": "メンテナー: Yusarina と 989onan",
@@ -814,6 +815,6 @@
         "EyeTrackingPanel.troubleshooting.shapeKeys": "• シェイプキーの名前が正しく付けられていることを確認",
         "EyeTrackingPanel.troubleshooting.boneWeights": "• 目のボーンが適切にウェイト付けされていることを確認",
         "EyeTrackingPanel.troubleshooting.restPosition": "• アーマチュアが静止位置にあることを確認",
-        "merge_armatures.error.mustapplytransforms": "アーマチュアのX、Y、Z軸のスケール値が異なっており、\n統一されたスケーリング（すべての軸が同じスケール値）になっていません。\n\nアーマチュアをマージする前にこれを修正することは、\n適切なボーンの変換と変形の問題を防ぐために重要です。\n\nこの警告があってもマージを続行したい場合は、\nマージを開始する前に「トランスフォームを適用」にチェックを入れてください。"
+        "merge_armatures.error.mustapplytransforms": "変換の問題が検出されました！\n\nアーマチュアには、マージする前に修正する必要がある均一でないスケーリングまたは回転があります。\nこれは、サイズの変更と変形の問題を防ぐために重要です。\n\nこれを修正するには：\n1. マージ設定で「トランスフォームを適用」チェックボックスを有効にします\n2. もう一度マージしてみてください\n\n「トランスフォームを適用」オプションは、すべてのスケール、回転、および位置の値を正規化するため、\nアーマチュアはサイズを変更せずに正しくマージされます。\n\n既に「トランスフォームを適用」をチェックしてもこのエラーが表示される場合は、\nこれをバグとして報告してください。"
     }
 }

--- a/resources/translations/ja_JP.json
+++ b/resources/translations/ja_JP.json
@@ -404,7 +404,7 @@
         "EnableMMD.required1": "この機能には \"mmd_tools\" プラグインが必要です。",
         "EnableMMD.required2": "Blenderを再起動してください。",
         "XpsToolsButton.label": "XPSツールをダウンロード",
-        "XpsToolsButton.URL": "https://github.com/johnzero7/XNALaraMesh",
+        "XpsToolsButton.URL": "https://github.com/Valerie-Bosco/XNALara-io-Tools",
         "XpsToolsButton.success": "XPSツールのリンクが開かれました",
         "SourceToolsButton.label": "ソースツールをダウンロード",
         "SourceToolsButton.URL": "https://github.com/Artfunkel/BlenderSourceTools",

--- a/resources/translations/ko_KR.json
+++ b/resources/translations/ko_KR.json
@@ -556,7 +556,7 @@
         "Scene.eye_rotation_x.desc": "세로 축에서 눈 뼈를 회전시킵니다",
         "select_this_to_only_merge_the_weights_of_the_visible_meshes": "보이는 메쉬의 무게 만 병합하려면 이것을 선택하십시오.",
         "ImportFBX.desc": "FBX 모델 가져 오기 (.FBX)",
-        "XpsToolsButton.URL": "https://github.com/johnzero7/XNALaraMesh",
+        "XpsToolsButton.URL": "https://github.com/Valerie-Bosco/XNALara-io-Tools",
         "Scene.merge_armatures_cleanup_shape_keys.desc": "메쉬 모양 키를 정리합니다.\n유지하려는 모양 키가 삭제 된 경우 이것을 선택 취소하십시오.",
         "decimate.cantDecimate1": "모델은 {number} tris로 소멸 될 수 없습니다.",
         "ImportSource.desc": "소스 모델 가져 오기 (.smd/.qc/.vta/.dmx)",

--- a/resources/translations/ko_KR.json
+++ b/resources/translations/ko_KR.json
@@ -32,6 +32,8 @@
         "MaterialDeprecation.info5": "권장되지 않습니다.",
         "MaterialDeprecation.info6": "이전 재질 수정은 구버전 VRChat에 특화된 기능으로",
         "MaterialDeprecation.info7": "현재 워크플로우에서는 더 이상 필요하지 않습니다.",
+        "Scene.skip_locked_shape_keys.label": "잠긴 쉐이프 키 건너뛰기",
+        "Scene.skip_locked_shape_keys.desc": "이 옵션을 선택하면 잠긴 쉐이프 키 번역을 건너뜁니다. 쉐이프 키를 잠금/잠금 해제하려면 옆의 잠금 아이콘을 클릭하거나 여러 잠금 아이콘을 클릭하고 드래그하여 여러 항목을 잠금/잠금 해제합니다.",
         "QuickAccess.ImportAnyModel.label": "모델 불러오기",
         "QuickAccess.JoinMeshes.label": "모든 메쉬에 합류",
         "QuickAccess.CombineMats.label": "재료 결합",


### PR DESCRIPTION
This is the release candiate for Blender 4.5 (4.5.3.2) as long as there no major issues this will be release on 20/11/2025

This will be the last verison for 4.5, we will not release anything else for 4.5 after this one.

#### Fixed:
- PMX texture loss issues, textures will no longer disappear when importing models.

#### Changed:
- Updated the XPS Link to the correct and current location.

#### Added:
- Missing Japanese and Korean translation strings. both languages are now fully updated and complete.