### PR TITLE
Change directory property subtype to DIR_PATH in ImportAnyModel

### DIFF
--- a/tools/importer.py
+++ b/tools/importer.py
@@ -48,7 +48,7 @@ class ImportAnyModel(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
     bl_options = {'REGISTER', 'UNDO', 'INTERNAL'}
 
     files = bpy.props.CollectionProperty(type=bpy.types.OperatorFileListElement, options={'HIDDEN', 'SKIP_SAVE'})
-    directory = bpy.props.StringProperty(maxlen=1024, subtype='FILE_PATH', options={'HIDDEN', 'SKIP_SAVE'})
+    directory = bpy.props.StringProperty(maxlen=1024, subtype='DIR_PATH', options={'HIDDEN', 'SKIP_SAVE'})
 
     filter_glob = bpy.props.StringProperty(default=formats, options={'HIDDEN'})
     text1 = bpy.props.BoolProperty(


### PR DESCRIPTION
Fixes Blender 5.0 warning "directory expected a string with a 'DIR_PATH' subtype" when using the import button. Changed from FILE_PATH to DIR_PATH as required by Blender 5.0's file selector API.