### PR TITLE
Fix viseme shape key selection displaying gibberish for non-Latin languahes

### DIFF
--- a/ui/visemes.py
+++ b/ui/visemes.py
@@ -8,72 +8,6 @@ from ..tools.register import register_wrap
 from ..tools.translations import t
 
 @register_wrap
-class SearchMenuOperatorMouthA(bpy.types.Operator):
-    bl_description = t('Scene.mouth_a.desc')
-    bl_idname = "scene.search_menu_mouth_a"
-    bl_label = ""
-    bl_property = "my_enum"
-    
-    my_enum: bpy.props.EnumProperty(
-        name="shapekeys",
-        description=t('Scene.mouth_a.desc'),
-        items=Common.get_shapekeys_mouth_ah,
-    )
-
-    def execute(self, context):
-        context.scene.mouth_a = self.my_enum
-        return {'FINISHED'}
-
-    def invoke(self, context, event):
-        wm = context.window_manager
-        wm.invoke_search_popup(self)
-        return {'FINISHED'}
-
-@register_wrap
-class SearchMenuOperatorMouthO(bpy.types.Operator):
-    bl_description = t('Scene.mouth_o.desc')
-    bl_idname = "scene.search_menu_mouth_o"
-    bl_label = ""
-    bl_property = "my_enum"
-    
-    my_enum: bpy.props.EnumProperty(
-        name="shapekeys",
-        description=t('Scene.mouth_o.desc'),
-        items=Common.get_shapekeys_mouth_oh,
-    )
-
-    def execute(self, context):
-        context.scene.mouth_o = self.my_enum
-        return {'FINISHED'}
-
-    def invoke(self, context, event):
-        wm = context.window_manager
-        wm.invoke_search_popup(self)
-        return {'FINISHED'}
-
-@register_wrap
-class SearchMenuOperatorMouthCH(bpy.types.Operator):
-    bl_description = t('Scene.mouth_ch.desc')
-    bl_idname = "scene.search_menu_mouth_ch"
-    bl_label = ""
-    bl_property = "my_enum"
-    
-    my_enum: bpy.props.EnumProperty(
-        name="shapekeys",
-        description=t('Scene.mouth_ch.desc'),
-        items=Common.get_shapekeys_mouth_ch,
-    )
-
-    def execute(self, context):
-        context.scene.mouth_ch = self.my_enum
-        return {'FINISHED'}
-
-    def invoke(self, context, event):
-        wm = context.window_manager
-        wm.invoke_search_popup(self)
-        return {'FINISHED'}
-
-@register_wrap
 class VisemePanel(ToolPanel, bpy.types.Panel):
     bl_idname = 'VIEW3D_PT_viseme_v3'
     bl_label = t('VisemePanel.label')
@@ -110,26 +44,35 @@ class VisemePanel(ToolPanel, bpy.types.Panel):
         
         box_col.separator()
 
-        # Mouth A
-        row = box_col.row(align=True)
-        row.scale_y = 1.0
-        row.label(text=t('Scene.mouth_a.label')+":")
-        mouth_a_text = 'None' if Common.is_enum_empty(context.scene.mouth_a) else context.scene.mouth_a
-        row.operator(SearchMenuOperatorMouthA.bl_idname, text=mouth_a_text, icon='SHAPEKEY_DATA')
+        # Get the mesh for shape key selection
+        mesh_name = context.scene.mesh_name_viseme
+        if not mesh_name or mesh_name == 'Cats_empty_enum_identifier':
+            box_col.label(text=t('VisemePanel.error.noMesh'), icon='ERROR')
+        else:
+            try:
+                mesh = Common.get_objects()[mesh_name]
+                if not mesh or not mesh.data.shape_keys:
+                    box_col.label(text=t('VisemePanel.error.noShapekeys'), icon='ERROR')
+                else:
+                    # Mouth A
+                    row = box_col.row(align=True)
+                    row.scale_y = 1.0
+                    row.label(text=t('Scene.mouth_a.label')+":")
+                    row.prop_search(context.scene, "mouth_a", mesh.data.shape_keys, "key_blocks", text="")
 
-        # Mouth O
-        row = box_col.row(align=True)
-        row.scale_y = 1.0
-        row.label(text=t('Scene.mouth_o.label')+":")
-        mouth_o_text = 'None' if Common.is_enum_empty(context.scene.mouth_o) else context.scene.mouth_o
-        row.operator(SearchMenuOperatorMouthO.bl_idname, text=mouth_o_text, icon='SHAPEKEY_DATA')
+                    # Mouth O
+                    row = box_col.row(align=True)
+                    row.scale_y = 1.0
+                    row.label(text=t('Scene.mouth_o.label')+":")
+                    row.prop_search(context.scene, "mouth_o", mesh.data.shape_keys, "key_blocks", text="")
 
-        # Mouth CH
-        row = box_col.row(align=True)
-        row.scale_y = 1.0
-        row.label(text=t('Scene.mouth_ch.label')+":")
-        mouth_ch_text = 'None' if Common.is_enum_empty(context.scene.mouth_ch) else context.scene.mouth_ch
-        row.operator(SearchMenuOperatorMouthCH.bl_idname, text=mouth_ch_text, icon='SHAPEKEY_DATA')
+                    # Mouth CH
+                    row = box_col.row(align=True)
+                    row.scale_y = 1.0
+                    row.label(text=t('Scene.mouth_ch.label')+":")
+                    row.prop_search(context.scene, "mouth_ch", mesh.data.shape_keys, "key_blocks", text="")
+            except KeyError:
+                box_col.label(text=t('VisemePanel.error.noMesh'), icon='ERROR')
 
         box_col.separator()
 


### PR DESCRIPTION
Changed viseme panel to use prop_search instead of custom search operators with invoke_search_popup. This allows Blender to handle shape key display directly, properly showing Japanese and other non-Latin characters. Now matches the eye tracking panel implementation.

Fixes #418 