### PR TITLE
fix: Resolve RecursionError crash when deleting multiple armatures

### DIFF
--- a/tools/common.py
+++ b/tools/common.py
@@ -2337,15 +2337,18 @@ def _fix_out_of_bounds_enum_choices(property_holder, scene, choices, property_na
 
 
 def _schedule_enum_fix(property_holder, scene, property_name, property_path, new_value):
-    """Schedule a fix for an enum property to be applied outside of the UI draw context."""
-    # First try to set it directly using setattr (works better for Scene properties)
-    try:
-        setattr(property_holder, property_name, new_value)
-        return
-    except (AttributeError, TypeError, RuntimeError):
-        pass
-    
-    # If direct setting failed (likely in UI draw context), schedule via timer
+    """Schedule a fix for an enum property to be applied outside of the UI draw context.
+
+    IMPORTANT: This function must NEVER attempt to set the property directly via setattr(),
+    as doing so will cause Blender to re-validate the enum value by calling the items callback,
+    which leads to infinite recursion when called during object deletion or other state changes.
+    All fixes must be scheduled via timer to run outside the callback context.
+    """
+    # REMOVED: Direct setattr attempt that caused infinite recursion (issue #431)
+    # The direct setattr() call would trigger enum validation, which calls the items callback,
+    # which detects the out-of-bounds value again, leading to infinite recursion.
+
+    # Always schedule via timer to avoid recursion
     scene_name = scene.name
     scheduled_property_set = _enum_choice_fix_scheduled.setdefault(scene_name, set())
     
@@ -2359,14 +2362,20 @@ def _schedule_enum_fix(property_holder, scene, property_name, property_path, new
         scene_by_name = bpy.data.scenes.get(scene_name)
         if scene_by_name:
             try:
-                # Try to set via setattr on the scene
-                setattr(scene_by_name, property_name, new_value)
+                # Resolve the property path and set the value
+                # Use path_resolve to handle nested properties correctly
+                prop = scene_by_name.path_resolve(property_path, False)
+                setattr(prop.data, property_name, new_value)
             except:
-                pass
+                # If path resolution fails, try direct setattr as fallback
+                try:
+                    setattr(scene_by_name, property_name, new_value)
+                except:
+                    pass
         scheduled_property_set.discard(property_path)
         return None  # Return None to not repeat the timer
 
-    bpy.app.timers.register(fix_enum_task)
+    bpy.app.timers.register(fix_enum_task, first_interval=0.0)
 
 
 def is_enum_empty(string):

--- a/tools/common.py
+++ b/tools/common.py
@@ -2391,6 +2391,13 @@ def is_enum_non_empty(string):
     return _empty_enum_identifier != string
 
 
+# Recursion guard: tracks which enum properties are currently being evaluated to prevent infinite recursion.
+# Dictionary of {int: set(str)} where keys are id(self) and set elements are property names being processed.
+# This prevents crashes when enum items callbacks are triggered recursively during state changes like object deletion.
+# See issue #431 for details on the recursion bug this guards against.
+_enum_items_being_processed = {}
+
+
 def wrap_dynamic_enum_items(items_func, property_name, sort=True, in_place=True, is_holder=True):
     """Wrap an EnumProperty items function to automatically fix the property when it goes out of bounds of the items list.
     Automatically adds at least one choice if the items function returns an empty list.
@@ -2399,23 +2406,44 @@ def wrap_dynamic_enum_items(items_func, property_name, sort=True, in_place=True,
     Only works for properties whose owner is a scene.
     By setting is_holder=false, the fix for out of bounds values will be disabled."""
     def wrapped_items_func(self, context):
-        # Use local variable to avoid modifying the closure's in_place on subsequent calls
-        do_in_place = in_place
-        items = items_func(self, context)
-        if sort:
-            items = _sort_enum_choices_by_identifier_lower(items, in_place=do_in_place)
-            if not do_in_place:
-                # Sorting has already created a new list in this case, so the rest can be done in place
-                do_in_place = True
-        items = _ensure_enum_choices_not_empty(items, in_place=do_in_place)
-        property_path = self.path_from_id(property_name) if is_holder else property_name
-        # If ensuring the list wasn't empty wasn't done in place, then a new list has been created and the rest can
-        # be done in place
-        items = _ensure_python_references(items, property_path)
-        if is_holder:
-            return _fix_out_of_bounds_enum_choices(self, context.scene, items, property_name, property_path)
-        else:
-            return items
+        # Create unique key for this property to detect recursion
+        # Using id(self) and property_name to uniquely identify each property being accessed
+        holder_id = id(self)
+        property_set = _enum_items_being_processed.setdefault(holder_id, set())
+
+        # Check if we're already processing this property (recursion guard)
+        if property_name in property_set:
+            # Recursion detected! Return minimal valid result to break the cycle
+            # This prevents infinite recursion that causes Blender crashes
+            return [(_empty_enum_identifier, "Loading...", "")]
+
+        try:
+            # Mark this property as being processed
+            property_set.add(property_name)
+
+            # Use local variable to avoid modifying the closure's in_place on subsequent calls
+            do_in_place = in_place
+            items = items_func(self, context)
+            if sort:
+                items = _sort_enum_choices_by_identifier_lower(items, in_place=do_in_place)
+                if not do_in_place:
+                    # Sorting has already created a new list in this case, so the rest can be done in place
+                    do_in_place = True
+            items = _ensure_enum_choices_not_empty(items, in_place=do_in_place)
+            property_path = self.path_from_id(property_name) if is_holder else property_name
+            # If ensuring the list wasn't empty wasn't done in place, then a new list has been created and the rest can
+            # be done in place
+            items = _ensure_python_references(items, property_path)
+            if is_holder:
+                return _fix_out_of_bounds_enum_choices(self, context.scene, items, property_name, property_path)
+            else:
+                return items
+        finally:
+            # Always clean up - remove this property from the processing set
+            property_set.discard(property_name)
+            # If the set is now empty, clean up the holder entry to avoid memory leaks
+            if not property_set:
+                _enum_items_being_processed.pop(holder_id, None)
 
     return wrapped_items_func
     


### PR DESCRIPTION
Fixes #431

I made heavy use of AI when diagnosing this issue and working on a fix, and am not intimately familiar with the code (new to CATS overall). So a little scrutiny from y'all would be much appreciated~

## Summary

This PR resolves a crash in Blender 5.0 where deleting multiple objects with armatures causes infinite recursion in the enum property handling code, leading to `RecursionError` and complete Blender crashes.

## Changes

### Primary Fix: Remove Direct Property Assignment
- **Commit:** 60743bb
- Removed the direct `setattr()` attempt in `_schedule_enum_fix()` that caused recursion
- All enum property corrections now happen asynchronously via Blender's timer system
- Improved timer task to properly handle nested property paths using `path_resolve()`
- This commit alone was enough to resolve my crashes.

### Defense-in-Depth: Add Recursion Guard
- **Commit:** d432251
- Added recursion detection to `wrapped_items_func()`
- Tracks currently-processing properties to prevent re-entry
- Returns minimal valid result if recursion is detected
- Proper cleanup with try/finally to prevent memory leaks

## Technical Details

**Root Cause:**
When armatures are deleted, the `Scene.armature` EnumProperty can reference a deleted object. The fix mechanism attempted to update the enum value directly using `setattr()`, which triggered Blender's enum validation, which called the items callback again, creating an infinite loop.

**The Recursion Chain:**
```
User deletes armatures
→ Blender UI accesses Scene.armature
→ wrapped_items_func() called
→ Detects out-of-bounds value
→ _schedule_enum_fix() attempts setattr()
→ Blender validates enum → calls wrapped_items_func() again
→ INFINITE RECURSION → crash
```

## Testing

- Tested on macOS Sequoia (15.x)
- Blender 5.0.0
- CATS 5.0.2 (HEAD of `blender-5x-dev` branch)
- Verified with real VRChat avatar project where my crashes originally occurred
  - Was unable to reproduce with a minimal test case, so I couldn't verify outside of my actual project.

I would appreciate help with testing this change with CATS' various use cases (like making sure this doesn't break something else).

## Notes

- This issue only affects Blender 5.0+ due to EnumProperty behavior changes (integer indices vs. string identifiers)
- Difficult to reproduce in synthetic test cases, but consistently crashes in real VRChat avatar projects
- Previous commit 3e1af6b partially addressed enum handling but left this recursion path intact
- The first commit (60743bb) was enough to prevent my crashes, the second commit (d432251) is precautionary.

## Related

- Blender API changes: [EnumProperty now returns int](https://projects.blender.org/blender/blender/issues/115908)
