### PR TITLE
5.0.2.1 Release Candidate (Blender 5.0)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # MIT License
 
-CATS_VERSION = "5.0.2.0"
+CATS_VERSION = "5.0.2.1"
 dev_branch = True
 
 import os

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -2,7 +2,7 @@ schema_version = "1.0.0"
 
 # Unoffical Cats Blender Plugin Extenstion
 id = "cats_blender_plugin"
-version = "5.0.1"
+version = "5.0.2"
 name = "Unoffical Cats Blender Plugin"
 tagline = "A tool designed to shorten steps needed to import and optimize models into VRChat"
 maintainer = "Unoffical Cats Team <hello@yusarina.xyz>"

--- a/extern_tools/mmd_tools_local/auto_load.py
+++ b/extern_tools/mmd_tools_local/auto_load.py
@@ -38,10 +38,13 @@ def register():
         if hasattr(module, "register"):
             module.register()
 
-
+# Werid that the MMD tools devs removed this function...
 def unregister():
     for cls in reversed(ordered_classes):
-        bpy.utils.unregister_class(cls)
+        try:
+            bpy.utils.unregister_class(cls)
+        except RuntimeError:
+            pass
 
     for module in modules:
         if module.__name__ == __name__:

--- a/tools/armature_manual.py
+++ b/tools/armature_manual.py
@@ -162,10 +162,11 @@ def start_pose_mode(reset_pose=True):
     Common.switch('POSE')
     armature.data.pose_position = 'POSE'
 
-    for mesh in Common.get_meshes_objects():
-        if Common.has_shapekeys(mesh):
-            for shape_key in mesh.data.shape_keys.key_blocks:
-                shape_key.value = 0
+    if reset_pose:
+        for mesh in Common.get_meshes_objects():
+            if Common.has_shapekeys(mesh):
+                for shape_key in mesh.data.shape_keys.key_blocks:
+                    shape_key.value = 0
 
     for pb in armature.pose.bones:
         pb.select = True
@@ -250,11 +251,13 @@ def stop_pose_mode(reset_pose=True):
     Common.remove_rigidbodies_global()
     # armature.data.pose_position = 'REST'
 
-    for mesh in Common.get_meshes_objects():
-        if Common.has_shapekeys(mesh):
-            for shape_key in mesh.data.shape_keys.key_blocks:
-                shape_key.value = 0
-        bpy.ops.wm.tool_set_by_id(name="builtin.select_box")
+    if reset_pose:
+        for mesh in Common.get_meshes_objects():
+            if Common.has_shapekeys(mesh):
+                for shape_key in mesh.data.shape_keys.key_blocks:
+                    shape_key.value = 0
+
+    bpy.ops.wm.tool_set_by_id(name="builtin.select_box")
 
     Eyetracking.eye_left = None
 

--- a/tools/common.py
+++ b/tools/common.py
@@ -2337,15 +2337,18 @@ def _fix_out_of_bounds_enum_choices(property_holder, scene, choices, property_na
 
 
 def _schedule_enum_fix(property_holder, scene, property_name, property_path, new_value):
-    """Schedule a fix for an enum property to be applied outside of the UI draw context."""
-    # First try to set it directly using setattr (works better for Scene properties)
-    try:
-        setattr(property_holder, property_name, new_value)
-        return
-    except (AttributeError, TypeError, RuntimeError):
-        pass
-    
-    # If direct setting failed (likely in UI draw context), schedule via timer
+    """Schedule a fix for an enum property to be applied outside of the UI draw context.
+
+    IMPORTANT: This function must NEVER attempt to set the property directly via setattr(),
+    as doing so will cause Blender to re-validate the enum value by calling the items callback,
+    which leads to infinite recursion when called during object deletion or other state changes.
+    All fixes must be scheduled via timer to run outside the callback context.
+    """
+    # REMOVED: Direct setattr attempt that caused infinite recursion (issue #431)
+    # The direct setattr() call would trigger enum validation, which calls the items callback,
+    # which detects the out-of-bounds value again, leading to infinite recursion.
+
+    # Always schedule via timer to avoid recursion
     scene_name = scene.name
     scheduled_property_set = _enum_choice_fix_scheduled.setdefault(scene_name, set())
     
@@ -2359,14 +2362,20 @@ def _schedule_enum_fix(property_holder, scene, property_name, property_path, new
         scene_by_name = bpy.data.scenes.get(scene_name)
         if scene_by_name:
             try:
-                # Try to set via setattr on the scene
-                setattr(scene_by_name, property_name, new_value)
+                # Resolve the property path and set the value
+                # Use path_resolve to handle nested properties correctly
+                prop = scene_by_name.path_resolve(property_path, False)
+                setattr(prop.data, property_name, new_value)
             except:
-                pass
+                # If path resolution fails, try direct setattr as fallback
+                try:
+                    setattr(scene_by_name, property_name, new_value)
+                except:
+                    pass
         scheduled_property_set.discard(property_path)
         return None  # Return None to not repeat the timer
 
-    bpy.app.timers.register(fix_enum_task)
+    bpy.app.timers.register(fix_enum_task, first_interval=0.0)
 
 
 def is_enum_empty(string):

--- a/tools/common.py
+++ b/tools/common.py
@@ -2391,6 +2391,13 @@ def is_enum_non_empty(string):
     return _empty_enum_identifier != string
 
 
+# Recursion guard: tracks which enum properties are currently being evaluated to prevent infinite recursion.
+# Dictionary of {int: set(str)} where keys are id(self) and set elements are property names being processed.
+# This prevents crashes when enum items callbacks are triggered recursively during state changes like object deletion.
+# See issue #431 for details on the recursion bug this guards against.
+_enum_items_being_processed = {}
+
+
 def wrap_dynamic_enum_items(items_func, property_name, sort=True, in_place=True, is_holder=True):
     """Wrap an EnumProperty items function to automatically fix the property when it goes out of bounds of the items list.
     Automatically adds at least one choice if the items function returns an empty list.
@@ -2399,23 +2406,44 @@ def wrap_dynamic_enum_items(items_func, property_name, sort=True, in_place=True,
     Only works for properties whose owner is a scene.
     By setting is_holder=false, the fix for out of bounds values will be disabled."""
     def wrapped_items_func(self, context):
-        # Use local variable to avoid modifying the closure's in_place on subsequent calls
-        do_in_place = in_place
-        items = items_func(self, context)
-        if sort:
-            items = _sort_enum_choices_by_identifier_lower(items, in_place=do_in_place)
-            if not do_in_place:
-                # Sorting has already created a new list in this case, so the rest can be done in place
-                do_in_place = True
-        items = _ensure_enum_choices_not_empty(items, in_place=do_in_place)
-        property_path = self.path_from_id(property_name) if is_holder else property_name
-        # If ensuring the list wasn't empty wasn't done in place, then a new list has been created and the rest can
-        # be done in place
-        items = _ensure_python_references(items, property_path)
-        if is_holder:
-            return _fix_out_of_bounds_enum_choices(self, context.scene, items, property_name, property_path)
-        else:
-            return items
+        # Create unique key for this property to detect recursion
+        # Using id(self) and property_name to uniquely identify each property being accessed
+        holder_id = id(self)
+        property_set = _enum_items_being_processed.setdefault(holder_id, set())
+
+        # Check if we're already processing this property (recursion guard)
+        if property_name in property_set:
+            # Recursion detected! Return minimal valid result to break the cycle
+            # This prevents infinite recursion that causes Blender crashes
+            return [(_empty_enum_identifier, "Loading...", "")]
+
+        try:
+            # Mark this property as being processed
+            property_set.add(property_name)
+
+            # Use local variable to avoid modifying the closure's in_place on subsequent calls
+            do_in_place = in_place
+            items = items_func(self, context)
+            if sort:
+                items = _sort_enum_choices_by_identifier_lower(items, in_place=do_in_place)
+                if not do_in_place:
+                    # Sorting has already created a new list in this case, so the rest can be done in place
+                    do_in_place = True
+            items = _ensure_enum_choices_not_empty(items, in_place=do_in_place)
+            property_path = self.path_from_id(property_name) if is_holder else property_name
+            # If ensuring the list wasn't empty wasn't done in place, then a new list has been created and the rest can
+            # be done in place
+            items = _ensure_python_references(items, property_path)
+            if is_holder:
+                return _fix_out_of_bounds_enum_choices(self, context.scene, items, property_name, property_path)
+            else:
+                return items
+        finally:
+            # Always clean up - remove this property from the processing set
+            property_set.discard(property_name)
+            # If the set is now empty, clean up the holder entry to avoid memory leaks
+            if not property_set:
+                _enum_items_being_processed.pop(holder_id, None)
 
     return wrapped_items_func
     


### PR DESCRIPTION
Fixed Cats not disabling correctly after recent updates
Fixed a crash that could occur when deleting multiple armatures
Improved stability when deleting objects, undoing actions, or changing scenes
Fixed Pose Mode issues that could cause unexpected behavior
Fixed “Start Pose Mode with No Shapekey Reset” button not working
General internal safeguards added to prevent similar crashes in the future